### PR TITLE
Add fork-only CLAUDE.md and expanded CI matrix

### DIFF
--- a/.github/workflows/numbox_ci.yml
+++ b/.github/workflows/numbox_ci.yml
@@ -13,9 +13,62 @@ jobs:
   build:
 
     strategy:
+      fail-fast: false
       matrix:
         python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]
+        numba-version: [ "0.65.0" ]
         arch: [ "ubuntu-latest", "ubuntu-24.04-arm", "windows-latest" ]
+        exclude:
+          - arch: "windows-latest"
+            python-version: "3.11"
+          - arch: "windows-latest"
+            python-version: "3.12"
+          - arch: "windows-latest"
+            python-version: "3.13"
+        include:
+          # min numba for 3.10-3.12 (0.60.0)
+          - python-version: "3.10"
+            numba-version: "0.60.0"
+            arch: "ubuntu-latest"
+          - python-version: "3.10"
+            numba-version: "0.60.0"
+            arch: "ubuntu-24.04-arm"
+          - python-version: "3.10"
+            numba-version: "0.60.0"
+            arch: "windows-latest"
+          - python-version: "3.11"
+            numba-version: "0.60.0"
+            arch: "ubuntu-latest"
+          - python-version: "3.11"
+            numba-version: "0.60.0"
+            arch: "ubuntu-24.04-arm"
+          - python-version: "3.12"
+            numba-version: "0.60.0"
+            arch: "ubuntu-latest"
+          - python-version: "3.12"
+            numba-version: "0.60.0"
+            arch: "ubuntu-24.04-arm"
+          # min numba for 3.13 (0.61.0)
+          - python-version: "3.13"
+            numba-version: "0.61.0"
+            arch: "ubuntu-latest"
+          - python-version: "3.13"
+            numba-version: "0.61.0"
+            arch: "ubuntu-24.04-arm"
+          # min numba for 3.14 (0.63.0)
+          - python-version: "3.14"
+            numba-version: "0.63.0"
+            arch: "ubuntu-latest"
+          - python-version: "3.14"
+            numba-version: "0.63.0"
+            arch: "ubuntu-24.04-arm"
+          - python-version: "3.14"
+            numba-version: "0.63.0"
+            arch: "windows-latest"
+          # macOS
+          - python-version: "3.14"
+            numba-version: "0.65.0"
+            arch: "macos-latest"
     runs-on: "${{ matrix.arch }}"
 
     steps:
@@ -41,6 +94,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install flake8 pytest
+        pip install "numba==${{ matrix.numba-version }}"
         pip install -e .
     - name: Lint with flake8
       run: |
@@ -50,7 +104,7 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
-        pytest
+        pytest --durations=20
     - name: Install build dependencies
       run: |
         pip install build==1.2.2.post1 wheel==0.45.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,90 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project
+
+numbox — a toolbox of low-level utilities for working with numba. Provides type erasure (`Any`), native library bindings (`Bindings`), graph nodes (`Node`), function proxies (`Proxy`), graph calculation (`Variable`), and units of work (`Work`).
+
+## Build & Dev
+
+- Venv: `python3.10 -m venv venv && venv/bin/pip install -e . flake8 pytest`
+- Install: `pip install -e .`
+- Test: `pytest`
+- Lint: `flake8` (max-line-length=127, max-complexity=10)
+- Docs: `cd docs && make html` (Sphinx)
+- Python: >=3.10 (CI tests 3.10–3.14)
+- Key dependency: `numba>=0.60.0,<=0.64.0` (use `numba==0.60.0` locally)
+
+## Architecture
+
+### Bindings System (core/bindings/)
+
+The bindings subsystem wraps C library functions for use inside numba `@njit` code. Four layers:
+
+1. **`utils.py`** — loads shared libraries via `ctypes.CDLL` with `RTLD_GLOBAL` so symbols are visible to LLVM
+2. **`signatures.py`** — flat dict mapping C function names to numba type signatures (e.g., `"cos": float64(float64)`). Organized by library: `signatures_c`, `signatures_m`, `signatures_sqlite`
+3. **`call.py`** — `@numba.extending.intrinsic` that generates LLVM IR to call native functions directly via `llvmlite`
+4. **`_math.py`, `_c.py`, `_sqlite.py`** — thin Python wrappers using `@cres(signatures.get("func"), cache=True)`
+
+### Adding a New Binding
+
+1. Add signature to `signatures.py` in the appropriate sub-dict
+2. Add wrapper to the corresponding `_*.py` file following this pattern:
+```python
+@cres(signatures.get("func_name"), cache=True)
+def func_name(x):
+    return _call_lib_func("func_name", (x,))
+```
+3. Function names must match the C library names exactly
+4. Args passed as tuple literal to `_call_lib_func`
+
+### Core Modules
+
+- **`core/any/`** — type erasure: wraps any value into uniform type
+- **`core/bindings/`** — JIT-compatible wrappers for native C libraries
+- **`core/proxy/`** — function proxies with specified signatures for JIT caching
+- **`core/variable/`** — graph calculation framework with JIT dispatcher
+- **`core/work/`** — JIT-compatible units of calculation with dependencies
+
+### Utilities (utils/)
+
+- `highlevel.py` — `cres` decorator (compiles to `CompileResultWAP` with explicit signature)
+- `lowlevel.py` — low-level numba helpers
+- `clock.py` — JIT-callable `monotonic_ns() -> int64` intrinsic (cross-platform)
+- `meminfo.py` — memory info utilities
+- `standard.py` — standard utilities
+- `timer.py` — timing utilities
+- `void_type.py` — void type support
+
+## Key Paths
+
+- `numbox/core/bindings/signatures.py` — all native function type signatures
+- `numbox/core/bindings/_math.py` — libm wrappers (34 single-arg + 9 two-arg float64 functions)
+- `numbox/core/bindings/_c.py` — libc wrappers
+- `numbox/core/bindings/_sqlite.py` — libsqlite3 wrappers
+- `numbox/utils/clock.py` — cross-platform monotonic nanosecond clock intrinsic
+- `test/core/` — tests for all core modules
+
+## Preferences
+
+- Never include "Co-Authored-By" in git commit messages
+- Avoid shell variable substitution in bash — inline actual values directly into commands
+- Prefer simpler approaches
+- Always git pull before making edits
+- Commit messages must not mention AI, Claude, Anthropic, or any AI tooling — only attribute to the user
+- Keep all memories in both MEMORY.md and the project CLAUDE.md (CLAUDE.md is in git and survives OS reinstalls)
+- Environment details go in MEMORY.md only (may change between OS installs)
+- Always exclude CLAUDE.md from upstream PRs (use a dedicated branch based on upstream/main)
+
+## CI
+
+- **numbox_ci.yml** — lint + test + build on push/PR (matrix: Python 3.10–3.14, ubuntu + ubuntu-arm + windows + macOS; min/max numba versions; pytest --durations=20)
+- **docs.yml** — Sphinx docs → GitHub Pages on push to main
+- **release.yml** — build + publish to PyPI on release
+
+## Project Status
+
+### monotonic_ns (numbox#7) — merged
+
+- **Upstream PR:** Goykhman/numbox#8 — merged 2026-04-13


### PR DESCRIPTION
## Summary
- Add CLAUDE.md with project guidance for Claude Code sessions
- Expand CI matrix with min numba version pins per Python version, macOS runner, and `pytest --durations=20`

## Context
Post-merge cleanup after Goykhman/numbox#8 (monotonic_ns). These are fork-only files excluded from upstream PRs.