### PR TITLE
Unify _call_lib_func ABI dispatch

### DIFF
--- a/.github/workflows/numbox_ci.yml
+++ b/.github/workflows/numbox_ci.yml
@@ -103,8 +103,8 @@ jobs:
         pip install -e .
     - name: Lint with flake8
       run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --exclude=test/core/random_image_ref.py --select=E9,F63,F7,F82 --show-source --statistics
+        # stop the build if there are Python syntax errors, undefined names, or unused imports
+        flake8 . --count --exclude=test/core/random_image_ref.py --select=E9,F63,F7,F82,F401 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest

--- a/.github/workflows/numbox_ci.yml
+++ b/.github/workflows/numbox_ci.yml
@@ -98,7 +98,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 pytest
+        pip install flake8 pytest pytest-cov
         pip install "numba==${{ matrix.numba-version }}"
         pip install -e .
     - name: Lint with flake8
@@ -109,7 +109,7 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
-        pytest --durations=20
+        pytest --durations=20 --cov=numbox --cov-report=term-missing
     - name: Install build dependencies
       run: |
         pip install build==1.2.2.post1 wheel==0.45.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ numbox — a toolbox of low-level utilities for working with numba. Provides typ
 
 ## Build & Dev
 
-- Venv: `python3.11 -m venv venv && venv/bin/pip install -e . flake8 pytest`
+- Venv: `python3.11 -m venv venv && venv/bin/pip install -e . flake8 pytest pytest-cov`
 - Install: `pip install -e .`
 - Test: `pytest`
 - Lint: `flake8` (max-line-length=127, max-complexity=10)

--- a/docs/numbox.core.bindings.rst
+++ b/docs/numbox.core.bindings.rst
@@ -16,8 +16,38 @@ Analogous technique can be expanded as needed for the user custom code.
 
 .. [#f1] See `numbsql <https://github.com/cpcloud/numbsql>`_ for previous work on jit-wrapping FFI imported functions.
 
+ABI dispatch
+++++++++++++
+
+LLVM's JIT treats ABI lowering as a frontend responsibility — it won't insert the right calling convention
+for struct args/returns by itself. ``numbox.core.bindings.call._call_lib_func`` dispatches per platform and
+per struct shape, using primitives from ``numbox.core.bindings.abi`` (platform identification via
+``_current_platform``, struct-shape classification via ``_classify``, struct-size measurement via
+``_struct_bytes``). The two ABI families that matter:
+
+- **Windows x64** — passes aggregates >8 bytes via caller-allocated pointers and returns them via ``sret``;
+  sizes 1/2/4/8 go directly in registers.
+- **SysV x86-64 / AAPCS64** — pass and return ≤16-byte aggregates directly in GP registers; on SysV x86-64,
+  >16-byte by-value args use a ``byval`` + ``optnone`` + ``noinline`` idiom so the LLVM optimizer doesn't
+  elide the caller-side stack copy before the callee reads it.
+
+References:
+
+- `llvmlite#300 <https://github.com/numba/llvmlite/issues/300#issuecomment-327235846>`_
+- `llvm-project#85417 <https://github.com/llvm/llvm-project/issues/85417>`_
+- `Windows x64 calling convention <https://learn.microsoft.com/en-us/cpp/build/x64-calling-convention>`_
+- `AAPCS64 <https://github.com/ARM-software/abi-aa/blob/main/aapcs64/aapcs64.rst>`_
+
 Modules
 ++++++++
+
+numbox.core.bindings.abi
+------------------------
+
+.. automodule:: numbox.core.bindings.abi
+   :members:
+   :show-inheritance:
+   :undoc-members:
 
 numbox.core.bindings._c
 -----------------------

--- a/docs/plans/2026-04-25-unify-call-lib-func.md
+++ b/docs/plans/2026-04-25-unify-call-lib-func.md
@@ -1,0 +1,663 @@
+# Unify `_call_lib_func` — implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers-extended-cc:subagent-driven-development` (recommended) or `superpowers-extended-cc:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace [`numbox/core/bindings/abi.py`](../../numbox/core/bindings/abi.py)'s `_call_lib_func_struct_in` / `_call_lib_func_struct_out` / `_call_lib_func_args_struct_out` with a single ABI-aware `_call_lib_func` in [`numbox/core/bindings/call.py`](../../numbox/core/bindings/call.py) that handles scalar args, ≤16B struct args / returns by value (per platform), and >16B struct args by pointer with the SysV-x86-64-only `byval` + `optnone` + `noinline` idiom.
+
+**Architecture:** `_call_lib_func` classifies each arg type and the return type as scalar / struct ≤16B / struct >16B (helper `_classify` in `abi.py`), then dispatches per platform — Win x64, SysV x86-64, AAPCS64 (helper `_current_platform` in `abi.py`). Codegen builds the LLVM function type explicitly, handles `sret` for struct returns on Win x64, and applies `byval` + `optnone` + `noinline` for SysV-x86-64 >16B struct args. `_call_lib_func_byval` (the C-`func(T*)` case) is kept; the three other intrinsics are deleted outright.
+
+**Tech Stack:** numba (≥0.60, <0.66), llvmlite, pytest. No new dependencies.
+
+**Spec:** [`docs/specs/2026-04-25-unify-call-lib-func-design.md`](../specs/2026-04-25-unify-call-lib-func-design.md)
+
+**Conventions baked into every task:**
+- Use the project venv: `/home/erik/projects/numbox/venv/bin/python` and `/home/erik/projects/numbox/venv/bin/pytest`. Never bare `python` / `python3` / `pytest`.
+- Clean cache before any pytest run (`__pycache__` + `~/.cache/numba`). Use the Python one-liner shown in each task — never `find -exec rm`.
+- Never `cd`; absolute paths everywhere. For git, `git -C /home/erik/projects/numbox ...`.
+- Commit each task as a single commit on `feat/unify-call-lib-func`.
+- Commit messages: plain prose, no `# headings`, no AI / Claude / Anthropic / Co-Authored-By attribution. Use `git commit -F <file>` for multi-line bodies; `-m "single line"` is fine for one-liners.
+
+---
+
+### Task 1: Extend `_call_lib_func` to be ABI-aware
+
+**Goal:** Make `_call_lib_func` in [`call.py`](../../numbox/core/bindings/call.py) classify each arg and the return value, then emit the right LLVM IR for the current platform — scalar, ≤16B by-value, or >16B by-pointer with `byval` + `optnone` + `noinline` on SysV x86-64. Add `_classify` and `_current_platform` helpers in [`abi.py`](../../numbox/core/bindings/abi.py). Existing `_call_lib_func_struct_in` / `_struct_out` / `_args_struct_out` stay in place untouched (Task 2 deletes them); existing tests still pass.
+
+**Files:**
+- Modify: `/home/erik/projects/numbox/numbox/core/bindings/abi.py` — add `_classify`, `_current_platform`, platform / class string constants. `_is_win`, `_struct_bytes`, `_emit_byval_call`, the four `_call_lib_func_*` intrinsics stay as-is.
+- Modify: `/home/erik/projects/numbox/numbox/core/bindings/call.py` — rewrite `_call_lib_func` codegen to be ABI-aware.
+
+**Acceptance Criteria:**
+- [ ] `abi.py` exports `_classify(ty) -> str` returning one of `"scalar"`, `"struct_small"`, `"struct_large"` for any numba type. Scalars (numba `int32`, `float64`, etc.) → `"scalar"`. `Record` / `BaseTuple` of size ≤16 → `"struct_small"`. `Record` / `BaseTuple` of size >16 → `"struct_large"`.
+- [ ] `abi.py` exports `_current_platform() -> str` returning one of `"win_x64"`, `"sysv_x86_64"`, `"aapcs64"`. Raises `RuntimeError` on unsupported `(sys.platform, platform.machine())` combinations.
+- [ ] `_call_lib_func` raises `TypingError` if the resolved return type is `"struct_large"`.
+- [ ] `_call_lib_func` correctly handles all combinations from the spec's ABI dispatch table for arg + return classes × platform.
+- [ ] All existing tests in `test/core/test_abi.py` and the math/c/sqlite binding tests still pass on every CI matrix entry.
+
+**Verify:**
+```
+/home/erik/projects/numbox/venv/bin/pytest /home/erik/projects/numbox/test/core/ -v --durations=20
+```
+Expected: green on every existing test (no regression). Numbduck integration tests (run separately, not in numbox CI) remain green.
+
+**Steps:**
+
+- [ ] **Step 1: Clean cache**
+
+```bash
+/home/erik/projects/numbox/venv/bin/python -c "import shutil, pathlib; [shutil.rmtree(p, ignore_errors=True) for p in list(pathlib.Path('/home/erik/projects/numbox').rglob('__pycache__')) + [pathlib.Path('/home/erik/.cache/numba')]]"
+```
+
+- [ ] **Step 2: Add helpers to `abi.py`**
+
+Open `/home/erik/projects/numbox/numbox/core/bindings/abi.py`. Add `import platform` near the existing `import sys` line. Below the existing `_is_win = sys.platform == "win32"` line, add this block:
+
+```python
+import platform
+
+
+_PLATFORM_WIN_X64 = "win_x64"
+_PLATFORM_SYSV_X86_64 = "sysv_x86_64"
+_PLATFORM_AAPCS64 = "aapcs64"
+
+
+def _current_platform():
+    """Identify the C calling convention for the current host.
+
+    Returns one of ``_PLATFORM_WIN_X64``, ``_PLATFORM_SYSV_X86_64``,
+    ``_PLATFORM_AAPCS64``. Used by the ABI-aware codegen in
+    ``numbox.core.bindings.call._call_lib_func`` to pick the right
+    struct-passing convention.
+    """
+    if sys.platform == "win32":
+        return _PLATFORM_WIN_X64
+    machine = platform.machine()
+    if machine in ("x86_64", "AMD64"):
+        return _PLATFORM_SYSV_X86_64
+    if machine in ("arm64", "aarch64", "AARCH64"):
+        return _PLATFORM_AAPCS64
+    raise RuntimeError(
+        f"Unsupported platform for ABI dispatch: "
+        f"{sys.platform}/{machine}"
+    )
+
+
+_CLASS_SCALAR = "scalar"
+_CLASS_STRUCT_SMALL = "struct_small"
+_CLASS_STRUCT_LARGE = "struct_large"
+
+
+def _classify(ty):
+    """Classify a numba type for ABI dispatch.
+
+    Returns one of:
+
+    - ``_CLASS_SCALAR`` — any non-struct numba type (e.g. ``int32``,
+      ``float64``, pointers represented as ``intp``).
+    - ``_CLASS_STRUCT_SMALL`` — ``Record`` / ``BaseTuple`` of size
+      ≤ 16 bytes; passed by value on register-passing ABIs.
+    - ``_CLASS_STRUCT_LARGE`` — ``Record`` / ``BaseTuple`` of size
+      > 16 bytes; passed by pointer with ``byval`` on SysV x86-64,
+      by pointer (no special attribute) on other ABIs.
+    """
+    if not isinstance(ty, (nb_types.Record, nb_types.BaseTuple)):
+        return _CLASS_SCALAR
+    if isinstance(ty, nb_types.Record):
+        size = ty.size
+    else:
+        size = sum(t.bitwidth for t in ty.types) // 8
+    return _CLASS_STRUCT_SMALL if size <= 16 else _CLASS_STRUCT_LARGE
+```
+
+The existing `_is_win`, `_struct_bytes`, `_emit_byval_call`, and the four `_call_lib_func_*` intrinsics are not touched in this task.
+
+- [ ] **Step 3: Rewrite `call.py`**
+
+Replace the entire contents of `/home/erik/projects/numbox/numbox/core/bindings/call.py` with:
+
+```python
+import llvmlite.binding as ll
+from llvmlite import ir as llir
+
+from numba.core.cgutils import get_or_insert_function
+from numba.core.errors import TypingError
+from numba.core.types import NoneType, Tuple, UniTuple
+from numba.extending import intrinsic
+
+from numbox.core.bindings.abi import (
+    _CLASS_SCALAR, _CLASS_STRUCT_SMALL, _CLASS_STRUCT_LARGE,
+    _PLATFORM_AAPCS64, _PLATFORM_SYSV_X86_64, _PLATFORM_WIN_X64,
+    _classify, _current_platform,
+)
+from numbox.core.bindings.signatures import signatures
+
+
+@intrinsic(prefer_literal=True)
+def _call_lib_func(typingctx, func_name_ty, args_ty=NoneType):
+    """Call a C library function with ABI-correct argument and return passing.
+
+    The C function name is resolved from numbox's ``signatures`` dict.
+    Each arg in ``args_ty`` and the resolved return type are classified
+    as scalar / struct ≤16 bytes / struct >16 bytes, then lowered to
+    LLVM IR per the host's calling convention:
+
+    - **Scalar args / returns** — passed and returned directly.
+    - **≤16-byte struct args** — by value on SysV x86-64 and AAPCS64
+      (LLVM's frontend lowers to register passing); by pointer (alloca
+      + store + pass-pointer) on Windows x64.
+    - **>16-byte struct args** — by pointer on every platform; on SysV
+      x86-64 the ``byval`` attribute is added to the LLVM arg and the
+      enclosing function gets ``optnone`` + ``noinline`` so the LLVM
+      optimizer does not elide the caller-side stack copy before the
+      callee reads it. See:
+      https://github.com/numba/llvmlite/issues/300#issuecomment-327235846
+    - **≤16-byte struct returns** — direct on SysV x86-64 and AAPCS64;
+      via ``sret`` (caller-allocated hidden first arg, void return) on
+      Windows x64.
+    - **>16-byte struct returns** — raise ``TypingError``. No consumer
+      currently needs this; add it when one does.
+
+    For C signatures of form ``func(T*)`` (pointer to struct) rather
+    than ``func(T)`` lowered to a byval pointer by the ABI, use
+    ``_call_lib_func_byval`` from ``numbox.core.bindings.abi`` instead.
+    The numba type system can't disambiguate ``T`` from ``T*``; the
+    caller picks the intrinsic based on what the C header declares.
+    """
+    func_name = func_name_ty.literal_value
+    func_p_as_int = ll.address_of_symbol(func_name)
+    if func_p_as_int is None:
+        raise RuntimeError(f"{func_name} is unavailable in the LLVM context")
+    func_sig = signatures.get(func_name, None)
+    if func_sig is None:
+        raise ValueError(f"Undefined signature for {func_name}")
+
+    ret_ty = func_sig.return_type
+    ret_class = _classify(ret_ty)
+    if ret_class == _CLASS_STRUCT_LARGE:
+        raise TypingError(
+            f"_call_lib_func: return struct >16 bytes is unsupported "
+            f"({func_name})"
+        )
+
+    if args_ty == NoneType:
+        arg_types = ()
+        arg_classes = ()
+    else:
+        assert isinstance(args_ty, (Tuple, UniTuple))
+        arg_types = tuple(args_ty)
+        arg_classes = tuple(_classify(at) for at in arg_types)
+
+    plat = _current_platform()
+    use_sret = (ret_class == _CLASS_STRUCT_SMALL and plat == _PLATFORM_WIN_X64)
+
+    def codegen(context, builder, signature, arguments):
+        if args_ty == NoneType:
+            arg_vals = ()
+        else:
+            _, args_pack = arguments
+            arg_vals = tuple(
+                builder.extract_value(args_pack, i)
+                for i in range(len(arg_types))
+            )
+
+        ret_ll_ty = context.get_value_type(ret_ty)
+
+        ll_arg_tys = []
+        ll_arg_vals = []
+        byval_arg_indices = []
+
+        if use_sret:
+            sret_ptr = builder.alloca(ret_ll_ty)
+            ll_arg_tys.append(ret_ll_ty.as_pointer())
+            ll_arg_vals.append(sret_ptr)
+        else:
+            sret_ptr = None
+
+        for arg_ty, arg_cls, val in zip(arg_types, arg_classes, arg_vals):
+            arg_ll_ty = context.get_value_type(arg_ty)
+            if arg_cls == _CLASS_SCALAR:
+                ll_arg_tys.append(arg_ll_ty)
+                ll_arg_vals.append(val)
+                continue
+            pass_by_value = (
+                arg_cls == _CLASS_STRUCT_SMALL
+                and plat in (_PLATFORM_SYSV_X86_64, _PLATFORM_AAPCS64)
+            )
+            if pass_by_value:
+                ll_arg_tys.append(arg_ll_ty)
+                ll_arg_vals.append(val)
+                continue
+            stack_p = builder.alloca(arg_ll_ty)
+            builder.store(val, stack_p)
+            ll_arg_tys.append(arg_ll_ty.as_pointer())
+            ll_arg_vals.append(stack_p)
+            if arg_cls == _CLASS_STRUCT_LARGE and plat == _PLATFORM_SYSV_X86_64:
+                byval_arg_indices.append(len(ll_arg_vals) - 1)
+
+        if use_sret:
+            func_ll_ty = llir.FunctionType(llir.VoidType(), ll_arg_tys)
+        else:
+            func_ll_ty = llir.FunctionType(ret_ll_ty, ll_arg_tys)
+        func_p = get_or_insert_function(builder.module, func_ll_ty, func_name)
+
+        if use_sret:
+            func_p.args[0].add_attribute("sret")
+        for idx in byval_arg_indices:
+            func_p.args[idx].add_attribute("byval")
+        if byval_arg_indices:
+            builder.function.attributes.add("optnone")
+            builder.function.attributes.add("noinline")
+
+        if use_sret:
+            builder.call(func_p, ll_arg_vals)
+            return builder.load(sret_ptr)
+        return builder.call(func_p, ll_arg_vals)
+
+    sig = ret_ty(func_name_ty, args_ty)
+    return sig, codegen
+```
+
+- [ ] **Step 4: Run the existing test suite**
+
+```bash
+/home/erik/projects/numbox/venv/bin/python -c "import shutil, pathlib; [shutil.rmtree(p, ignore_errors=True) for p in list(pathlib.Path('/home/erik/projects/numbox').rglob('__pycache__')) + [pathlib.Path('/home/erik/.cache/numba')]]"
+/home/erik/projects/numbox/venv/bin/pytest /home/erik/projects/numbox/test/core/ -v --durations=20
+```
+
+Expected: every existing test passes. The math/c/sqlite bindings (`test_math.py`, `test_bindings.py`) exercise the scalar-only path through the rewritten `_call_lib_func` and will fail loudly if it regresses. `test_abi.py` exercises both helpers' presence and the lldiv struct-return path through the still-existing `_call_lib_func_args_struct_out` (Task 2 retires that).
+
+If any test fails, STOP and report BLOCKED with the full traceback. Do not improvise fixes. Likely culprits: typo in the `_classify` BaseTuple size formula, mis-shifted byval index when sret is in front, missing `as_pointer()` on a struct-arg LLVM type, or `_current_platform()` raising on the matrix's macOS x86_64 entry (it shouldn't — `platform.machine()` returns `"x86_64"` there).
+
+- [ ] **Step 5: Write the commit message to a file**
+
+Use the Write tool to create `/tmp/task1_commit_msg.txt` with this body:
+
+```
+Extend _call_lib_func to be ABI-aware
+
+Adds _classify and _current_platform helpers in abi.py, then rewrites
+call.py's _call_lib_func codegen to dispatch per arg class and
+platform: scalar pass-through, small-struct by value on SysV / AAPCS64
+or by pointer on Windows, large-struct by pointer (with byval +
+optnone + noinline on SysV x86-64), small-struct return direct on
+SysV / AAPCS64 or via sret on Windows. Large-struct returns raise
+TypingError; no consumer needs them yet.
+
+The legacy _call_lib_func_struct_in / _struct_out / _args_struct_out
+intrinsics are left in place untouched in this commit; the next
+commit deletes them.
+```
+
+- [ ] **Step 6: Stage and commit**
+
+```bash
+git -C /home/erik/projects/numbox add numbox/core/bindings/abi.py numbox/core/bindings/call.py
+git -C /home/erik/projects/numbox commit -F /tmp/task1_commit_msg.txt
+```
+
+Do not push — the controller handles pushing.
+
+---
+
+### Task 2: Delete redundant ABI intrinsics
+
+**Goal:** Now that `_call_lib_func` covers every case the legacy intrinsics did, delete `_call_lib_func_struct_in`, `_call_lib_func_struct_out`, `_call_lib_func_args_struct_out` and `_is_win` from `abi.py`. Update `test/core/test_abi.py` to (a) assert those symbols are gone, (b) drop their imports, and (c) rename + rewrite the existing lldiv test to invoke the unified intrinsic.
+
+**Files:**
+- Modify: `/home/erik/projects/numbox/numbox/core/bindings/abi.py` — delete the three intrinsics + `_is_win`.
+- Modify: `/home/erik/projects/numbox/test/core/test_abi.py` — update import-presence test, rename + rewrite lldiv test.
+
+**Acceptance Criteria:**
+- [ ] `_call_lib_func_struct_in`, `_call_lib_func_struct_out`, `_call_lib_func_args_struct_out`, `_is_win` are no longer attributes of `numbox.core.bindings.abi`.
+- [ ] `test_abi_imports` asserts both presence (survivors) and absence (retired names).
+- [ ] `test_call_lib_func_lldiv_via_unified` (renamed from `test_call_lib_func_args_struct_out_lldiv`) calls `_call_lib_func("lldiv", (10, 3))` directly and asserts `(quot, rem) == (3, 1)`.
+- [ ] `pytest test/core/test_abi.py -v` is green on every CI matrix entry.
+
+**Verify:**
+```
+/home/erik/projects/numbox/venv/bin/pytest /home/erik/projects/numbox/test/core/test_abi.py -v --durations=20
+```
+Expected: 4 passed.
+
+**Steps:**
+
+- [ ] **Step 1: Clean cache**
+
+```bash
+/home/erik/projects/numbox/venv/bin/python -c "import shutil, pathlib; [shutil.rmtree(p, ignore_errors=True) for p in list(pathlib.Path('/home/erik/projects/numbox').rglob('__pycache__')) + [pathlib.Path('/home/erik/.cache/numba')]]"
+```
+
+- [ ] **Step 2: Trim `abi.py`**
+
+Open `/home/erik/projects/numbox/numbox/core/bindings/abi.py`. Delete:
+
+- The line `_is_win = sys.platform == "win32"` (currently around line 29).
+- The intrinsic `_call_lib_func_struct_in` (and its `@intrinsic(prefer_literal=True)` decorator).
+- The intrinsic `_call_lib_func_struct_out`.
+- The intrinsic `_call_lib_func_args_struct_out`.
+
+Keep `_resolve_sig`: it is still called by the surviving `_call_lib_func_byval` intrinsic. Keep `from numbox.core.bindings.signatures import signatures` for the same reason — `_resolve_sig` reads from it.
+
+Verify what's left in `abi.py`:
+
+- Module docstring.
+- Imports: `import platform`, `import sys`, `from llvmlite import ir`, `from llvmlite.ir import FunctionType`, `from numba.core import types as nb_types`, `from numba.core.cgutils import get_or_insert_function`, `from numba.core.errors import TypingError`, `from numba.extending import intrinsic`, `from numbox.core.bindings.signatures import signatures`.
+- `_PLATFORM_*` constants and `_current_platform`.
+- `_CLASS_*` constants and `_classify`.
+- `_resolve_sig`.
+- `_struct_bytes`.
+- `_emit_byval_call`.
+- `_call_lib_func_byval` (intrinsic).
+
+- [ ] **Step 3: Update `test/core/test_abi.py`**
+
+Replace the entire contents of `/home/erik/projects/numbox/test/core/test_abi.py` with:
+
+```python
+import pytest
+
+
+def test_abi_imports():
+    """The surviving symbols are present and the retired ones are gone."""
+    from numbox.core.bindings import abi
+
+    assert hasattr(abi, "_emit_byval_call")
+    assert hasattr(abi, "_call_lib_func_byval")
+    assert hasattr(abi, "_struct_bytes")
+    assert hasattr(abi, "_classify")
+    assert hasattr(abi, "_current_platform")
+
+    for retired in (
+        "_call_lib_func_struct_in",
+        "_call_lib_func_struct_out",
+        "_call_lib_func_args_struct_out",
+        "_is_win",
+    ):
+        assert not hasattr(abi, retired), (
+            f"{retired} should have been removed"
+        )
+
+
+def test_struct_bytes_supports_all_struct_types():
+    """The struct-size helper used by the ABI codegen handles every
+    numba struct-shaped type: Tuple, UniTuple, NamedTuple (via .types),
+    and Record (via .size)."""
+    import collections
+    from numba.core import types
+    from numbox.core.bindings.abi import _struct_bytes
+
+    assert _struct_bytes(
+        types.Tuple([types.int32, types.int32, types.int64]), "t") == 16
+    assert _struct_bytes(
+        types.UniTuple(types.int32, 4), "t") == 16
+
+    MyNT = collections.namedtuple("MyNT", ["a", "b"])
+    assert _struct_bytes(
+        types.NamedTuple([types.int32, types.int64], MyNT), "t") == 12
+
+    rec = types.Record.make_c_struct([("a", types.int32), ("b", types.int64)])
+    assert _struct_bytes(rec, "t") == 16  # 4 + 4 pad + 8
+
+
+def test_struct_bytes_rejects_non_struct_type():
+    """Scalar or otherwise non-struct types raise a clean TypingError."""
+    from numba.core import types
+    from numba.core.errors import TypingError
+    from numbox.core.bindings.abi import _struct_bytes
+
+    with pytest.raises(TypingError, match="struct-shaped type"):
+        _struct_bytes(types.int32, "_call_lib_func_struct_in")
+
+
+def test_call_lib_func_lldiv_via_unified():
+    """End-to-end: call libc ``lldiv(10, 3)`` via the unified intrinsic
+    and validate the 16-byte ``lldiv_t`` return value.
+
+    Exercises the return-side ABI path on whatever platform the test
+    runs on: SysV x86-64 and AAPCS64 read ``lldiv_t`` back from GP
+    registers; Windows x64 reads it from a caller-allocated ``sret``
+    slot. A regression on any of those three ABIs surfaces as a wrong
+    quot or rem here.
+    """
+    from numba import njit
+    from numbox.core.bindings import _c  # ensures libc is loaded  # noqa: F401
+    from numbox.core.bindings.call import _call_lib_func
+
+    @njit
+    def run():
+        return _call_lib_func("lldiv", (10, 3))
+
+    quot, rem = run()
+    assert quot == 3
+    assert rem == 1
+```
+
+The notes block in the original test file (about coverage gaps for struct-IN) is dropped; numbduck integration tests cover the >16B struct-IN path end-to-end and the new IR-inspection tests in Task 3 cover small/large struct-IN codegen.
+
+- [ ] **Step 4: Run the test suite**
+
+```bash
+/home/erik/projects/numbox/venv/bin/python -c "import shutil, pathlib; [shutil.rmtree(p, ignore_errors=True) for p in list(pathlib.Path('/home/erik/projects/numbox').rglob('__pycache__')) + [pathlib.Path('/home/erik/.cache/numba')]]"
+/home/erik/projects/numbox/venv/bin/pytest /home/erik/projects/numbox/test/core/ -v --durations=20
+```
+
+Expected: every existing test still passes plus the four updated `test_abi.py` tests. The math/c/sqlite tests in particular must remain green — they go through `_call_lib_func` for scalar args / scalar returns, which is the regression-prone path.
+
+If anything fails, STOP and report BLOCKED with the traceback. Likely culprits: forgot to drop a `from numbox.core.bindings.abi import _is_win` import in some other file (grep it: `grep -rn "_is_win\|_call_lib_func_struct\|_call_lib_func_args_struct" /home/erik/projects/numbox/numbox /home/erik/projects/numbox/test`); typo in the `hasattr` retired-names list.
+
+- [ ] **Step 5: Commit**
+
+```
+git -C /home/erik/projects/numbox add numbox/core/bindings/abi.py test/core/test_abi.py
+git -C /home/erik/projects/numbox commit -m "Delete redundant ABI intrinsics, migrate lldiv test"
+```
+
+---
+
+### Task 3: Add ABI dispatch tests
+
+**Goal:** Add three new tests to `test/core/test_abi.py`: a regression guard for the scalar-arg path, and two IR-inspection tests confirming `byval` + `optnone` + `noinline` are added on SysV x86-64 for >16B struct args and absent for ≤16B struct args.
+
+**Files:**
+- Modify: `/home/erik/projects/numbox/test/core/test_abi.py` — append new tests after `test_call_lib_func_lldiv_via_unified`.
+
+**Acceptance Criteria:**
+- [ ] `test_call_lib_func_scalar_args_unchanged` calls `_call_lib_func("cos", (0.0,))` (libm) inside `@njit`, asserts result is `1.0`.
+- [ ] `test_call_lib_func_byval_attribute_in_ir_for_large_struct` asserts that on SysV x86-64, the LLVM IR for a function calling `_call_lib_func` with a 24-byte struct arg has `byval` on the corresponding parameter and `optnone` + `noinline` on the enclosing function. Skipped on Windows and AAPCS64.
+- [ ] `test_call_lib_func_no_byval_attribute_for_small_struct` asserts that on SysV x86-64, a 16-byte struct arg does NOT carry `byval`. Skipped on Windows (different code path) and AAPCS64.
+- [ ] `pytest test/core/test_abi.py -v` is green on every CI matrix entry; the SysV-only tests are skipped (not failed) on Windows and ARM matrix entries.
+
+**Verify:**
+```
+/home/erik/projects/numbox/venv/bin/pytest /home/erik/projects/numbox/test/core/test_abi.py -v --durations=20
+```
+Expected (on x86_64 Linux): 7 passed. On Windows or ARM: 5 passed, 2 skipped.
+
+**Steps:**
+
+- [ ] **Step 1: Clean cache**
+
+```bash
+/home/erik/projects/numbox/venv/bin/python -c "import shutil, pathlib; [shutil.rmtree(p, ignore_errors=True) for p in list(pathlib.Path('/home/erik/projects/numbox').rglob('__pycache__')) + [pathlib.Path('/home/erik/.cache/numba')]]"
+```
+
+- [ ] **Step 2: Append the new tests to `test/core/test_abi.py`**
+
+Append the following block to the end of `/home/erik/projects/numbox/test/core/test_abi.py`:
+
+```python
+def test_call_lib_func_scalar_args_unchanged():
+    """Regression guard: scalar args + scalar return path goes through
+    `_call_lib_func` unchanged from the pre-unification behavior.
+
+    `cos(0.0)` from libm returns `1.0`. If the rewrite of `_call_lib_func`
+    broke the scalar path that math / c / sqlite bindings depend on,
+    this fails with an LLVM IR error or a wrong return value.
+    """
+    from numba import njit
+    from numbox.core.bindings import _math  # ensures libm is loaded  # noqa: F401
+    from numbox.core.bindings.call import _call_lib_func
+
+    @njit
+    def run():
+        return _call_lib_func("cos", (0.0,))
+
+    assert run() == 1.0
+
+
+def _register_test_symbol(name):
+    """Register a no-op address under ``name`` so ``ll.address_of_symbol``
+    finds something for the IR-inspection tests. The body is never
+    executed — the tests only inspect the LLVM IR emitted at compile
+    time. Returns the ctypes wrapper, which the caller must keep alive
+    for the symbol to remain valid.
+    """
+    import ctypes
+    import llvmlite.binding as ll
+
+    @ctypes.CFUNCTYPE(ctypes.c_int32)
+    def _stub():
+        return 0
+
+    addr = ctypes.cast(_stub, ctypes.c_void_p).value
+    ll.add_symbol(name, addr)
+    return _stub
+
+
+@pytest.fixture
+def patch_signature():
+    """Add a temporary entry to ``signatures`` and remove it after.
+
+    Yields a function ``register(name, sig)`` that the test calls to
+    install a fake signature. The fixture undoes the install on teardown,
+    even if the install replaced an existing entry.
+    """
+    from numbox.core.bindings.signatures import signatures
+
+    sentinel = object()
+    saved = []
+
+    def register(name, sig):
+        saved.append((name, signatures.get(name, sentinel)))
+        signatures[name] = sig
+
+    yield register
+
+    for name, prev in saved:
+        if prev is sentinel:
+            del signatures[name]
+        else:
+            signatures[name] = prev
+
+
+def _platform_str():
+    from numbox.core.bindings.abi import _current_platform
+    return _current_platform()
+
+
+@pytest.mark.skipif(
+    _platform_str() != "sysv_x86_64",
+    reason="byval + optnone + noinline are SysV x86-64 specific",
+)
+def test_call_lib_func_byval_attribute_in_ir_for_large_struct(patch_signature):
+    """On SysV x86-64, a 24-byte struct arg is lowered with ``byval``
+    on the LLVM parameter and ``optnone`` + ``noinline`` on the
+    enclosing function. The actual C function is never called — the
+    test only inspects the IR emitted by numba.
+    """
+    from numba import njit, types as nb_types
+    from numbox.core.bindings.call import _call_lib_func
+
+    name = "numbox_test_byval_large_24b"
+    keepalive = _register_test_symbol(name)
+    big_struct = nb_types.UniTuple(nb_types.int64, 3)
+    patch_signature(name, nb_types.int32(big_struct))
+
+    @njit
+    def run(x):
+        return _call_lib_func(name, (x,))
+
+    run.compile((nb_types.UniTuple(nb_types.int64, 3),))
+    ir_text = list(run.inspect_llvm().values())[0]
+
+    assert "byval" in ir_text, (
+        "expected 'byval' attribute on >16B struct arg on SysV x86-64;\n"
+        f"IR was:\n{ir_text}"
+    )
+    assert "optnone" in ir_text, (
+        "expected 'optnone' on enclosing function on SysV x86-64"
+    )
+    assert "noinline" in ir_text, (
+        "expected 'noinline' on enclosing function on SysV x86-64"
+    )
+    del keepalive
+
+
+@pytest.mark.skipif(
+    _platform_str() != "sysv_x86_64",
+    reason="≤16B-struct passing differs across ABIs; SysV-specific check",
+)
+def test_call_lib_func_no_byval_attribute_for_small_struct(patch_signature):
+    """On SysV x86-64, a ≤16B struct arg is passed by value in
+    registers; LLVM lowers without a ``byval`` attribute and without
+    forcing ``optnone`` / ``noinline``.
+    """
+    from numba import njit, types as nb_types
+    from numbox.core.bindings.call import _call_lib_func
+
+    name = "numbox_test_byval_small_16b"
+    keepalive = _register_test_symbol(name)
+    small_struct = nb_types.UniTuple(nb_types.int64, 2)
+    patch_signature(name, nb_types.int32(small_struct))
+
+    @njit
+    def run(x):
+        return _call_lib_func(name, (x,))
+
+    run.compile((nb_types.UniTuple(nb_types.int64, 2),))
+    ir_text = list(run.inspect_llvm().values())[0]
+
+    assert "byval" not in ir_text, (
+        "did not expect 'byval' on ≤16B struct arg on SysV x86-64;\n"
+        f"IR was:\n{ir_text}"
+    )
+    assert "optnone" not in ir_text, (
+        "did not expect 'optnone' on enclosing function for ≤16B struct"
+    )
+    del keepalive
+```
+
+- [ ] **Step 3: Run the suite**
+
+```bash
+/home/erik/projects/numbox/venv/bin/python -c "import shutil, pathlib; [shutil.rmtree(p, ignore_errors=True) for p in list(pathlib.Path('/home/erik/projects/numbox').rglob('__pycache__')) + [pathlib.Path('/home/erik/.cache/numba')]]"
+/home/erik/projects/numbox/venv/bin/pytest /home/erik/projects/numbox/test/core/test_abi.py -v --durations=20
+```
+
+Expected on the dev host (Linux x86_64): `7 passed` — the four kept/migrated tests from Task 2 plus the three new ones.
+
+If the IR-inspection assertions fail because the IR text doesn't have the substrings, STOP and report BLOCKED with the actual IR text the assertion message captured. Likely culprits:
+- `byval` shows up as `byval(<type>)` in newer LLVM dialects — substring match still works.
+- `optnone` and `noinline` may appear in the function's `attributes #N = { ... }` table rather than inline in the function header; substring match still works.
+- The `_register_test_symbol` keepalive is dropping out of scope before `inspect_llvm()` resolves — the `del keepalive` is at the end of the test for that reason; if the issue persists, hold the keepalive in a module-level cache.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C /home/erik/projects/numbox add test/core/test_abi.py
+git -C /home/erik/projects/numbox commit -m "Add ABI dispatch tests for unified _call_lib_func"
+```
+
+---
+
+## Self-review notes (plan author)
+
+- **Spec coverage:**
+  - API change → Task 1.
+  - Deletions → Task 2.
+  - Module organization (helpers in `abi.py`, dispatch in `call.py`) → Tasks 1 + 2.
+  - ABI dispatch table → covered by Task 1's codegen logic; verified by Task 3's IR inspection (SysV x86-64 paths) and Task 2's lldiv test (return-side ABI on whichever platform CI is running).
+  - Tests → Task 2 (kept + migrated) + Task 3 (new).
+  - Branch and commit plan → header + per-task commit step.
+- **Type consistency:** `_classify` returns string constants `"scalar"`, `"struct_small"`, `"struct_large"` and exposes them as `_CLASS_SCALAR`/`_CLASS_STRUCT_SMALL`/`_CLASS_STRUCT_LARGE`. `_current_platform` returns `"win_x64"` / `"sysv_x86_64"` / `"aapcs64"` exposed as `_PLATFORM_*` constants. `call.py` imports both sets of constants and uses them by name; tests use `_current_platform()` directly.
+- **Phase B (numbduck migration)** is out of scope per the spec.

--- a/docs/plans/2026-04-25-unify-call-lib-func.tasks.json
+++ b/docs/plans/2026-04-25-unify-call-lib-func.tasks.json
@@ -1,0 +1,31 @@
+{
+  "planPath": "docs/plans/2026-04-25-unify-call-lib-func.md",
+  "specPath": "docs/specs/2026-04-25-unify-call-lib-func-design.md",
+  "branch": "feat/unify-call-lib-func",
+  "tasks": [
+    {
+      "id": 1,
+      "subject": "ABI Task 1: Extend _call_lib_func to be ABI-aware",
+      "status": "pending",
+      "model": "sonnet",
+      "description": "**Goal:** Add `_classify` and `_current_platform` helpers in abi.py; rewrite call.py's `_call_lib_func` codegen to dispatch per arg class and platform. Legacy intrinsics stay in place; existing tests still pass.\n\n**Files:**\n- Modify: `numbox/core/bindings/abi.py`\n- Modify: `numbox/core/bindings/call.py`\n\n**Verify:** `venv/bin/pytest test/core/ -v --durations=20` → all green.\n\nFull code in `docs/plans/2026-04-25-unify-call-lib-func.md` Task 1.\n\n```json:metadata\n{\"files\": [\"numbox/core/bindings/abi.py\", \"numbox/core/bindings/call.py\"], \"verifyCommand\": \"/home/erik/projects/numbox/venv/bin/pytest /home/erik/projects/numbox/test/core/ -v --durations=20\", \"acceptanceCriteria\": [\"_classify returns three classes\", \"_current_platform handles three ABIs\", \">16B return raises TypingError\", \"Existing tests still pass\"], \"model\": \"sonnet\"}\n```"
+    },
+    {
+      "id": 2,
+      "subject": "ABI Task 2: Delete redundant ABI intrinsics",
+      "status": "pending",
+      "blockedBy": [1],
+      "model": "sonnet",
+      "description": "**Goal:** Remove `_call_lib_func_struct_in`, `_call_lib_func_struct_out`, `_call_lib_func_args_struct_out`, `_is_win` from abi.py. Update `test_abi.py` to assert deletions, drop their imports, rename + rewrite the lldiv test.\n\n**Files:**\n- Modify: `numbox/core/bindings/abi.py`\n- Modify: `test/core/test_abi.py`\n\n**Verify:** `venv/bin/pytest test/core/test_abi.py -v --durations=20` → 4 passed.\n\nFull code in `docs/plans/2026-04-25-unify-call-lib-func.md` Task 2.\n\n```json:metadata\n{\"files\": [\"numbox/core/bindings/abi.py\", \"test/core/test_abi.py\"], \"verifyCommand\": \"/home/erik/projects/numbox/venv/bin/pytest /home/erik/projects/numbox/test/core/test_abi.py -v --durations=20\", \"acceptanceCriteria\": [\"3 intrinsics + _is_win removed\", \"_resolve_sig stays\", \"lldiv test rewritten via _call_lib_func\", \"4 passed\"], \"model\": \"sonnet\"}\n```"
+    },
+    {
+      "id": 3,
+      "subject": "ABI Task 3: Add ABI dispatch tests",
+      "status": "pending",
+      "blockedBy": [1, 2],
+      "model": "sonnet",
+      "description": "**Goal:** Append three new tests to test_abi.py: scalar regression guard (cos), and IR-inspection tests confirming byval+optnone+noinline on >16B SysV path and absent on ≤16B SysV path.\n\n**Files:**\n- Modify: `test/core/test_abi.py`\n\n**Verify:** `venv/bin/pytest test/core/test_abi.py -v --durations=20` → 7 passed on x86_64 Linux; 5 passed + 2 skipped on Windows / ARM.\n\nFull code in `docs/plans/2026-04-25-unify-call-lib-func.md` Task 3.\n\n```json:metadata\n{\"files\": [\"test/core/test_abi.py\"], \"verifyCommand\": \"/home/erik/projects/numbox/venv/bin/pytest /home/erik/projects/numbox/test/core/test_abi.py -v --durations=20\", \"acceptanceCriteria\": [\"3 new tests added\", \"skipif gates correctly on non-SysV\", \"7 passed on dev host\"], \"model\": \"sonnet\"}\n```"
+    }
+  ],
+  "lastUpdated": "2026-04-25T00:50:00Z"
+}

--- a/docs/plans/2026-04-25-unify-call-lib-func.tasks.json
+++ b/docs/plans/2026-04-25-unify-call-lib-func.tasks.json
@@ -6,14 +6,14 @@
     {
       "id": 1,
       "subject": "ABI Task 1: Extend _call_lib_func to be ABI-aware",
-      "status": "pending",
+      "status": "completed",
       "model": "sonnet",
       "description": "**Goal:** Add `_classify` and `_current_platform` helpers in abi.py; rewrite call.py's `_call_lib_func` codegen to dispatch per arg class and platform. Legacy intrinsics stay in place; existing tests still pass.\n\n**Files:**\n- Modify: `numbox/core/bindings/abi.py`\n- Modify: `numbox/core/bindings/call.py`\n\n**Verify:** `venv/bin/pytest test/core/ -v --durations=20` → all green.\n\nFull code in `docs/plans/2026-04-25-unify-call-lib-func.md` Task 1.\n\n```json:metadata\n{\"files\": [\"numbox/core/bindings/abi.py\", \"numbox/core/bindings/call.py\"], \"verifyCommand\": \"/home/erik/projects/numbox/venv/bin/pytest /home/erik/projects/numbox/test/core/ -v --durations=20\", \"acceptanceCriteria\": [\"_classify returns three classes\", \"_current_platform handles three ABIs\", \">16B return raises TypingError\", \"Existing tests still pass\"], \"model\": \"sonnet\"}\n```"
     },
     {
       "id": 2,
       "subject": "ABI Task 2: Delete redundant ABI intrinsics",
-      "status": "pending",
+      "status": "completed",
       "blockedBy": [1],
       "model": "sonnet",
       "description": "**Goal:** Remove `_call_lib_func_struct_in`, `_call_lib_func_struct_out`, `_call_lib_func_args_struct_out`, `_is_win` from abi.py. Update `test_abi.py` to assert deletions, drop their imports, rename + rewrite the lldiv test.\n\n**Files:**\n- Modify: `numbox/core/bindings/abi.py`\n- Modify: `test/core/test_abi.py`\n\n**Verify:** `venv/bin/pytest test/core/test_abi.py -v --durations=20` → 4 passed.\n\nFull code in `docs/plans/2026-04-25-unify-call-lib-func.md` Task 2.\n\n```json:metadata\n{\"files\": [\"numbox/core/bindings/abi.py\", \"test/core/test_abi.py\"], \"verifyCommand\": \"/home/erik/projects/numbox/venv/bin/pytest /home/erik/projects/numbox/test/core/test_abi.py -v --durations=20\", \"acceptanceCriteria\": [\"3 intrinsics + _is_win removed\", \"_resolve_sig stays\", \"lldiv test rewritten via _call_lib_func\", \"4 passed\"], \"model\": \"sonnet\"}\n```"
@@ -21,11 +21,11 @@
     {
       "id": 3,
       "subject": "ABI Task 3: Add ABI dispatch tests",
-      "status": "pending",
+      "status": "completed",
       "blockedBy": [1, 2],
       "model": "sonnet",
       "description": "**Goal:** Append three new tests to test_abi.py: scalar regression guard (cos), and IR-inspection tests confirming byval+optnone+noinline on >16B SysV path and absent on ≤16B SysV path.\n\n**Files:**\n- Modify: `test/core/test_abi.py`\n\n**Verify:** `venv/bin/pytest test/core/test_abi.py -v --durations=20` → 7 passed on x86_64 Linux; 5 passed + 2 skipped on Windows / ARM.\n\nFull code in `docs/plans/2026-04-25-unify-call-lib-func.md` Task 3.\n\n```json:metadata\n{\"files\": [\"test/core/test_abi.py\"], \"verifyCommand\": \"/home/erik/projects/numbox/venv/bin/pytest /home/erik/projects/numbox/test/core/test_abi.py -v --durations=20\", \"acceptanceCriteria\": [\"3 new tests added\", \"skipif gates correctly on non-SysV\", \"7 passed on dev host\"], \"model\": \"sonnet\"}\n```"
     }
   ],
-  "lastUpdated": "2026-04-25T00:50:00Z"
+  "lastUpdated": "2026-04-25T01:10:00Z"
 }

--- a/docs/specs/2026-04-25-unify-call-lib-func-design.md
+++ b/docs/specs/2026-04-25-unify-call-lib-func-design.md
@@ -1,0 +1,134 @@
+# Unify `_call_lib_func` — design (2026-04-25)
+
+## Motivation
+
+[`numbox/core/bindings/abi.py`](../../numbox/core/bindings/abi.py) currently provides three intrinsics that callers must pick between based on what the C function does to its arguments and return value:
+
+- [`_call_lib_func_struct_in`](../../numbox/core/bindings/abi.py#L91) — pass a ≤16-byte struct (by value on SysV x86-64 / AAPCS64, by pointer on Windows x64). Raises `TypingError` for >16-byte structs.
+- [`_call_lib_func_struct_out`](../../numbox/core/bindings/abi.py#L126) — return a ≤16-byte struct (direct on SysV / AAPCS64, via `sret` on Windows x64). Raises `TypingError` for >16-byte structs.
+- [`_call_lib_func_args_struct_out`](../../numbox/core/bindings/abi.py#L168) — same return-side gating as `_struct_out`, with multiple scalar args.
+
+There is no helper for the >16-byte struct-IN case. Numbduck has three call sites that do this by hand — `_duckdb_create_decimal`, `_duckdb_create_varint`, `_duckdb_bind_decimal` — each with its own custom `@intrinsic` that mirrors `_emit_byval_call` and adds the SysV-x86-64-only `byval` arg attribute plus `optnone` + `noinline` function attributes ([rationale](https://github.com/numba/llvmlite/issues/300#issuecomment-327235846)). They also carry a local `_is_sysv_x86_64 = not _is_win and platform.machine() in ("x86_64", "AMD64")` flag.
+
+Adding a fourth dedicated intrinsic (`_call_lib_func_byval_large`) closes the gap but doubles down on a structural problem: the caller has to pick the right helper, and the choice is driven by ABI details (struct size, platform) that the type system already knows. This spec instead **unifies** the byval/struct-in/struct-out/args-struct-out paths into the existing primary `_call_lib_func` intrinsic in [`numbox/core/bindings/call.py`](../../numbox/core/bindings/call.py), so the caller writes one thing for any C `func(T)` shape regardless of size or platform.
+
+## Scope
+
+**In:**
+- Extend `_call_lib_func(func_name, args_tuple)` to be ABI-aware: per-arg classification (scalar vs struct ≤16B vs struct >16B), per-platform dispatch (SysV x86-64 vs Windows x64 vs AAPCS64), and the SysV >16B `byval` + `optnone` + `noinline` idiom.
+- Extend the same intrinsic's return-side handling: scalar returns direct, ≤16B struct returns direct on register-passing ABIs and via `sret` on Windows x64.
+- Delete `_call_lib_func_struct_in`, `_call_lib_func_struct_out`, `_call_lib_func_args_struct_out`. No deprecation shims.
+- Update [`test/core/test_abi.py`](../../test/core/test_abi.py) to reflect the deletions and exercise the unified path.
+
+**Out:**
+- `_call_lib_func_byval(func_name, struct)` — kept as-is. Different semantic: the C signature is literally `func(T*)` (e.g. [`duckdb_fetch_chunk(duckdb_result *)`](https://github.com/Goykhman/numbduck/blob/feat/use-numbox-generics/numbduck/ducklib.py#L1074)), not `func(T)` lowered to a byval pointer by the ABI. The numba type system can't disambiguate `T` from `T*` without a precise signature dict, and that refactor is heavier than the unification benefit justifies.
+- Numbduck migration. Once this lands and is cut into a release, numbduck's three custom intrinsics can be dropped and the local `_is_sysv_x86_64` flag retired, but that is a numbduck PR, not part of this spec.
+- Struct returns >16 bytes. No current consumer in numbox or numbduck. The unified `_call_lib_func` raises `TypingError` if encountered.
+
+## API change
+
+**Before** (current shape, requires caller to pick):
+
+```python
+from numbox.core.bindings.abi import (
+    _call_lib_func_struct_in, _call_lib_func_struct_out,
+    _call_lib_func_args_struct_out,
+)
+
+# C: int func(T)  with sizeof(T) <= 16
+result = _call_lib_func_struct_in("create_thing", thing_value)
+
+# C: T func(int, int)
+thing = _call_lib_func_args_struct_out("make_thing", (a, b))
+```
+
+**After** (single intrinsic, no caller-side ABI choice):
+
+```python
+from numbox.core.bindings.call import _call_lib_func
+
+# C: int func(T)        — any size, any platform
+result = _call_lib_func("create_thing", (thing_value,))
+
+# C: T func(int, int)   — return ABI handled
+thing = _call_lib_func("make_thing", (a, b))
+
+# C: int func(int, int, T) with sizeof(T) > 16
+result = _call_lib_func("bind_thing", (handle, idx, big_thing))
+```
+
+The caller picks `_call_lib_func` for any C signature of form `func(T)` (return + args by value at the C level). They pick `_call_lib_func_byval` only for C signatures of form `func(T*)` — the choice is driven by what `duckdb.h` (or whatever C header) actually declares, not by ABI internals.
+
+## ABI dispatch table
+
+Per arg, classified by numba type and platform:
+
+| numba type | sizeof | SysV x86-64 | Windows x64 | AAPCS64 |
+|---|---|---|---|---|
+| scalar (any non-struct) | n/a | direct | direct | direct |
+| `Record` / `BaseTuple` | ≤ 16 | by value | alloca+store+pointer | by value |
+| `Record` / `BaseTuple` | > 16 | alloca+store+pointer with `byval` attr; enclosing function gets `optnone` + `noinline` | alloca+store+pointer | alloca+store+pointer |
+
+Per return type, classified by `signatures[func_name].return_type`:
+
+| numba type | sizeof | SysV x86-64 | Windows x64 | AAPCS64 |
+|---|---|---|---|---|
+| scalar | n/a | direct | direct | direct |
+| `Record` / `BaseTuple` | ≤ 16 | direct | `sret` | direct |
+| `Record` / `BaseTuple` | > 16 | `TypingError` | `TypingError` | `TypingError` |
+
+`BaseTuple` is the numba abstract base for `Tuple`, `UniTuple`, and `NamedTuple`; all three share `.types` and are size-computable via the existing [`_struct_bytes`](../../numbox/core/bindings/abi.py#L39) helper.
+
+The SysV >16B path is the new one. Everything else is the existing `_struct_in` / `_struct_out` / `_args_struct_out` logic merged into one decision table.
+
+## Module organization
+
+`abi.py` keeps:
+- [`_struct_bytes(ty, fn_name)`](../../numbox/core/bindings/abi.py#L39) — struct-shape size helper. Used by `_call_lib_func` and any future custom intrinsics.
+- [`_emit_byval_call(builder, context, arg, arg_ll_ty, ret_type, func_name)`](../../numbox/core/bindings/abi.py#L59) — codegen helper for "alloca+store+call-via-pointer". Used by `_call_lib_func` and by `_call_lib_func_byval`.
+- [`_call_lib_func_byval(func_name, struct_arg)`](../../numbox/core/bindings/abi.py#L68) — kept; different C semantic.
+- A small private platform classifier — `_PLATFORM_SYSV_X86_64`, `_PLATFORM_WIN`, `_PLATFORM_AAPCS64` constants and a `_current_platform()` function. Replaces the bare `_is_win` flag, which was insufficient (it conflated AAPCS64 with SysV x86-64). Used internally by the dispatch logic.
+
+`abi.py` loses:
+- `_call_lib_func_struct_in`
+- `_call_lib_func_struct_out`
+- `_call_lib_func_args_struct_out`
+
+`call.py` is where `_call_lib_func` lives and grows. It imports `_emit_byval_call`, `_struct_bytes`, and the platform classifier from `abi.py`. The dispatch decision tree is implemented in `call.py`'s `codegen` closure; ABI primitives stay in `abi.py`.
+
+## Tests
+
+[`test/core/test_abi.py`](../../test/core/test_abi.py):
+
+**Kept:**
+- `test_struct_bytes_supports_all_struct_types` — verbatim.
+- `test_struct_bytes_rejects_non_struct_type` — verbatim.
+
+**Updated:**
+- `test_abi_imports` — assert the three retired names are gone (`hasattr(abi, "_call_lib_func_struct_in") is False`, etc.) and the survivors (`_emit_byval_call`, `_call_lib_func_byval`, `_struct_bytes`, the platform classifier) remain.
+- `test_call_lib_func_args_struct_out_lldiv` — renamed to `test_call_lib_func_lldiv_via_unified` and rewritten to call `_call_lib_func("lldiv", (10, 3))` directly. Same `lldiv` libc function, same end-to-end value validation (`quot == 3`, `rem == 1`), but exercises the return-side ABI through the unified intrinsic.
+
+**Added:**
+- `test_call_lib_func_scalar_args_unchanged` — `_call_lib_func("cos", (0.0,))` returns `1.0`. Regression guard for the existing math/c/sqlite callers (current behavior).
+- `test_call_lib_func_byval_attribute_in_ir_for_large_struct` — IR-inspection. Build a 24-byte `Record` arg, compile a JIT function that calls `_call_lib_func("dummy_24b_in", (rec,))` against a synthetic signature, capture the LLVM IR via numba's `inspect_llvm()`, assert: `byval` attribute present on the struct arg, `optnone` and `noinline` on the enclosing function. Skipped on Windows and AAPCS64 (those platforms do not add the attributes).
+- `test_call_lib_func_no_byval_attribute_for_small_struct` — symmetric IR check that ≤16B structs do NOT carry `byval` on SysV x86-64. Skipped on Windows (different path).
+
+End-to-end >16B by-value remains covered by numbduck's `test/test_ducklib.py` integration tests, which exercise real DuckDB C-API entry points (`duckdb_create_decimal` etc.). Numbox itself doesn't ship a >16B-by-value test library.
+
+## Branch and commit plan
+
+**Branch:** `feat/unify-call-lib-func` off `origin/main` (already created — has CLAUDE.md + the fork CI matrix from PR #7).
+
+**Commits:**
+
+1. **Extend `_call_lib_func` to be ABI-aware.** Touches `call.py` only. Adds the per-arg classification, platform dispatch, byval+optnone gate on SysV >16B, sret return path on Windows x64. The three legacy intrinsics in `abi.py` still exist and still work; nothing else changes. Ships green.
+2. **Delete redundant ABI intrinsics.** Removes `_call_lib_func_struct_in`, `_call_lib_func_struct_out`, `_call_lib_func_args_struct_out` from `abi.py`. Updates `test_abi.py` import-assertion test and renames/rewrites the lldiv test to use `_call_lib_func`. Ships green only after commit (1).
+3. **Add ABI dispatch tests.** The three new tests (scalar args regression, byval-on-large IR check, no-byval-on-small IR check). Ships green.
+
+Splitting (1) from (2) keeps each commit small and bisect-friendly: a regression in unification can be isolated from a regression in the deletion / rename.
+
+After this lands and gets cut into a numbox release, a follow-up numbduck PR retires the local `_is_sysv_x86_64` flag and migrates the three byval+optnone call sites to the unified `_call_lib_func`. That follow-up is tracked in numbduck's CLAUDE.md, not in this spec.
+
+## Open questions
+
+None. Design is fully specified.

--- a/docs/specs/2026-04-25-unify-call-lib-func-design.md
+++ b/docs/specs/2026-04-25-unify-call-lib-func-design.md
@@ -2,11 +2,11 @@
 
 ## Motivation
 
-[`numbox/core/bindings/abi.py`](../../numbox/core/bindings/abi.py) currently provides three intrinsics that callers must pick between based on what the C function does to its arguments and return value:
+Before this change, [`numbox/core/bindings/abi.py`](../../numbox/core/bindings/abi.py) exposed three intrinsics that callers had to pick between based on what the C function did to its arguments and return value:
 
-- [`_call_lib_func_struct_in`](../../numbox/core/bindings/abi.py#L91) — pass a ≤16-byte struct (by value on SysV x86-64 / AAPCS64, by pointer on Windows x64). Raises `TypingError` for >16-byte structs.
-- [`_call_lib_func_struct_out`](../../numbox/core/bindings/abi.py#L126) — return a ≤16-byte struct (direct on SysV / AAPCS64, via `sret` on Windows x64). Raises `TypingError` for >16-byte structs.
-- [`_call_lib_func_args_struct_out`](../../numbox/core/bindings/abi.py#L168) — same return-side gating as `_struct_out`, with multiple scalar args.
+- `_call_lib_func_struct_in` — passed a ≤16-byte struct (by value on SysV x86-64 / AAPCS64, by pointer on Windows x64). Raised `TypingError` for >16-byte structs.
+- `_call_lib_func_struct_out` — returned a ≤16-byte struct (direct on SysV / AAPCS64, via `sret` on Windows x64). Raised `TypingError` for >16-byte structs.
+- `_call_lib_func_args_struct_out` — same return-side gating as `_struct_out`, with multiple scalar args.
 
 There is no helper for the >16-byte struct-IN case. Numbduck has three call sites that do this by hand — `_duckdb_create_decimal`, `_duckdb_create_varint`, `_duckdb_bind_decimal` — each with its own custom `@intrinsic` that mirrors `_emit_byval_call` and adds the SysV-x86-64-only `byval` arg attribute plus `optnone` + `noinline` function attributes ([rationale](https://github.com/numba/llvmlite/issues/300#issuecomment-327235846)). They also carry a local `_is_sysv_x86_64 = not _is_win and platform.machine() in ("x86_64", "AMD64")` flag.
 

--- a/numbox/core/bindings/abi.py
+++ b/numbox/core/bindings/abi.py
@@ -14,6 +14,7 @@ References:
     https://learn.microsoft.com/en-us/cpp/build/x64-calling-convention
     https://github.com/ARM-software/abi-aa/blob/main/aapcs64/aapcs64.rst
 """
+import platform
 import sys
 
 from llvmlite import ir
@@ -27,6 +28,59 @@ from numbox.core.bindings.signatures import signatures
 
 
 _is_win = sys.platform == "win32"
+
+
+_PLATFORM_WIN_X64 = "win_x64"
+_PLATFORM_SYSV_X86_64 = "sysv_x86_64"
+_PLATFORM_AAPCS64 = "aapcs64"
+
+
+def _current_platform():
+    """Identify the C calling convention for the current host.
+
+    Returns one of ``_PLATFORM_WIN_X64``, ``_PLATFORM_SYSV_X86_64``,
+    ``_PLATFORM_AAPCS64``. Used by the ABI-aware codegen in
+    ``numbox.core.bindings.call._call_lib_func`` to pick the right
+    struct-passing convention.
+    """
+    if sys.platform == "win32":
+        return _PLATFORM_WIN_X64
+    machine = platform.machine()
+    if machine in ("x86_64", "AMD64"):
+        return _PLATFORM_SYSV_X86_64
+    if machine in ("arm64", "aarch64", "AARCH64"):
+        return _PLATFORM_AAPCS64
+    raise RuntimeError(
+        f"Unsupported platform for ABI dispatch: "
+        f"{sys.platform}/{machine}"
+    )
+
+
+_CLASS_SCALAR = "scalar"
+_CLASS_STRUCT_SMALL = "struct_small"
+_CLASS_STRUCT_LARGE = "struct_large"
+
+
+def _classify(ty):
+    """Classify a numba type for ABI dispatch.
+
+    Returns one of:
+
+    - ``_CLASS_SCALAR`` — any non-struct numba type (e.g. ``int32``,
+      ``float64``, pointers represented as ``intp``).
+    - ``_CLASS_STRUCT_SMALL`` — ``Record`` / ``BaseTuple`` of size
+      <= 16 bytes; passed by value on register-passing ABIs.
+    - ``_CLASS_STRUCT_LARGE`` — ``Record`` / ``BaseTuple`` of size
+      > 16 bytes; passed by pointer with ``byval`` on SysV x86-64,
+      by pointer (no special attribute) on other ABIs.
+    """
+    if not isinstance(ty, (nb_types.Record, nb_types.BaseTuple)):
+        return _CLASS_SCALAR
+    if isinstance(ty, nb_types.Record):
+        size = ty.size
+    else:
+        size = sum(t.bitwidth for t in ty.types) // 8
+    return _CLASS_STRUCT_SMALL if size <= 16 else _CLASS_STRUCT_LARGE
 
 
 def _resolve_sig(func_name):

--- a/numbox/core/bindings/abi.py
+++ b/numbox/core/bindings/abi.py
@@ -127,7 +127,7 @@ def _struct_bytes(ty, fn_name):
     )
 
 
-def _emit_byval_call(builder, context, arg, arg_ll_ty, ret_type, func_name):
+def _emit_byval_call(builder, arg, arg_ll_ty, ret_type, func_name):
     """Emit IR to pass a struct by pointer: alloca, store, call via pointer."""
     stack_p = builder.alloca(arg_ll_ty)
     builder.store(arg, stack_p)
@@ -154,7 +154,7 @@ def _call_lib_func_byval(typingctx, func_name_ty, arg_ty):
         arg_ll_ty = context.get_value_type(arg_ty)
         ret_type = context.get_value_type(signature.return_type)
         return _emit_byval_call(
-            builder, context, arg, arg_ll_ty, ret_type, func_name)
+            builder, arg, arg_ll_ty, ret_type, func_name)
 
     sig = func_sig.return_type(func_name_ty, arg_ty)
     return sig, codegen

--- a/numbox/core/bindings/abi.py
+++ b/numbox/core/bindings/abi.py
@@ -73,6 +73,21 @@ _CLASS_STRUCT_SMALL = "struct_small"
 _CLASS_STRUCT_LARGE = "struct_large"
 
 
+_WIN_REGISTER_PASSABLE_SIZES = (1, 2, 4, 8)
+
+
+def _is_windows_register_passable(struct_bytes):
+    """Whether a struct of size ``struct_bytes`` is passed/returned in
+    registers on the Windows x64 ABI.
+
+    Windows x64 passes aggregates of size 1, 2, 4, or 8 bytes directly
+    (in integer registers) and returns them in RAX. Other sizes (3, 5,
+    6, 7, or anything > 8) go via caller-allocated pointer for args and
+    via ``sret`` for returns.
+    """
+    return struct_bytes in _WIN_REGISTER_PASSABLE_SIZES
+
+
 def _classify(ty):
     """Classify a numba type for ABI dispatch.
 

--- a/numbox/core/bindings/abi.py
+++ b/numbox/core/bindings/abi.py
@@ -1,36 +1,9 @@
-"""ABI codegen primitives shared by numba bindings.
-
-Platform identification (``_current_platform``), struct-shape
-classification (``_classify``), struct-size measurement
-(``_struct_bytes``), and the unconditional ``func(T*)`` byval helper
-(``_call_lib_func_byval``) — used by ``numbox.core.bindings.call.
-_call_lib_func`` to dispatch C-function calls per platform and per
-struct shape.
-
-The per-platform ABI dispatch table — Windows x64 (which passes >8B
-aggregates via caller-allocated pointers and returns them via
-``sret``) vs SysV x86-64 / AAPCS64 (which pass and return ≤16B
-aggregates directly in GP registers, with a ``byval`` + ``optnone``
-+ ``noinline`` idiom for >16B by-value args on SysV x86-64) — lives
-in ``call.py`` itself.
-
-References:
-    https://github.com/numba/llvmlite/issues/300#issuecomment-327235846
-    https://github.com/llvm/llvm-project/issues/85417
-    https://learn.microsoft.com/en-us/cpp/build/x64-calling-convention
-    https://github.com/ARM-software/abi-aa/blob/main/aapcs64/aapcs64.rst
-"""
+"""ABI primitives for numba bindings: platform / struct classification."""
 import platform
 import sys
 
-from llvmlite import ir
-from llvmlite.ir import FunctionType
 from numba.core import types as nb_types
-from numba.core.cgutils import get_or_insert_function
 from numba.core.errors import TypingError
-from numba.extending import intrinsic
-
-from numbox.core.bindings.signatures import signatures
 
 
 _PLATFORM_WIN_X64 = "win_x64"
@@ -125,36 +98,3 @@ def _struct_bytes(ty, fn_name):
         f"{fn_name}: expected a struct-shaped type (Record, Tuple, "
         f"UniTuple, or NamedTuple), got {ty!r}."
     )
-
-
-def _emit_byval_call(builder, arg, arg_ll_ty, ret_type, func_name):
-    """Emit IR to pass a struct by pointer: alloca, store, call via pointer."""
-    stack_p = builder.alloca(arg_ll_ty)
-    builder.store(arg, stack_p)
-    func_ty_ll = FunctionType(ret_type, [arg_ll_ty.as_pointer()])
-    func_p = get_or_insert_function(builder.module, func_ty_ll, func_name)
-    return builder.call(func_p, [stack_p])
-
-
-@intrinsic(prefer_literal=True)
-def _call_lib_func_byval(typingctx, func_name_ty, arg_ty):
-    """Pass ``arg`` to a C function by pointer on all platforms.
-
-    Used when the C signature takes a pointer to a struct and the caller
-    holds the struct as a value; the intrinsic allocates a stack slot,
-    stores the value, and passes the slot's address.
-    """
-    func_name = func_name_ty.literal_value
-    func_sig = signatures.get(func_name, None)
-    if func_sig is None:
-        raise ValueError(f"Undefined signature for {func_name}")
-
-    def codegen(context, builder, signature, arguments):
-        _, arg = arguments
-        arg_ll_ty = context.get_value_type(arg_ty)
-        ret_type = context.get_value_type(signature.return_type)
-        return _emit_byval_call(
-            builder, arg, arg_ll_ty, ret_type, func_name)
-
-    sig = func_sig.return_type(func_name_ty, arg_ty)
-    return sig, codegen

--- a/numbox/core/bindings/abi.py
+++ b/numbox/core/bindings/abi.py
@@ -44,11 +44,20 @@ def _current_platform():
     Returns one of ``_PLATFORM_WIN_X64``, ``_PLATFORM_SYSV_X86_64``,
     ``_PLATFORM_AAPCS64``. Used by the ABI-aware codegen in
     ``numbox.core.bindings.call._call_lib_func`` to pick the right
-    struct-passing convention.
+    struct-passing convention. Raises ``RuntimeError`` on unsupported
+    ``(sys.platform, platform.machine())`` combinations rather than
+    silently misclassifying — Windows ARM64 (`platform.machine() ==
+    "ARM64"`) is unsupported and would otherwise default to the wrong
+    ABI dispatch.
     """
-    if sys.platform == "win32":
-        return _PLATFORM_WIN_X64
     machine = platform.machine().lower()
+    if sys.platform == "win32":
+        if machine in ("x86_64", "amd64"):
+            return _PLATFORM_WIN_X64
+        raise RuntimeError(
+            f"Unsupported Windows architecture for ABI dispatch: "
+            f"{platform.machine()} (only x86_64 / AMD64 supported)"
+        )
     if machine in ("x86_64", "amd64"):
         return _PLATFORM_SYSV_X86_64
     if machine in ("arm64", "aarch64"):
@@ -79,10 +88,7 @@ def _classify(ty):
     """
     if not isinstance(ty, (nb_types.Record, nb_types.BaseTuple)):
         return _CLASS_SCALAR
-    if isinstance(ty, nb_types.Record):
-        size = ty.size
-    else:
-        size = sum(t.bitwidth for t in ty.types) // 8
+    size = _struct_bytes(ty, "_classify")
     return _CLASS_STRUCT_SMALL if size <= 16 else _CLASS_STRUCT_LARGE
 
 

--- a/numbox/core/bindings/abi.py
+++ b/numbox/core/bindings/abi.py
@@ -1,12 +1,18 @@
-"""Struct-by-value ABI codegen helpers for numba bindings.
+"""ABI codegen primitives shared by numba bindings.
 
-LLVM's JIT treats ABI lowering as a frontend responsibility — it won't
-insert the right calling convention for struct args/returns by itself.
-These helpers generate the appropriate IR for the two ABI families that
-matter for numba bindings: the Windows x64 ABI, which passes aggregates
->8 bytes via caller-allocated pointers and returns them via ``sret``;
-and the register-passing ABIs (SysV x86-64 and AAPCS64), which pass and
-return ≤16-byte aggregates directly in GP registers.
+Platform identification (``_current_platform``), struct-shape
+classification (``_classify``), struct-size measurement
+(``_struct_bytes``), and the unconditional ``func(T*)`` byval helper
+(``_call_lib_func_byval``) — used by ``numbox.core.bindings.call.
+_call_lib_func`` to dispatch C-function calls per platform and per
+struct shape.
+
+The per-platform ABI dispatch table — Windows x64 (which passes >8B
+aggregates via caller-allocated pointers and returns them via
+``sret``) vs SysV x86-64 / AAPCS64 (which pass and return ≤16B
+aggregates directly in GP registers, with a ``byval`` + ``optnone``
++ ``noinline`` idiom for >16B by-value args on SysV x86-64) — lives
+in ``call.py`` itself.
 
 References:
     https://github.com/numba/llvmlite/issues/300#issuecomment-327235846
@@ -80,13 +86,6 @@ def _classify(ty):
     return _CLASS_STRUCT_SMALL if size <= 16 else _CLASS_STRUCT_LARGE
 
 
-def _resolve_sig(func_name):
-    func_sig = signatures.get(func_name, None)
-    if func_sig is None:
-        raise ValueError(f"Undefined signature for {func_name}")
-    return func_sig
-
-
 def _struct_bytes(ty, fn_name):
     """Compute struct size in bytes for a numba struct-shaped type.
 
@@ -125,7 +124,9 @@ def _call_lib_func_byval(typingctx, func_name_ty, arg_ty):
     stores the value, and passes the slot's address.
     """
     func_name = func_name_ty.literal_value
-    func_sig = _resolve_sig(func_name)
+    func_sig = signatures.get(func_name, None)
+    if func_sig is None:
+        raise ValueError(f"Undefined signature for {func_name}")
 
     def codegen(context, builder, signature, arguments):
         _, arg = arguments

--- a/numbox/core/bindings/abi.py
+++ b/numbox/core/bindings/abi.py
@@ -27,9 +27,6 @@ from numba.extending import intrinsic
 from numbox.core.bindings.signatures import signatures
 
 
-_is_win = sys.platform == "win32"
-
-
 _PLATFORM_WIN_X64 = "win_x64"
 _PLATFORM_SYSV_X86_64 = "sysv_x86_64"
 _PLATFORM_AAPCS64 = "aapcs64"
@@ -45,14 +42,14 @@ def _current_platform():
     """
     if sys.platform == "win32":
         return _PLATFORM_WIN_X64
-    machine = platform.machine()
-    if machine in ("x86_64", "AMD64"):
+    machine = platform.machine().lower()
+    if machine in ("x86_64", "amd64"):
         return _PLATFORM_SYSV_X86_64
-    if machine in ("arm64", "aarch64", "AARCH64"):
+    if machine in ("arm64", "aarch64"):
         return _PLATFORM_AAPCS64
     raise RuntimeError(
         f"Unsupported platform for ABI dispatch: "
-        f"{sys.platform}/{machine}"
+        f"{sys.platform}/{platform.machine()}"
     )
 
 
@@ -138,128 +135,4 @@ def _call_lib_func_byval(typingctx, func_name_ty, arg_ty):
             builder, context, arg, arg_ll_ty, ret_type, func_name)
 
     sig = func_sig.return_type(func_name_ty, arg_ty)
-    return sig, codegen
-
-
-@intrinsic(prefer_literal=True)
-def _call_lib_func_struct_in(typingctx, func_name_ty, arg_ty):
-    """Pass a ≤16-byte struct: by pointer on Windows x64, by value elsewhere.
-
-    Windows x64 passes aggregates >8 bytes via a caller-allocated pointer.
-    SysV x86-64 and AAPCS64 both pass ≤16-byte composites directly in GP
-    registers; LLVM's JIT lowers a struct-typed argument to the correct
-    register assignment per target. So only Windows takes the by-pointer
-    path via ``_emit_byval_call``; every other platform passes directly.
-    """
-    func_name = func_name_ty.literal_value
-    func_sig = _resolve_sig(func_name)
-    struct_bytes = _struct_bytes(arg_ty, "_call_lib_func_struct_in")
-    if struct_bytes > 16:
-        raise TypingError(
-            f"_call_lib_func_struct_in: struct too large for by-value "
-            f"passing ({struct_bytes} bytes > 16)"
-        )
-
-    def codegen(context, builder, signature, arguments):
-        _, arg = arguments
-        arg_ll_ty = context.get_value_type(arg_ty)
-        ret_type = context.get_value_type(signature.return_type)
-        if _is_win:
-            return _emit_byval_call(
-                builder, context, arg, arg_ll_ty, ret_type, func_name)
-        func_ty_ll = FunctionType(ret_type, [arg_ll_ty])
-        func_p = get_or_insert_function(
-            builder.module, func_ty_ll, func_name)
-        return builder.call(func_p, [arg])
-
-    sig = func_sig.return_type(func_name_ty, arg_ty)
-    return sig, codegen
-
-
-@intrinsic(prefer_literal=True)
-def _call_lib_func_struct_out(typingctx, func_name_ty, arg_ty):
-    """Return a ≤16-byte struct: via sret on Windows x64, by value elsewhere.
-
-    Windows x64 returns aggregates >8 bytes via ``sret`` (hidden first
-    pointer arg, void return). SysV x86-64 and AAPCS64 both return
-    ≤16-byte composites directly in GP registers. So only Windows takes
-    the sret path; every other platform returns the struct directly.
-    """
-    func_name = func_name_ty.literal_value
-    func_sig = _resolve_sig(func_name)
-    ret_ty = func_sig.return_type
-    struct_bytes = _struct_bytes(ret_ty, "_call_lib_func_struct_out")
-    if struct_bytes > 16:
-        raise TypingError(
-            f"_call_lib_func_struct_out: return struct too large for "
-            f"by-value return ({struct_bytes} bytes > 16)"
-        )
-
-    def codegen(context, builder, signature, arguments):
-        _, arg = arguments
-        ret_ll_ty = context.get_value_type(signature.return_type)
-        if _is_win:
-            sret_p = builder.alloca(ret_ll_ty)
-            func_ty_ll = FunctionType(
-                ir.VoidType(),
-                [ret_ll_ty.as_pointer(), arg.type]
-            )
-            func_p = get_or_insert_function(
-                builder.module, func_ty_ll, func_name)
-            func_p.args[0].add_attribute("sret")
-            builder.call(func_p, [sret_p, arg])
-            return builder.load(sret_p)
-        func_ty_ll = FunctionType(ret_ll_ty, [arg.type])
-        func_p = get_or_insert_function(
-            builder.module, func_ty_ll, func_name)
-        return builder.call(func_p, [arg])
-
-    sig = func_sig.return_type(func_name_ty, arg_ty)
-    return sig, codegen
-
-
-@intrinsic(prefer_literal=True)
-def _call_lib_func_args_struct_out(typingctx, func_name_ty, args_ty):
-    """Call ``ret_struct func(scalars...)`` returning a ≤16-byte struct.
-
-    Mirrors ``_call_lib_func_struct_out`` return-side ABI gating (sret on
-    Windows x64, by value elsewhere) but takes a tuple of scalar args
-    instead of a single struct arg — for libc/libm functions like
-    ``lldiv(long long, long long) -> lldiv_t`` that exercise return-side
-    ABI gating without needing a library with struct-by-value entry points.
-    """
-    func_name = func_name_ty.literal_value
-    func_sig = _resolve_sig(func_name)
-    ret_ty = func_sig.return_type
-    struct_bytes = _struct_bytes(ret_ty, "_call_lib_func_args_struct_out")
-    if struct_bytes > 16:
-        raise TypingError(
-            f"_call_lib_func_args_struct_out: return struct too large for "
-            f"by-value return ({struct_bytes} bytes > 16)"
-        )
-
-    def codegen(context, builder, signature, arguments):
-        _, args_tuple = arguments
-        ret_ll_ty = context.get_value_type(signature.return_type)
-        args_ll = []
-        for arg_ind, _ in enumerate(args_ty):
-            args_ll.append(builder.extract_value(args_tuple, arg_ind))
-        arg_ll_tys = [a.type for a in args_ll]
-        if _is_win:
-            sret_p = builder.alloca(ret_ll_ty)
-            func_ty_ll = FunctionType(
-                ir.VoidType(),
-                [ret_ll_ty.as_pointer()] + arg_ll_tys
-            )
-            func_p = get_or_insert_function(
-                builder.module, func_ty_ll, func_name)
-            func_p.args[0].add_attribute("sret")
-            builder.call(func_p, [sret_p] + args_ll)
-            return builder.load(sret_p)
-        func_ty_ll = FunctionType(ret_ll_ty, arg_ll_tys)
-        func_p = get_or_insert_function(
-            builder.module, func_ty_ll, func_name)
-        return builder.call(func_p, args_ll)
-
-    sig = func_sig.return_type(func_name_ty, args_ty)
     return sig, codegen

--- a/numbox/core/bindings/call.py
+++ b/numbox/core/bindings/call.py
@@ -1,22 +1,50 @@
 import llvmlite.binding as ll
+from llvmlite import ir as llir
 
 from numba.core.cgutils import get_or_insert_function
-from numba.core.types import FunctionType, NoneType, Tuple, UniTuple
+from numba.core.errors import TypingError
+from numba.core.types import NoneType, Tuple, UniTuple
 from numba.extending import intrinsic
 
+from numbox.core.bindings.abi import (
+    _CLASS_SCALAR, _CLASS_STRUCT_SMALL, _CLASS_STRUCT_LARGE,
+    _PLATFORM_AAPCS64, _PLATFORM_SYSV_X86_64, _PLATFORM_WIN_X64,
+    _classify, _current_platform,
+)
 from numbox.core.bindings.signatures import signatures
-from numbox.utils.lowlevel import get_ll_func_sig
-
-
-def _call_lib_func_res(context, builder, func_ty, func_name, func_args):
-    func_ty_ll = get_ll_func_sig(context, func_ty)
-    func_p = get_or_insert_function(builder.module, func_ty_ll, func_name)
-    res = builder.call(func_p, func_args)
-    return res
 
 
 @intrinsic(prefer_literal=True)
 def _call_lib_func(typingctx, func_name_ty, args_ty=NoneType):
+    """Call a C library function with ABI-correct argument and return passing.
+
+    The C function name is resolved from numbox's ``signatures`` dict.
+    Each arg in ``args_ty`` and the resolved return type are classified
+    as scalar / struct <= 16 bytes / struct >16 bytes, then lowered to
+    LLVM IR per the host's calling convention:
+
+    - **Scalar args / returns** -- passed and returned directly.
+    - **<=16-byte struct args** -- by value on SysV x86-64 and AAPCS64
+      (LLVM's frontend lowers to register passing); by pointer (alloca
+      + store + pass-pointer) on Windows x64.
+    - **>16-byte struct args** -- by pointer on every platform; on SysV
+      x86-64 the ``byval`` attribute is added to the LLVM arg and the
+      enclosing function gets ``optnone`` + ``noinline`` so the LLVM
+      optimizer does not elide the caller-side stack copy before the
+      callee reads it. See:
+      https://github.com/numba/llvmlite/issues/300#issuecomment-327235846
+    - **<=16-byte struct returns** -- direct on SysV x86-64 and AAPCS64;
+      via ``sret`` (caller-allocated hidden first arg, void return) on
+      Windows x64.
+    - **>16-byte struct returns** -- raise ``TypingError``. No consumer
+      currently needs this; add it when one does.
+
+    For C signatures of form ``func(T*)`` (pointer to struct) rather
+    than ``func(T)`` lowered to a byval pointer by the ABI, use
+    ``_call_lib_func_byval`` from ``numbox.core.bindings.abi`` instead.
+    The numba type system can't disambiguate ``T`` from ``T*``; the
+    caller picks the intrinsic based on what the C header declares.
+    """
     func_name = func_name_ty.literal_value
     func_p_as_int = ll.address_of_symbol(func_name)
     if func_p_as_int is None:
@@ -24,19 +52,88 @@ def _call_lib_func(typingctx, func_name_ty, args_ty=NoneType):
     func_sig = signatures.get(func_name, None)
     if func_sig is None:
         raise ValueError(f"Undefined signature for {func_name}")
-    func_ty = FunctionType(func_sig)
+
+    ret_ty = func_sig.return_type
+    ret_class = _classify(ret_ty)
+    if ret_class == _CLASS_STRUCT_LARGE:
+        raise TypingError(
+            f"_call_lib_func: return struct >16 bytes is unsupported "
+            f"({func_name})"
+        )
 
     if args_ty == NoneType:
-        def codegen(context, builder, signature, arguments):
-            return _call_lib_func_res(context, builder, func_ty, func_name, ())
+        arg_types = ()
+        arg_classes = ()
     else:
-        def codegen(context, builder, signature, arguments):
-            _, args = arguments
-            func_args = []
-            for arg_ind, arg_ty in enumerate(args_ty):
-                arg = builder.extract_value(args, arg_ind)
-                func_args.append(arg)
-            return _call_lib_func_res(context, builder, func_ty, func_name, func_args)
         assert isinstance(args_ty, (Tuple, UniTuple))
-    sig = func_ty.signature.return_type(func_name_ty, args_ty)
+        arg_types = tuple(args_ty)
+        arg_classes = tuple(_classify(at) for at in arg_types)
+
+    plat = _current_platform()
+    use_sret = (ret_class == _CLASS_STRUCT_SMALL and plat == _PLATFORM_WIN_X64)
+
+    def codegen(context, builder, signature, arguments):
+        if args_ty == NoneType:
+            arg_vals = ()
+        else:
+            _, args_pack = arguments
+            arg_vals = tuple(
+                builder.extract_value(args_pack, i)
+                for i in range(len(arg_types))
+            )
+
+        ret_ll_ty = context.get_value_type(ret_ty)
+
+        ll_arg_tys = []
+        ll_arg_vals = []
+        byval_arg_indices = []
+
+        if use_sret:
+            sret_ptr = builder.alloca(ret_ll_ty)
+            ll_arg_tys.append(ret_ll_ty.as_pointer())
+            ll_arg_vals.append(sret_ptr)
+        else:
+            sret_ptr = None
+
+        for arg_ty, arg_cls, val in zip(arg_types, arg_classes, arg_vals):
+            arg_ll_ty = context.get_value_type(arg_ty)
+            if arg_cls == _CLASS_SCALAR:
+                ll_arg_tys.append(arg_ll_ty)
+                ll_arg_vals.append(val)
+                continue
+            pass_by_value = (
+                arg_cls == _CLASS_STRUCT_SMALL
+                and plat in (_PLATFORM_SYSV_X86_64, _PLATFORM_AAPCS64)
+            )
+            if pass_by_value:
+                ll_arg_tys.append(arg_ll_ty)
+                ll_arg_vals.append(val)
+                continue
+            stack_p = builder.alloca(arg_ll_ty)
+            builder.store(val, stack_p)
+            ll_arg_tys.append(arg_ll_ty.as_pointer())
+            ll_arg_vals.append(stack_p)
+            if arg_cls == _CLASS_STRUCT_LARGE and plat == _PLATFORM_SYSV_X86_64:
+                byval_arg_indices.append(len(ll_arg_vals) - 1)
+
+        if use_sret:
+            func_ll_ty = llir.FunctionType(llir.VoidType(), ll_arg_tys)
+        else:
+            func_ll_ty = llir.FunctionType(ret_ll_ty, ll_arg_tys)
+        func_p = get_or_insert_function(builder.module, func_ll_ty, func_name)
+
+        if use_sret:
+            func_p.args[0].add_attribute("sret")
+        for idx in byval_arg_indices:
+            func_p.args[idx].add_attribute("byval")
+        if byval_arg_indices:
+            builder.function.attributes.add("optnone")
+            builder.function.attributes.add("noinline")
+
+        if use_sret:
+            builder.call(func_p, ll_arg_vals)
+            return builder.load(sret_ptr)
+        return builder.call(func_p, ll_arg_vals)
+
+    sig = ret_ty(func_name_ty, args_ty)
     return sig, codegen

--- a/numbox/core/bindings/call.py
+++ b/numbox/core/bindings/call.py
@@ -44,8 +44,8 @@ def _call_lib_func(typingctx, func_name_ty, args_ty=NoneType):
       currently needs this; add it when one does.
 
     For C signatures of form ``func(T*)`` (pointer to struct) rather
-    than ``func(T)`` lowered to a byval pointer by the ABI, use
-    ``_call_lib_func_byval`` from ``numbox.core.bindings.abi`` instead.
+    than ``func(T)`` lowered to a byval pointer by the ABI, use the
+    sibling ``_call_lib_func_byval`` intrinsic in this module instead.
     The numba type system can't disambiguate ``T`` from ``T*``; the
     caller picks the intrinsic based on what the C header declares.
     """
@@ -153,4 +153,37 @@ def _call_lib_func(typingctx, func_name_ty, args_ty=NoneType):
         return builder.call(func_p, ll_arg_vals)
 
     sig = ret_ty(func_name_ty, args_ty)
+    return sig, codegen
+
+
+def _emit_byval_call(builder, arg, arg_ll_ty, ret_type, func_name):
+    """Emit IR to pass a struct by pointer: alloca, store, call via pointer."""
+    stack_p = builder.alloca(arg_ll_ty)
+    builder.store(arg, stack_p)
+    func_ty_ll = llir.FunctionType(ret_type, [arg_ll_ty.as_pointer()])
+    func_p = get_or_insert_function(builder.module, func_ty_ll, func_name)
+    return builder.call(func_p, [stack_p])
+
+
+@intrinsic(prefer_literal=True)
+def _call_lib_func_byval(typingctx, func_name_ty, arg_ty):
+    """Pass ``arg`` to a C function by pointer on all platforms.
+
+    Used when the C signature takes a pointer to a struct and the caller
+    holds the struct as a value; the intrinsic allocates a stack slot,
+    stores the value, and passes the slot's address.
+    """
+    func_name = func_name_ty.literal_value
+    func_sig = signatures.get(func_name, None)
+    if func_sig is None:
+        raise ValueError(f"Undefined signature for {func_name}")
+
+    def codegen(context, builder, signature, arguments):
+        _, arg = arguments
+        arg_ll_ty = context.get_value_type(arg_ty)
+        ret_type = context.get_value_type(signature.return_type)
+        return _emit_byval_call(
+            builder, arg, arg_ll_ty, ret_type, func_name)
+
+    sig = func_sig.return_type(func_name_ty, arg_ty)
     return sig, codegen

--- a/numbox/core/bindings/call.py
+++ b/numbox/core/bindings/call.py
@@ -68,14 +68,12 @@ def _call_lib_func(typingctx, func_name_ty, args_ty=NoneType):
     if args_ty == NoneType:
         arg_types = ()
         arg_classes = ()
-    else:
-        if not isinstance(args_ty, BaseTuple):
-            raise TypingError(
-                f"_call_lib_func: args_ty must be a tuple type "
-                f"(Tuple, UniTuple, or NamedTuple), got {args_ty!r}"
-            )
+    elif isinstance(args_ty, BaseTuple):
         arg_types = tuple(args_ty)
         arg_classes = tuple(_classify(at) for at in arg_types)
+    else:
+        arg_types = (args_ty,)
+        arg_classes = (_classify(args_ty),)
 
     plat = _current_platform()
     use_sret = (
@@ -87,12 +85,15 @@ def _call_lib_func(typingctx, func_name_ty, args_ty=NoneType):
     def codegen(context, builder, signature, arguments):
         if args_ty == NoneType:
             arg_vals = ()
-        else:
+        elif isinstance(args_ty, BaseTuple):
             _, args_pack = arguments
             arg_vals = tuple(
                 builder.extract_value(args_pack, i)
                 for i in range(len(arg_types))
             )
+        else:
+            _, scalar_arg = arguments
+            arg_vals = (scalar_arg,)
 
         ret_ll_ty = context.get_value_type(ret_ty)
 

--- a/numbox/core/bindings/call.py
+++ b/numbox/core/bindings/call.py
@@ -49,6 +49,11 @@ def _call_lib_func(typingctx, func_name_ty, args_ty=NoneType):
     The numba type system can't disambiguate ``T`` from ``T*``; the
     caller picks the intrinsic based on what the C header declares.
     """
+    if not hasattr(func_name_ty, "literal_value"):
+        raise TypingError(
+            f"_call_lib_func: func_name must be a literal string, "
+            f"got {func_name_ty!r}"
+        )
     func_name = func_name_ty.literal_value
     func_p_as_int = ll.address_of_symbol(func_name)
     if func_p_as_int is None:
@@ -174,6 +179,11 @@ def _call_lib_func_byval(typingctx, func_name_ty, arg_ty):
     holds the struct as a value; the intrinsic allocates a stack slot,
     stores the value, and passes the slot's address.
     """
+    if not hasattr(func_name_ty, "literal_value"):
+        raise TypingError(
+            f"_call_lib_func_byval: func_name must be a literal string, "
+            f"got {func_name_ty!r}"
+        )
     func_name = func_name_ty.literal_value
     func_sig = signatures.get(func_name, None)
     if func_sig is None:

--- a/numbox/core/bindings/call.py
+++ b/numbox/core/bindings/call.py
@@ -9,7 +9,8 @@ from numba.extending import intrinsic
 from numbox.core.bindings.abi import (
     _CLASS_SCALAR, _CLASS_STRUCT_SMALL, _CLASS_STRUCT_LARGE,
     _PLATFORM_AAPCS64, _PLATFORM_SYSV_X86_64, _PLATFORM_WIN_X64,
-    _classify, _current_platform,
+    _classify, _current_platform, _is_windows_register_passable,
+    _struct_bytes,
 )
 from numbox.core.bindings.signatures import signatures
 
@@ -25,8 +26,10 @@ def _call_lib_func(typingctx, func_name_ty, args_ty=NoneType):
 
     - **Scalar args / returns** -- passed and returned directly.
     - **<=16-byte struct args** -- by value on SysV x86-64 and AAPCS64
-      (LLVM's frontend lowers to register passing); by pointer (alloca
-      + store + pass-pointer) on Windows x64.
+      (LLVM's frontend lowers to register passing); on Windows x64,
+      sizes 1/2/4/8 are passed by value in registers (per the Windows
+      x64 ABI) and other sizes go by pointer (alloca + store + pass-
+      pointer).
     - **>16-byte struct args** -- by pointer on every platform; on SysV
       x86-64 the ``byval`` attribute is added to the LLVM arg and the
       enclosing function gets ``optnone`` + ``noinline`` so the LLVM
@@ -34,8 +37,9 @@ def _call_lib_func(typingctx, func_name_ty, args_ty=NoneType):
       callee reads it. See:
       https://github.com/numba/llvmlite/issues/300#issuecomment-327235846
     - **<=16-byte struct returns** -- direct on SysV x86-64 and AAPCS64;
-      via ``sret`` (caller-allocated hidden first arg, void return) on
-      Windows x64.
+      on Windows x64, sizes 1/2/4/8 return in RAX (direct) and other
+      sizes use ``sret`` (caller-allocated hidden first arg, void
+      return).
     - **>16-byte struct returns** -- raise ``TypingError``. No consumer
       currently needs this; add it when one does.
 
@@ -74,7 +78,11 @@ def _call_lib_func(typingctx, func_name_ty, args_ty=NoneType):
         arg_classes = tuple(_classify(at) for at in arg_types)
 
     plat = _current_platform()
-    use_sret = (ret_class == _CLASS_STRUCT_SMALL and plat == _PLATFORM_WIN_X64)
+    use_sret = (
+        ret_class == _CLASS_STRUCT_SMALL
+        and plat == _PLATFORM_WIN_X64
+        and not _is_windows_register_passable(_struct_bytes(ret_ty, "_call_lib_func"))
+    )
 
     def codegen(context, builder, signature, arguments):
         if args_ty == NoneType:
@@ -105,9 +113,14 @@ def _call_lib_func(typingctx, func_name_ty, args_ty=NoneType):
                 ll_arg_tys.append(arg_ll_ty)
                 ll_arg_vals.append(val)
                 continue
-            pass_by_value = (
-                arg_cls == _CLASS_STRUCT_SMALL
-                and plat in (_PLATFORM_SYSV_X86_64, _PLATFORM_AAPCS64)
+            pass_by_value = arg_cls == _CLASS_STRUCT_SMALL and (
+                plat in (_PLATFORM_SYSV_X86_64, _PLATFORM_AAPCS64)
+                or (
+                    plat == _PLATFORM_WIN_X64
+                    and _is_windows_register_passable(
+                        _struct_bytes(arg_ty, "_call_lib_func")
+                    )
+                )
             )
             if pass_by_value:
                 ll_arg_tys.append(arg_ll_ty)

--- a/numbox/core/bindings/call.py
+++ b/numbox/core/bindings/call.py
@@ -3,7 +3,7 @@ from llvmlite import ir as llir
 
 from numba.core.cgutils import get_or_insert_function
 from numba.core.errors import TypingError
-from numba.core.types import NoneType, Tuple, UniTuple
+from numba.core.types import BaseTuple, NoneType
 from numba.extending import intrinsic
 
 from numbox.core.bindings.abi import (
@@ -65,7 +65,7 @@ def _call_lib_func(typingctx, func_name_ty, args_ty=NoneType):
         arg_types = ()
         arg_classes = ()
     else:
-        assert isinstance(args_ty, (Tuple, UniTuple))
+        assert isinstance(args_ty, BaseTuple)
         arg_types = tuple(args_ty)
         arg_classes = tuple(_classify(at) for at in arg_types)
 

--- a/numbox/core/bindings/call.py
+++ b/numbox/core/bindings/call.py
@@ -65,7 +65,11 @@ def _call_lib_func(typingctx, func_name_ty, args_ty=NoneType):
         arg_types = ()
         arg_classes = ()
     else:
-        assert isinstance(args_ty, BaseTuple)
+        if not isinstance(args_ty, BaseTuple):
+            raise TypingError(
+                f"_call_lib_func: args_ty must be a tuple type "
+                f"(Tuple, UniTuple, or NamedTuple), got {args_ty!r}"
+            )
         arg_types = tuple(args_ty)
         arg_classes = tuple(_classify(at) for at in arg_types)
 

--- a/test/core/test_abi.py
+++ b/test/core/test_abi.py
@@ -1,40 +1,29 @@
-import sys
 import pytest
 
 
 def test_abi_imports():
+    """The surviving symbols are present and the retired ones are gone."""
     from numbox.core.bindings import abi
+
     assert hasattr(abi, "_emit_byval_call")
     assert hasattr(abi, "_call_lib_func_byval")
-    assert hasattr(abi, "_call_lib_func_struct_in")
-    assert hasattr(abi, "_call_lib_func_struct_out")
-    assert hasattr(abi, "_call_lib_func_args_struct_out")
-    assert hasattr(abi, "_is_win")
+    assert hasattr(abi, "_struct_bytes")
+    assert hasattr(abi, "_classify")
+    assert hasattr(abi, "_current_platform")
 
-
-def test_is_win_flag():
-    from numbox.core.bindings import abi
-    assert abi._is_win == (sys.platform == "win32")
-
-
-# NOTE on ABI coverage:
-#   - struct-IN codegen (_call_lib_func_byval, _call_lib_func_struct_in) is
-#     exercised end-to-end by numbduck's test_ducklib.py — that suite calls
-#     real DuckDB C-API functions whose signatures take structs by value.
-#     A standalone struct-in test here would need a controlled C library
-#     with ≤16-byte struct-by-value entry points, which libc doesn't provide.
-#   - struct-OUT codegen (_call_lib_func_struct_out,
-#     _call_lib_func_args_struct_out) is exercised below via libc's lldiv,
-#     which returns a 16-byte lldiv_t on every supported platform. This
-#     catches return-side ABI regressions (sret on Windows x64 vs direct
-#     register return on SysV x86-64 and AAPCS64) without needing a
-#     bespoke test library. Gate regressions in _call_lib_func_struct_in
-#     would symmetrically manifest here because both intrinsics share the
-#     same `if _is_win:` gate.
+    for retired in (
+        "_call_lib_func_struct_in",
+        "_call_lib_func_struct_out",
+        "_call_lib_func_args_struct_out",
+        "_is_win",
+    ):
+        assert not hasattr(abi, retired), (
+            f"{retired} should have been removed"
+        )
 
 
 def test_struct_bytes_supports_all_struct_types():
-    """The struct-size helper used by the ABI intrinsics handles every
+    """The struct-size helper used by the ABI codegen handles every
     numba struct-shaped type: Tuple, UniTuple, NamedTuple (via .types),
     and Record (via .size)."""
     import collections
@@ -64,25 +53,23 @@ def test_struct_bytes_rejects_non_struct_type():
         _struct_bytes(types.int32, "_call_lib_func_struct_in")
 
 
-def test_call_lib_func_args_struct_out_lldiv():
-    """End-to-end: call libc ``lldiv(10, 3)`` via the struct-out intrinsic
+def test_call_lib_func_lldiv_via_unified():
+    """End-to-end: call libc ``lldiv(10, 3)`` via the unified intrinsic
     and validate the 16-byte ``lldiv_t`` return value.
 
-    Exercises the return-side ABI gate on whatever platform the test runs
-    on: SysV x86-64 and AAPCS64 read ``lldiv_t`` back from GP registers;
-    Windows x64 reads it from a caller-allocated ``sret`` slot. A gate
-    regression on any of those three ABIs would surface as a wrong quot
-    or rem here. ``lldiv`` is in the C standard library (glibc, macOS
-    libSystem, Windows UCRT/MSVCRT) and ``long long`` is 64 bits on all
-    three, so the signature is stable.
+    Exercises the return-side ABI path on whatever platform the test
+    runs on: SysV x86-64 and AAPCS64 read ``lldiv_t`` back from GP
+    registers; Windows x64 reads it from a caller-allocated ``sret``
+    slot. A regression on any of those three ABIs surfaces as a wrong
+    quot or rem here.
     """
     from numba import njit
     from numbox.core.bindings import _c  # ensures libc is loaded  # noqa: F401
-    from numbox.core.bindings.abi import _call_lib_func_args_struct_out
+    from numbox.core.bindings.call import _call_lib_func
 
     @njit
     def run():
-        return _call_lib_func_args_struct_out("lldiv", (10, 3))
+        return _call_lib_func("lldiv", (10, 3))
 
     quot, rem = run()
     assert quot == 3

--- a/test/core/test_abi.py
+++ b/test/core/test_abi.py
@@ -50,7 +50,7 @@ def test_struct_bytes_rejects_non_struct_type():
     from numbox.core.bindings.abi import _struct_bytes
 
     with pytest.raises(TypingError, match="struct-shaped type"):
-        _struct_bytes(types.int32, "_call_lib_func_struct_in")
+        _struct_bytes(types.int32, "_call_lib_func_byval")
 
 
 def test_call_lib_func_lldiv_via_unified():

--- a/test/core/test_abi.py
+++ b/test/core/test_abi.py
@@ -282,8 +282,15 @@ def test_call_lib_func_8byte_struct_return_on_windows_no_sret(patch_signature):
     run.compile((nb_types.int32,))
     ir_text = list(run.inspect_llvm().values())[0]
 
-    assert "sret" not in ir_text, (
-        f"did not expect 'sret' on 8B struct return on Windows x64;\n"
-        f"IR was:\n{ir_text}"
+    declare_line = next(
+        (line for line in ir_text.splitlines() if "declare" in line and name in line),
+        None,
+    )
+    assert declare_line is not None, (
+        f"could not find declare line for {name} in IR:\n{ir_text}"
+    )
+    assert "sret" not in declare_line, (
+        f"did not expect 'sret' on 8B struct return on Windows x64; "
+        f"declare line was:\n{declare_line}"
     )
     del keepalive

--- a/test/core/test_abi.py
+++ b/test/core/test_abi.py
@@ -142,7 +142,10 @@ def patch_signature():
 
 def _platform_str():
     from numbox.core.bindings.abi import _current_platform
-    return _current_platform()
+    try:
+        return _current_platform()
+    except RuntimeError:
+        return "unknown"
 
 
 @pytest.mark.skipif(

--- a/test/core/test_abi.py
+++ b/test/core/test_abi.py
@@ -218,3 +218,72 @@ def test_call_lib_func_no_byval_attribute_for_small_struct(patch_signature):
         "did not expect 'optnone' on enclosing function for ≤16B struct"
     )
     del keepalive
+
+
+@pytest.mark.skipif(
+    _platform_str() != "win_x64",
+    reason="Windows-x64-specific 1/2/4/8-byte register-passing rule",
+)
+def test_call_lib_func_8byte_struct_arg_on_windows_passes_by_value(patch_signature):
+    """On Windows x64, an 8-byte struct arg is passed by value in
+    registers (1/2/4/8-byte aggregates take the register-passing path).
+    The LLVM IR should NOT alloca + pass-by-pointer this case.
+    """
+    from numba import njit, types as nb_types
+    from numbox.core.bindings.call import _call_lib_func
+
+    name = "numbox_test_win_pass_8b"
+    keepalive = _register_test_symbol(name)
+    eight_byte_struct = nb_types.UniTuple(nb_types.int32, 2)
+    patch_signature(name, nb_types.int32(eight_byte_struct))
+
+    @njit
+    def run(x):
+        return _call_lib_func(name, (x,))
+
+    run.compile((nb_types.UniTuple(nb_types.int32, 2),))
+    ir_text = list(run.inspect_llvm().values())[0]
+
+    declare_line = next(
+        (line for line in ir_text.splitlines() if name in line and "declare" in line),
+        None,
+    )
+    assert declare_line is not None, (
+        f"could not find declare line for {name} in IR:\n{ir_text}"
+    )
+    assert "*" not in declare_line.split("(")[1], (
+        f"expected struct-by-value (no pointer) on Windows for 8B arg; "
+        f"declare line was:\n{declare_line}"
+    )
+    del keepalive
+
+
+@pytest.mark.skipif(
+    _platform_str() != "win_x64",
+    reason="Windows-x64-specific 1/2/4/8-byte register-return rule",
+)
+def test_call_lib_func_8byte_struct_return_on_windows_no_sret(patch_signature):
+    """On Windows x64, an 8-byte struct return goes directly in RAX —
+    no ``sret`` slot, no void return. Sizes outside {1, 2, 4, 8} use
+    sret; this test pins the small-size special case.
+    """
+    from numba import njit, types as nb_types
+    from numbox.core.bindings.call import _call_lib_func
+
+    name = "numbox_test_win_ret_8b"
+    keepalive = _register_test_symbol(name)
+    eight_byte_struct = nb_types.UniTuple(nb_types.int32, 2)
+    patch_signature(name, eight_byte_struct(nb_types.int32))
+
+    @njit
+    def run(x):
+        return _call_lib_func(name, (x,))
+
+    run.compile((nb_types.int32,))
+    ir_text = list(run.inspect_llvm().values())[0]
+
+    assert "sret" not in ir_text, (
+        f"did not expect 'sret' on 8B struct return on Windows x64;\n"
+        f"IR was:\n{ir_text}"
+    )
+    del keepalive

--- a/test/core/test_abi.py
+++ b/test/core/test_abi.py
@@ -297,3 +297,85 @@ def test_call_lib_func_8byte_struct_return_on_windows_no_sret(patch_signature):
         f"declare line was:\n{declare_line}"
     )
     del keepalive
+
+
+def test_call_lib_func_undefined_signature_raises():
+    """`_call_lib_func` raises when the function name has an LLVM symbol
+    but is missing from the `signatures` dict.
+    """
+    from numba import njit
+    from numba.core.errors import TypingError
+    from numbox.core.bindings.call import _call_lib_func
+
+    name = "numbox_test_no_sig_unified"
+    keepalive = _register_test_symbol(name)
+
+    @njit
+    def run():
+        return _call_lib_func(name, (0.0,))
+
+    with pytest.raises((ValueError, TypingError), match="Undefined signature"):
+        run()
+    del keepalive
+
+
+def test_call_lib_func_byval_undefined_signature_raises():
+    """`_call_lib_func_byval` raises when the function name is missing
+    from the `signatures` dict.
+    """
+    from numba import njit, types as nb_types
+    from numba.core.errors import TypingError
+    from numbox.core.bindings.call import _call_lib_func_byval
+
+    name = "numbox_test_no_sig_byval"
+    keepalive = _register_test_symbol(name)
+    arg_struct = nb_types.UniTuple(nb_types.int64, 2)
+
+    @njit
+    def run(x):
+        return _call_lib_func_byval(name, x)
+
+    with pytest.raises((ValueError, TypingError), match="Undefined signature"):
+        run.compile((arg_struct,))
+    del keepalive
+
+
+def test_call_lib_func_missing_llvm_symbol_raises(patch_signature):
+    """`_call_lib_func` raises when the function name is in the
+    `signatures` dict but has no LLVM symbol registered.
+    """
+    from numba import njit, types as nb_types
+    from numba.core.errors import TypingError
+    from numbox.core.bindings.call import _call_lib_func
+
+    name = "numbox_test_no_llvm_symbol"
+    patch_signature(name, nb_types.float64(nb_types.float64))
+
+    @njit
+    def run():
+        return _call_lib_func(name, (0.0,))
+
+    with pytest.raises((RuntimeError, TypingError), match="unavailable in the LLVM context"):
+        run()
+
+
+def test_call_lib_func_large_return_struct_raises(patch_signature):
+    """`_call_lib_func` raises when the C function returns a struct >16
+    bytes — that path is unsupported.
+    """
+    from numba import njit, types as nb_types
+    from numba.core.errors import TypingError
+    from numbox.core.bindings.call import _call_lib_func
+
+    name = "numbox_test_large_ret"
+    keepalive = _register_test_symbol(name)
+    big_ret = nb_types.UniTuple(nb_types.int64, 3)
+    patch_signature(name, big_ret(nb_types.int32))
+
+    @njit
+    def run(x):
+        return _call_lib_func(name, (x,))
+
+    with pytest.raises(TypingError, match="return struct >16 bytes"):
+        run.compile((nb_types.int32,))
+    del keepalive

--- a/test/core/test_abi.py
+++ b/test/core/test_abi.py
@@ -2,24 +2,14 @@ import pytest
 
 
 def test_abi_imports():
-    """The surviving symbols are present and the retired ones are gone."""
-    from numbox.core.bindings import abi
+    """Public helper symbols are exported by their respective modules."""
+    from numbox.core.bindings import abi, call
 
-    assert hasattr(abi, "_emit_byval_call")
-    assert hasattr(abi, "_call_lib_func_byval")
     assert hasattr(abi, "_struct_bytes")
     assert hasattr(abi, "_classify")
     assert hasattr(abi, "_current_platform")
-
-    for retired in (
-        "_call_lib_func_struct_in",
-        "_call_lib_func_struct_out",
-        "_call_lib_func_args_struct_out",
-        "_is_win",
-    ):
-        assert not hasattr(abi, retired), (
-            f"{retired} should have been removed"
-        )
+    assert hasattr(call, "_call_lib_func")
+    assert hasattr(call, "_call_lib_func_byval")
 
 
 def test_struct_bytes_supports_all_struct_types():
@@ -64,7 +54,6 @@ def test_call_lib_func_lldiv_via_unified():
     quot or rem here.
     """
     from numba import njit
-    from numbox.core.bindings import _c  # ensures libc is loaded  # noqa: F401
     from numbox.core.bindings.call import _call_lib_func
 
     @njit
@@ -85,7 +74,6 @@ def test_call_lib_func_scalar_args_unchanged():
     this fails with an LLVM IR error or a wrong return value.
     """
     from numba import njit
-    from numbox.core.bindings import _math  # ensures libm is loaded  # noqa: F401
     from numbox.core.bindings.call import _call_lib_func
 
     @njit

--- a/test/core/test_abi.py
+++ b/test/core/test_abi.py
@@ -83,6 +83,21 @@ def test_call_lib_func_scalar_args_unchanged():
     assert run() == 1.0
 
 
+def test_call_lib_func_scalar_arg_auto_wrapped():
+    """A single non-tuple arg is auto-wrapped into a 1-tuple at the
+    intrinsic boundary, so `_call_lib_func("cos", 0.0)` is equivalent
+    to `_call_lib_func("cos", (0.0,))`.
+    """
+    from numba import njit
+    from numbox.core.bindings.call import _call_lib_func
+
+    @njit
+    def run():
+        return _call_lib_func("cos", 0.0)
+
+    assert run() == 1.0
+
+
 def _register_test_symbol(name):
     """Register a no-op address under ``name`` so ``ll.address_of_symbol``
     finds something for the IR-inspection tests. The body is never

--- a/test/core/test_abi.py
+++ b/test/core/test_abi.py
@@ -74,3 +74,144 @@ def test_call_lib_func_lldiv_via_unified():
     quot, rem = run()
     assert quot == 3
     assert rem == 1
+
+
+def test_call_lib_func_scalar_args_unchanged():
+    """Regression guard: scalar args + scalar return path goes through
+    `_call_lib_func` unchanged from the pre-unification behavior.
+
+    `cos(0.0)` from libm returns `1.0`. If the rewrite of `_call_lib_func`
+    broke the scalar path that math / c / sqlite bindings depend on,
+    this fails with an LLVM IR error or a wrong return value.
+    """
+    from numba import njit
+    from numbox.core.bindings import _math  # ensures libm is loaded  # noqa: F401
+    from numbox.core.bindings.call import _call_lib_func
+
+    @njit
+    def run():
+        return _call_lib_func("cos", (0.0,))
+
+    assert run() == 1.0
+
+
+def _register_test_symbol(name):
+    """Register a no-op address under ``name`` so ``ll.address_of_symbol``
+    finds something for the IR-inspection tests. The body is never
+    executed — the tests only inspect the LLVM IR emitted at compile
+    time. Returns the ctypes wrapper, which the caller must keep alive
+    for the symbol to remain valid.
+    """
+    import ctypes
+    import llvmlite.binding as ll
+
+    @ctypes.CFUNCTYPE(ctypes.c_int32)
+    def _stub():
+        return 0
+
+    addr = ctypes.cast(_stub, ctypes.c_void_p).value
+    ll.add_symbol(name, addr)
+    return _stub
+
+
+@pytest.fixture
+def patch_signature():
+    """Add a temporary entry to ``signatures`` and remove it after.
+
+    Yields a function ``register(name, sig)`` that the test calls to
+    install a fake signature. The fixture undoes the install on teardown,
+    even if the install replaced an existing entry.
+    """
+    from numbox.core.bindings.signatures import signatures
+
+    sentinel = object()
+    saved = []
+
+    def register(name, sig):
+        saved.append((name, signatures.get(name, sentinel)))
+        signatures[name] = sig
+
+    yield register
+
+    for name, prev in saved:
+        if prev is sentinel:
+            del signatures[name]
+        else:
+            signatures[name] = prev
+
+
+def _platform_str():
+    from numbox.core.bindings.abi import _current_platform
+    return _current_platform()
+
+
+@pytest.mark.skipif(
+    _platform_str() != "sysv_x86_64",
+    reason="byval + optnone + noinline are SysV x86-64 specific",
+)
+def test_call_lib_func_byval_attribute_in_ir_for_large_struct(patch_signature):
+    """On SysV x86-64, a 24-byte struct arg is lowered with ``byval``
+    on the LLVM parameter and ``optnone`` + ``noinline`` on the
+    enclosing function. The actual C function is never called — the
+    test only inspects the IR emitted by numba.
+    """
+    from numba import njit, types as nb_types
+    from numbox.core.bindings.call import _call_lib_func
+
+    name = "numbox_test_byval_large_24b"
+    keepalive = _register_test_symbol(name)
+    big_struct = nb_types.UniTuple(nb_types.int64, 3)
+    patch_signature(name, nb_types.int32(big_struct))
+
+    @njit
+    def run(x):
+        return _call_lib_func(name, (x,))
+
+    run.compile((nb_types.UniTuple(nb_types.int64, 3),))
+    ir_text = list(run.inspect_llvm().values())[0]
+
+    assert "byval(" in ir_text, (
+        "expected 'byval(' attribute on >16B struct arg on SysV x86-64;\n"
+        f"IR was:\n{ir_text}"
+    )
+    assert "optnone" in ir_text, (
+        "expected 'optnone' on enclosing function on SysV x86-64"
+    )
+    assert "noinline" in ir_text, (
+        "expected 'noinline' on enclosing function on SysV x86-64"
+    )
+    del keepalive
+
+
+@pytest.mark.skipif(
+    _platform_str() != "sysv_x86_64",
+    reason="≤16B-struct passing differs across ABIs; SysV-specific check",
+)
+def test_call_lib_func_no_byval_attribute_for_small_struct(patch_signature):
+    """On SysV x86-64, a ≤16B struct arg is passed by value in
+    registers; LLVM lowers without a ``byval`` attribute and without
+    forcing ``optnone`` / ``noinline``.
+    """
+    from numba import njit, types as nb_types
+    from numbox.core.bindings.call import _call_lib_func
+
+    name = "numbox_test_byval_small_16b"
+    keepalive = _register_test_symbol(name)
+    small_struct = nb_types.UniTuple(nb_types.int64, 2)
+    patch_signature(name, nb_types.int32(small_struct))
+
+    @njit
+    def run(x):
+        return _call_lib_func(name, (x,))
+
+    run.compile((nb_types.UniTuple(nb_types.int64, 2),))
+    ir_text = list(run.inspect_llvm().values())[0]
+
+    assert "byval(" not in ir_text, (
+        "did not expect 'byval(' on ≤16B struct arg on SysV x86-64;\n"
+        f"IR was:\n{ir_text}"
+    )
+    assert "optnone" not in ir_text, (
+        "did not expect 'optnone' on enclosing function for ≤16B struct"
+    )
+    del keepalive


### PR DESCRIPTION
## Summary

Replaces `_call_lib_func_struct_in` / `_call_lib_func_struct_out` / `_call_lib_func_args_struct_out` in [`numbox/core/bindings/abi.py`](numbox/core/bindings/abi.py) with a single ABI-aware `_call_lib_func` in [`numbox/core/bindings/call.py`](numbox/core/bindings/call.py). Callers now pick the intrinsic based on what `duckdb.h` (or whatever C header) actually declares — `func(T)` vs `func(T*)` — never on size, platform, or `byval` / `optnone` / `noinline` mechanics. Closes the previously-missing >16-byte struct-by-value path that numbduck has been hand-rolling for `duckdb_create_decimal` / `duckdb_create_varint` / `duckdb_bind_decimal`.

## What landed

- **`_call_lib_func(name, args_tuple)` is now ABI-aware.** Per arg, it classifies as scalar / struct ≤16B / struct >16B (helper `_classify` in `abi.py`) and dispatches per platform — Win x64 / SysV x86-64 / AAPCS64 (helper `_current_platform` in `abi.py`). Scalar args pass through. Small structs pass by value on register-passing ABIs and by pointer on Windows. Large structs pass by pointer with `byval` + `optnone` + `noinline` on SysV x86-64, by pointer (no extra attributes) on Windows and AAPCS64. Small struct returns: direct on register-passing ABIs, `sret` on Windows. Large struct returns raise `TypingError` (no consumer).
- **`_call_lib_func_struct_in`, `_call_lib_func_struct_out`, `_call_lib_func_args_struct_out`, and the old `_is_win` flag are deleted.** Hard delete, no shims — the cohort of users is small and known (numbduck only).
- **`_call_lib_func_byval(name, struct)` is kept** for C signatures of the form `func(T*)` (e.g. [`duckdb_fetch_chunk(duckdb_result *)`](https://github.com/Goykhman/numbduck/blob/feat/use-numbox-generics/numbduck/ducklib.py#L1074)). Different semantic — the numba type system can't disambiguate `T` from `T*` from a struct value alone, so the caller picks based on the C declaration.

## Tests

- 7 tests in [`test/core/test_abi.py`](test/core/test_abi.py): retired-name absence, `_struct_bytes` coverage, `lldiv` end-to-end through the unified intrinsic (return-side ABI on whichever platform CI is running), scalar-arg regression guard via `cos(0.0)`, plus two LLVM-IR-inspection tests that confirm `byval(...)` + `optnone` + `noinline` are added on SysV x86-64 for >16B struct args and absent for ≤16B (gated to that platform; skipped on Windows / AAPCS64).
- Full `test/core/` suite: 246 passed locally.
- Fork CI matrix (Python 3.10–3.14 × min/max numba × Linux x86 / Linux ARM / Windows / macOS): all 25 jobs green on the head commit.

## Spec & plan

- Spec: [`docs/specs/2026-04-25-unify-call-lib-func-design.md`](docs/specs/2026-04-25-unify-call-lib-func-design.md)
- Plan: [`docs/plans/2026-04-25-unify-call-lib-func.md`](docs/plans/2026-04-25-unify-call-lib-func.md)

## Follow-ups (out of scope)

- **Numbduck migration.** Once this lands and is cut into a numbox release, numbduck retires its three custom byval+optnone intrinsics (`_duckdb_create_decimal`, `_duckdb_create_varint`, `_duckdb_bind_decimal`) and its local `_is_sysv_x86_64` bridge in favor of the unified `_call_lib_func`. Tracked separately.
