### PR TITLE
Add SysV x86-64 INT/INT eightbyte repack to _call_lib_func

### DIFF
--- a/.github/workflows/numbox_ci.yml
+++ b/.github/workflows/numbox_ci.yml
@@ -105,8 +105,8 @@ jobs:
       run: |
         # stop the build if there are Python syntax errors, undefined names, or unused imports
         flake8 . --count --exclude=test/core/random_image_ref.py --select=E9,F63,F7,F82,F401 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+        # exit-zero treats all errors as warnings. Cap at 120 chars per project convention.
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=120 --statistics
     - name: Test with pytest
       run: |
         pytest --durations=20 --cov=numbox --cov-report=term-missing

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ numbox — a toolbox of low-level utilities for working with numba. Provides typ
 - Venv: `python3.11 -m venv venv && venv/bin/pip install -e . flake8 pytest`
 - Install: `pip install -e .`
 - Test: `pytest`
-- Lint: `flake8` (max-line-length=127, max-complexity=10)
+- Lint: `flake8` (max-line-length=120, max-complexity=10)
 - Docs: `cd docs && make html` (Sphinx)
 - Python: >=3.10 (CI tests 3.10–3.14; local venv pinned to 3.11)
 - Key dependency: `numba>=0.60.0,<0.66.0` (matches `pyproject.toml`; use `numba==0.60.0` locally)

--- a/numbox/core/bindings/abi.py
+++ b/numbox/core/bindings/abi.py
@@ -98,3 +98,98 @@ def _struct_bytes(ty, fn_name):
         f"{fn_name}: expected a struct-shaped type (Record, Tuple, "
         f"UniTuple, or NamedTuple), got {ty!r}."
     )
+
+
+_EIGHTBYTE_CLASS_INTEGER = "integer"
+_EIGHTBYTE_CLASS_SSE = "sse"
+
+
+def _iter_struct_fields(ty, fn_name):
+    """Yield ``(offset, is_sse)`` for each scalar field of a struct-
+    shaped numba type. SSE = float/double; everything else (signed /
+    unsigned integers, pointers represented as ``intp``) is INTEGER.
+
+    For ``BaseTuple`` the fields are bit-packed sequentially with no
+    padding (mirrors ``_struct_bytes``'s ``sum(bitwidth)`` model). For
+    ``Record`` each ``_RecordField`` carries an explicit ``offset``
+    that already accounts for any C-layout padding gaps.
+    """
+    if isinstance(ty, nb_types.BaseTuple):
+        offset = 0
+        for ft in ty.types:
+            yield offset, isinstance(ft, nb_types.Float)
+            offset += ft.bitwidth // 8
+        return
+    if isinstance(ty, nb_types.Record):
+        for fld in ty.fields.values():
+            yield fld.offset, isinstance(fld.type, nb_types.Float)
+        return
+    raise TypingError(
+        f"{fn_name}: expected a struct-shaped type (Record, Tuple, "
+        f"UniTuple, or NamedTuple), got {ty!r}."
+    )
+
+
+def _classify_eightbytes(ty):
+    """Classify the two eightbytes of a 16-byte struct for SysV x86-64.
+
+    Returns ``(class_lo, class_hi)`` where each is
+    ``_EIGHTBYTE_CLASS_INTEGER`` (ints / pointers) or
+    ``_EIGHTBYTE_CLASS_SSE`` (float / double). SysV's per-eightbyte
+    rule: if any field in an eightbyte is SSE, the whole eightbyte is
+    SSE; otherwise INTEGER. (The full ABI has X87 / NO_CLASS / etc.;
+    our scope is fixed-size 16-byte aggregates of scalar integer-or-
+    float fields, which is what numbox bindings consume.)
+
+    Used by ``_call_lib_func`` together with
+    ``_is_canonical_int64_pair_layout`` to decide when a 16-byte by-
+    value arg needs repacking via memory bitcast to ``{i64, i64}`` to
+    work around llvmlite not modelling the eightbyte-packing rule (it
+    drops fields like the second ``i32`` in ``{i32, i32, i64}`` —
+    duckdb_interval).
+
+    Raises ``TypingError`` if ``ty`` is not a 16-byte struct-shaped
+    type — the caller should already have classified the size.
+    """
+    size = _struct_bytes(ty, "_classify_eightbytes")
+    if size != 16:
+        raise TypingError(
+            f"_classify_eightbytes: expected a 16-byte struct, got "
+            f"{size}-byte ({ty!r})."
+        )
+    cls_lo = _EIGHTBYTE_CLASS_INTEGER
+    cls_hi = _EIGHTBYTE_CLASS_INTEGER
+    for offset, is_sse in _iter_struct_fields(ty, "_classify_eightbytes"):
+        if not is_sse:
+            continue
+        if offset < 8:
+            cls_lo = _EIGHTBYTE_CLASS_SSE
+        else:
+            cls_hi = _EIGHTBYTE_CLASS_SSE
+    return cls_lo, cls_hi
+
+
+def _is_canonical_int64_pair_layout(ty):
+    """Whether ``ty`` already lowers to LLVM ``{i64, i64}`` — i.e. two
+    64-bit integer fields at offsets 0 and 8 with no gaps. When True,
+    the SysV-x86-64 small-struct INT/INT path needs no repack: llvmlite
+    already emits the canonical eightbyte-pair shape.
+    """
+    if isinstance(ty, nb_types.BaseTuple):
+        return len(ty.types) == 2 and all(
+            isinstance(f, nb_types.Integer) and f.bitwidth == 64
+            for f in ty.types
+        )
+    if isinstance(ty, nb_types.Record):
+        if ty.size != 16:
+            return False
+        flds = list(ty.fields.values())
+        if len(flds) != 2:
+            return False
+        if [f.offset for f in flds] != [0, 8]:
+            return False
+        return all(
+            isinstance(f.type, nb_types.Integer) and f.type.bitwidth == 64
+            for f in flds
+        )
+    return False

--- a/numbox/core/bindings/call.py
+++ b/numbox/core/bindings/call.py
@@ -8,8 +8,10 @@ from numba.extending import intrinsic
 
 from numbox.core.bindings.abi import (
     _CLASS_SCALAR, _CLASS_STRUCT_SMALL, _CLASS_STRUCT_LARGE,
+    _EIGHTBYTE_CLASS_INTEGER,
     _PLATFORM_AAPCS64, _PLATFORM_SYSV_X86_64, _PLATFORM_WIN_X64,
-    _classify, _current_platform, _is_windows_register_passable,
+    _classify, _classify_eightbytes, _current_platform,
+    _is_canonical_int64_pair_layout, _is_windows_register_passable,
     _struct_bytes,
 )
 from numbox.core.bindings.signatures import signatures
@@ -129,6 +131,9 @@ def _call_lib_func(typingctx, func_name_ty, args_ty=NoneType):
                 )
             )
             if pass_by_value:
+                if _needs_int_int_eightbyte_repack(arg_ty, plat):
+                    val, arg_ll_ty = _repack_to_i64_pair(
+                        builder, val, arg_ll_ty)
                 ll_arg_tys.append(arg_ll_ty)
                 ll_arg_vals.append(val)
                 continue
@@ -169,6 +174,48 @@ def _emit_byval_call(builder, arg, arg_ll_ty, ret_type, func_name):
     func_ty_ll = llir.FunctionType(ret_type, [arg_ll_ty.as_pointer()])
     func_p = get_or_insert_function(builder.module, func_ty_ll, func_name)
     return builder.call(func_p, [stack_p])
+
+
+def _needs_int_int_eightbyte_repack(arg_ty, plat):
+    """Whether a 16-byte by-value struct arg needs repack to ``{i64, i64}``
+    before the call on the host's ABI.
+
+    Only SysV x86-64 has the issue: llvmlite's small-struct lowering
+    drops fields when both eightbytes are pure-INTEGER but the LLVM
+    type isn't already the canonical ``{i64, i64}`` shape (e.g.
+    ``{i32, i32, i64}`` — the duckdb_interval layout — loses the
+    second ``i32``). AAPCS64 and Windows x64 are unaffected (their
+    by-value paths handle non-canonical 16B INT/INT aggregates
+    correctly via different ABI rules).
+    """
+    if plat != _PLATFORM_SYSV_X86_64:
+        return False
+    if _struct_bytes(arg_ty, "_call_lib_func") != 16:
+        return False
+    if _is_canonical_int64_pair_layout(arg_ty):
+        return False
+    return _classify_eightbytes(arg_ty) == (
+        _EIGHTBYTE_CLASS_INTEGER, _EIGHTBYTE_CLASS_INTEGER,
+    )
+
+
+def _repack_to_i64_pair(builder, val, orig_ll_ty):
+    """Repack a 16-byte struct value to ``{i64, i64}`` via memory bitcast.
+
+    Allocates an ``orig_ll_ty`` slot on the stack, stores ``val`` into
+    it, then loads the same bytes back as ``{i64, i64}``. Both
+    eightbytes must already be pure-INTEGER (caller checks via
+    ``_needs_int_int_eightbyte_repack``); the bitcast is a pure byte
+    reinterpretation, no zext/shift gymnastics required. Returns
+    ``(repacked_val, repacked_ll_ty)`` for the caller to substitute
+    into the call site. See: https://github.com/numba/llvmlite/issues/300#issuecomment-327235846
+    """
+    i64x2_ll_ty = llir.LiteralStructType(
+        [llir.IntType(64), llir.IntType(64)])
+    slot = builder.alloca(orig_ll_ty)
+    builder.store(val, slot)
+    slot_as_i64x2 = builder.bitcast(slot, i64x2_ll_ty.as_pointer())
+    return builder.load(slot_as_i64x2), i64x2_ll_ty
 
 
 @intrinsic(prefer_literal=True)

--- a/test/core/test_abi.py
+++ b/test/core/test_abi.py
@@ -7,9 +7,186 @@ def test_abi_imports():
 
     assert hasattr(abi, "_struct_bytes")
     assert hasattr(abi, "_classify")
+    assert hasattr(abi, "_classify_eightbytes")
+    assert hasattr(abi, "_is_canonical_int64_pair_layout")
+    assert hasattr(abi, "_EIGHTBYTE_CLASS_INTEGER")
+    assert hasattr(abi, "_EIGHTBYTE_CLASS_SSE")
     assert hasattr(abi, "_current_platform")
     assert hasattr(call, "_call_lib_func")
     assert hasattr(call, "_call_lib_func_byval")
+
+
+def test_classify_eightbytes_int_int_non_canonical():
+    """`Tuple([int32, int32, int64])` (the layout of duckdb_interval) has
+    two pure-INTEGER eightbytes. The lo eightbyte holds two i32 fields
+    (offsets 0, 4); the hi eightbyte holds one i64 (offset 8)."""
+    from numba.core import types
+    from numbox.core.bindings.abi import (
+        _EIGHTBYTE_CLASS_INTEGER, _classify_eightbytes,
+    )
+
+    ty = types.Tuple([types.int32, types.int32, types.int64])
+    assert _classify_eightbytes(ty) == (
+        _EIGHTBYTE_CLASS_INTEGER, _EIGHTBYTE_CLASS_INTEGER,
+    )
+
+
+def test_classify_eightbytes_int_int_canonical_pair():
+    """`UniTuple(int64, 2)` has the canonical `{i64, i64}` layout —
+    INT/INT eightbytes, no repack needed."""
+    from numba.core import types
+    from numbox.core.bindings.abi import (
+        _EIGHTBYTE_CLASS_INTEGER, _classify_eightbytes,
+    )
+
+    ty = types.UniTuple(types.int64, 2)
+    assert _classify_eightbytes(ty) == (
+        _EIGHTBYTE_CLASS_INTEGER, _EIGHTBYTE_CLASS_INTEGER,
+    )
+
+
+def test_classify_eightbytes_four_i32():
+    """`UniTuple(int32, 4)` has fields at offsets 0/4/8/12 — both
+    eightbytes are pure INTEGER, but the LLVM type isn't `{i64, i64}`."""
+    from numba.core import types
+    from numbox.core.bindings.abi import (
+        _EIGHTBYTE_CLASS_INTEGER, _classify_eightbytes,
+    )
+
+    ty = types.UniTuple(types.int32, 4)
+    assert _classify_eightbytes(ty) == (
+        _EIGHTBYTE_CLASS_INTEGER, _EIGHTBYTE_CLASS_INTEGER,
+    )
+
+
+def test_classify_eightbytes_sse_sse():
+    """`UniTuple(float64, 2)` has SSE eightbytes — lowered to XMM0/XMM1
+    on SysV x86-64. Repack to `{i64, i64}` would be wrong."""
+    from numba.core import types
+    from numbox.core.bindings.abi import (
+        _EIGHTBYTE_CLASS_SSE, _classify_eightbytes,
+    )
+
+    ty = types.UniTuple(types.float64, 2)
+    assert _classify_eightbytes(ty) == (
+        _EIGHTBYTE_CLASS_SSE, _EIGHTBYTE_CLASS_SSE,
+    )
+
+
+def test_classify_eightbytes_sse_int():
+    """`Tuple([float32, float32, int64])` has SSE in lo (two f32s),
+    INT in hi (one i64)."""
+    from numba.core import types
+    from numbox.core.bindings.abi import (
+        _EIGHTBYTE_CLASS_INTEGER, _EIGHTBYTE_CLASS_SSE,
+        _classify_eightbytes,
+    )
+
+    ty = types.Tuple([types.float32, types.float32, types.int64])
+    assert _classify_eightbytes(ty) == (
+        _EIGHTBYTE_CLASS_SSE, _EIGHTBYTE_CLASS_INTEGER,
+    )
+
+
+def test_classify_eightbytes_mixed_lo_eightbyte_is_sse():
+    """SysV rule: if any field in an eightbyte is SSE, the whole
+    eightbyte is SSE. `Tuple([int32, float32, int64])` has int+float
+    in lo → lo eightbyte is SSE."""
+    from numba.core import types
+    from numbox.core.bindings.abi import (
+        _EIGHTBYTE_CLASS_INTEGER, _EIGHTBYTE_CLASS_SSE,
+        _classify_eightbytes,
+    )
+
+    ty = types.Tuple([types.int32, types.float32, types.int64])
+    assert _classify_eightbytes(ty) == (
+        _EIGHTBYTE_CLASS_SSE, _EIGHTBYTE_CLASS_INTEGER,
+    )
+
+
+def test_classify_eightbytes_record_with_padding():
+    """`Record.make_c_struct([(a, int32), (b, int64)])` is 16B with a
+    4-byte gap (i32@0, pad, i64@8). Both eightbytes are pure INTEGER."""
+    from numba.core import types
+    from numbox.core.bindings.abi import (
+        _EIGHTBYTE_CLASS_INTEGER, _classify_eightbytes,
+    )
+
+    ty = types.Record.make_c_struct([("a", types.int32), ("b", types.int64)])
+    assert _classify_eightbytes(ty) == (
+        _EIGHTBYTE_CLASS_INTEGER, _EIGHTBYTE_CLASS_INTEGER,
+    )
+
+
+def test_classify_eightbytes_rejects_non_16b():
+    """The classifier is only meaningful for 16-byte aggregates (the size
+    where SysV may pass two eightbytes by-value in registers). Non-16B
+    inputs raise a clean `TypingError`."""
+    from numba.core import types
+    from numba.core.errors import TypingError
+    from numbox.core.bindings.abi import _classify_eightbytes
+
+    with pytest.raises(TypingError, match="16-byte"):
+        _classify_eightbytes(types.UniTuple(types.int64, 3))  # 24B
+    with pytest.raises(TypingError, match="16-byte"):
+        _classify_eightbytes(types.UniTuple(types.int32, 2))  # 8B
+
+
+def test_classify_eightbytes_rejects_non_struct():
+    """Scalar (non-struct) types raise a clean `TypingError`."""
+    from numba.core import types
+    from numba.core.errors import TypingError
+    from numbox.core.bindings.abi import _classify_eightbytes
+
+    with pytest.raises(TypingError, match="struct-shaped"):
+        _classify_eightbytes(types.int64)
+
+
+def test_is_canonical_int64_pair_layout_true_cases():
+    """`UniTuple(int64, 2)`, `Tuple([int64, int64])`, and `Tuple([uint64,
+    intp])` all lower to LLVM `{i64, i64}` — no repack needed."""
+    from numba.core import types
+    from numbox.core.bindings.abi import _is_canonical_int64_pair_layout
+
+    assert _is_canonical_int64_pair_layout(types.UniTuple(types.int64, 2))
+    assert _is_canonical_int64_pair_layout(
+        types.Tuple([types.int64, types.int64]))
+    assert _is_canonical_int64_pair_layout(
+        types.Tuple([types.uint64, types.intp]))
+
+
+def test_is_canonical_int64_pair_layout_false_cases():
+    """Anything not exactly two 64-bit integer fields at offsets 0/8 is
+    non-canonical — including `{i32, i32, i64}` (the duckdb_interval
+    layout that needs repack), `{i32 × 4}`, `{f64, f64}`, and 24-byte
+    aggregates."""
+    from numba.core import types
+    from numbox.core.bindings.abi import _is_canonical_int64_pair_layout
+
+    assert not _is_canonical_int64_pair_layout(
+        types.Tuple([types.int32, types.int32, types.int64]))
+    assert not _is_canonical_int64_pair_layout(
+        types.UniTuple(types.int32, 4))
+    assert not _is_canonical_int64_pair_layout(
+        types.UniTuple(types.float64, 2))
+    assert not _is_canonical_int64_pair_layout(
+        types.UniTuple(types.int64, 3))
+
+
+def test_is_canonical_int64_pair_layout_record():
+    """`Record.make_c_struct([(a, int64), (b, int64)])` lowers to
+    `{i64, i64}` — canonical. With smaller fields the LLVM type is
+    different and the helper returns False."""
+    from numba.core import types
+    from numbox.core.bindings.abi import _is_canonical_int64_pair_layout
+
+    rec_canonical = types.Record.make_c_struct([
+        ("a", types.int64), ("b", types.int64)])
+    assert _is_canonical_int64_pair_layout(rec_canonical)
+
+    rec_non_canonical = types.Record.make_c_struct([
+        ("a", types.int32), ("b", types.int64)])
+    assert not _is_canonical_int64_pair_layout(rec_non_canonical)
 
 
 def test_struct_bytes_supports_all_struct_types():
@@ -317,6 +494,148 @@ def test_call_lib_func_undefined_signature_raises():
     with pytest.raises((ValueError, TypingError), match="Undefined signature"):
         run()
     del keepalive
+
+
+@pytest.mark.skipif(
+    _platform_str() != "sysv_x86_64",
+    reason="INT/INT eightbyte repack only kicks in on SysV x86-64",
+)
+def test_call_lib_func_int_int_eightbyte_repack_round_trip(patch_signature):
+    """Round-trip a 16-byte ``{i32, i32, i64}`` struct (the
+    ``duckdb_interval`` shape) through ``_call_lib_func`` on SysV
+    x86-64. Without the eightbyte repack, llvmlite drops the second
+    ``i32`` field when lowering the by-value call — only the first
+    ``i32`` and the trailing ``i64`` survive. After the repack to
+    canonical ``{i64, i64}``, all three fields arrive intact.
+    """
+    import ctypes
+    import llvmlite.binding as ll
+    from numba import njit, types as nb_types
+    from numbox.core.bindings.call import _call_lib_func
+
+    class _IntervalC(ctypes.Structure):
+        _fields_ = [
+            ("a", ctypes.c_int32),
+            ("b", ctypes.c_int32),
+            ("c", ctypes.c_int64),
+        ]
+
+    received = {}
+
+    @ctypes.CFUNCTYPE(ctypes.c_int64, _IntervalC)
+    def echo(s):
+        received["a"] = s.a
+        received["b"] = s.b
+        received["c"] = s.c
+        return s.a + s.b + s.c
+
+    name = "numbox_test_int_int_eightbyte_round_trip"
+    addr = ctypes.cast(echo, ctypes.c_void_p).value
+    ll.add_symbol(name, addr)
+    arg_struct = nb_types.Tuple(
+        [nb_types.int32, nb_types.int32, nb_types.int64])
+    patch_signature(name, nb_types.int64(arg_struct))
+
+    @njit(nb_types.int64(nb_types.int32, nb_types.int32, nb_types.int64))
+    def run(a, b, c):
+        return _call_lib_func(name, ((a, b, c),))
+
+    result = run(7, 11, 1_000_000)
+
+    assert received == {"a": 7, "b": 11, "c": 1_000_000}, (
+        f"second i32 field was dropped by SysV by-value lowering: {received}"
+    )
+    assert result == 7 + 11 + 1_000_000
+    del echo  # keepalive
+
+
+@pytest.mark.skipif(
+    _platform_str() != "sysv_x86_64",
+    reason="repack-skip rules are SysV x86-64 specific",
+)
+def test_call_lib_func_sse_eightbyte_arg_not_repacked(patch_signature):
+    """A 16B ``{double, double}`` arg has SSE eightbytes — passed in
+    XMM0/XMM1 on SysV x86-64. It must NOT be repacked to ``{i64, i64}``
+    (which would force GP registers RDI/RSI), so the LLVM declare line
+    keeps the ``double, double`` shape rather than ``i64, i64``.
+    """
+    from numba import njit, types as nb_types
+    from numbox.core.bindings.call import _call_lib_func
+
+    name = "numbox_test_sse_pair_no_repack"
+    keepalive = _register_test_symbol(name)
+    sse_struct = nb_types.UniTuple(nb_types.float64, 2)
+    patch_signature(name, nb_types.int32(sse_struct))
+
+    @njit
+    def run(x):
+        return _call_lib_func(name, (x,))
+
+    run.compile((sse_struct,))
+    ir_text = list(run.inspect_llvm().values())[0]
+    declare_line = next(
+        (line for line in ir_text.splitlines()
+         if "declare" in line and name in line),
+        None,
+    )
+    assert declare_line is not None, (
+        f"could not find declare line for {name} in IR:\n{ir_text}"
+    )
+    assert "double" in declare_line, (
+        f"expected SSE pair to keep its double-typed arg in declare "
+        f"(numba lowers UniTuple(float64, 2) to '[2 x double]'); "
+        f"got:\n{declare_line}"
+    )
+    assert "i64" not in declare_line, (
+        f"SSE pair must not be repacked to a 64-bit-integer-typed arg "
+        f"(would force GP registers instead of XMM); declare line "
+        f"was:\n{declare_line}"
+    )
+    del keepalive
+
+
+@pytest.mark.skipif(
+    _platform_str() != "sysv_x86_64",
+    reason="canonical-skip is SysV x86-64 specific",
+)
+def test_call_lib_func_canonical_int64_pair_round_trip(patch_signature):
+    """A canonical 16B ``UniTuple(int64, 2)`` already lowers to
+    ``{i64, i64}`` and round-trips correctly through ``_call_lib_func``
+    without any repack — regression guard that the canonical-skip in
+    ``_needs_int_int_eightbyte_repack`` doesn't break the path numbduck
+    will use for ``duckdb_hugeint`` and ``duckdb_uhugeint``.
+    """
+    import ctypes
+    import llvmlite.binding as ll
+    from numba import njit, types as nb_types
+    from numbox.core.bindings.call import _call_lib_func
+
+    class _PairC(ctypes.Structure):
+        _fields_ = [("lo", ctypes.c_int64), ("hi", ctypes.c_int64)]
+
+    received = {}
+
+    @ctypes.CFUNCTYPE(ctypes.c_int64, _PairC)
+    def echo(s):
+        received["lo"] = s.lo
+        received["hi"] = s.hi
+        return s.hi
+
+    name = "numbox_test_canonical_i64_pair_round_trip"
+    addr = ctypes.cast(echo, ctypes.c_void_p).value
+    ll.add_symbol(name, addr)
+    arg_struct = nb_types.UniTuple(nb_types.int64, 2)
+    patch_signature(name, nb_types.int64(arg_struct))
+
+    @njit(nb_types.int64(nb_types.int64, nb_types.int64))
+    def run(lo, hi):
+        return _call_lib_func(name, ((lo, hi),))
+
+    result = run(0x0123456789ABCDEF, -42)
+
+    assert received == {"lo": 0x0123456789ABCDEF, "hi": -42}
+    assert result == -42
+    del echo  # keepalive
 
 
 def test_call_lib_func_byval_undefined_signature_raises():

--- a/test/core/test_abi.py
+++ b/test/core/test_abi.py
@@ -496,17 +496,22 @@ def test_call_lib_func_undefined_signature_raises():
     del keepalive
 
 
-@pytest.mark.skipif(
-    _platform_str() != "sysv_x86_64",
-    reason="INT/INT eightbyte repack only kicks in on SysV x86-64",
-)
-def test_call_lib_func_int_int_eightbyte_repack_round_trip(patch_signature):
+def test_call_lib_func_int_int_struct_arg_round_trip(patch_signature):
     """Round-trip a 16-byte ``{i32, i32, i64}`` struct (the
-    ``duckdb_interval`` shape) through ``_call_lib_func`` on SysV
-    x86-64. Without the eightbyte repack, llvmlite drops the second
-    ``i32`` field when lowering the by-value call — only the first
-    ``i32`` and the trailing ``i64`` survive. After the repack to
-    canonical ``{i64, i64}``, all three fields arrive intact.
+    ``duckdb_interval`` shape) through ``_call_lib_func`` on every
+    supported ABI.
+
+    On SysV x86-64 the by-value path requires the new INT/INT
+    eightbyte repack — without it, llvmlite drops fields. On Windows
+    x64, 16B falls outside the ``{1, 2, 4, 8}`` register-passable
+    set so the call goes via alloca + pointer-pass. On AAPCS64 the
+    by-value path passes the struct in ``X0`` / ``X1`` directly.
+
+    If this test fails on AAPCS64 (ubuntu-arm or macOS-ARM64),
+    llvmlite has the same eightbyte-packing gap there too — extend
+    ``_needs_int_int_eightbyte_repack`` in
+    [`call.py`](../../numbox/core/bindings/call.py) to include
+    ``_PLATFORM_AAPCS64``.
     """
     import ctypes
     import llvmlite.binding as ll
@@ -594,16 +599,16 @@ def test_call_lib_func_sse_eightbyte_arg_not_repacked(patch_signature):
     del keepalive
 
 
-@pytest.mark.skipif(
-    _platform_str() != "sysv_x86_64",
-    reason="canonical-skip is SysV x86-64 specific",
-)
 def test_call_lib_func_canonical_int64_pair_round_trip(patch_signature):
-    """A canonical 16B ``UniTuple(int64, 2)`` already lowers to
-    ``{i64, i64}`` and round-trips correctly through ``_call_lib_func``
-    without any repack — regression guard that the canonical-skip in
-    ``_needs_int_int_eightbyte_repack`` doesn't break the path numbduck
-    will use for ``duckdb_hugeint`` and ``duckdb_uhugeint``.
+    """A canonical 16B ``UniTuple(int64, 2)`` round-trips correctly
+    through ``_call_lib_func`` on every supported ABI — regression
+    guard that the canonical-skip in
+    ``_needs_int_int_eightbyte_repack`` doesn't break the by-value
+    path on SysV x86-64 / AAPCS64 or the alloca + pointer-pass path
+    on Windows x64. This is the arg-side complement to the existing
+    ``test_call_lib_func_lldiv_via_unified`` (which exercises the
+    return side of canonical 16B). Numbduck's ``duckdb_hugeint`` and
+    ``duckdb_uhugeint`` bind wrappers will rely on this path.
     """
     import ctypes
     import llvmlite.binding as ll


### PR DESCRIPTION
## Summary

- Detects 16B by-value struct args on SysV x86-64 where both eightbytes are pure-INTEGER but the LLVM type isn't already `{i64, i64}` (e.g. `{i32, i32, i64}` — `duckdb_interval`), and repacks via memory bitcast before the call. Skip cases: canonical `{i64, i64}`, SSE-bearing eightbytes, non-SysV platforms.
- Lifts numbduck's local [`_build_packed_interval`](https://github.com/Goykhman/numbduck/blob/main/numbduck/ducklib.py#L84) workaround into numbox where the rest of the SysV ABI handling lives. Once a numbox release ships, numbduck's interval / hugeint / uhugeint bind wrappers become mechanical migrations to [`_call_lib_func`](numbox/core/bindings/call.py).
- Also caps lenient flake8 line length at 120 (was 127) per project convention.

## Background

Without the repack, `_call_lib_func` on a `{i32, i32, i64}` arg drops fields. The new round-trip test demonstrates: passing `(7, 11, 1_000_000)` arrives at the C side as `{a: 7, b: 0, c: 11}` — `b` is junk, `c` got the `i32` that was supposed to be `b`, and the trailing `i64` is lost entirely. After the fix, all three fields arrive intact.

The eightbyte-packing rule is in the [SysV x86-64 psABI § 3.2.3](https://refspecs.linuxbase.org/elf/x86_64-abi-0.99.pdf); llvmlite's gap is tracked at [numba/llvmlite#300](https://github.com/numba/llvmlite/issues/300#issuecomment-327235846).

## New helpers

In [`abi.py`](numbox/core/bindings/abi.py): `_classify_eightbytes(ty) -> (cls_lo, cls_hi)`, `_is_canonical_int64_pair_layout(ty) -> bool`, and `_EIGHTBYTE_CLASS_INTEGER` / `_EIGHTBYTE_CLASS_SSE` constants. Both helpers handle `Tuple` / `UniTuple` / `NamedTuple` / `Record` (with explicit field offsets, including padding gaps).

In [`call.py`](numbox/core/bindings/call.py): `_needs_int_int_eightbyte_repack(arg_ty, plat)` (decision predicate) and `_repack_to_i64_pair(builder, val, orig_ll_ty)` (IR emitter — alloca + store + bitcast + load). One `if` wired into the small-struct by-value arg path inside `_call_lib_func`'s codegen.

## Test scope

14 new tests in [`test/core/test_abi.py`](test/core/test_abi.py): 11 classifier unit tests (INT/INT canonical and non-canonical, SSE/SSE, mixed eightbyte, Record with padding, size and shape validation) plus three SysV-only integration tests (the round-trip RED-driver, the SSE no-repack IR check, the canonical-pair regression guard).
