### PR TITLE
Sync upstream/main: PR #11 (SysV/AAPCS64 INT/INT eightbyte repack + sret >16B return) + 0.5.11

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License (with Citation Clause)
 
-Copyright (c) 2026 Mikhail Goykhman
+Copyright (c) 2026 NumbOx GitHub Repository Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Documentation is available at [numbox](https://goykhman.github.io/numbox).
 - **Node**: A lightweight JIT-compatible graph node with type-erased dependencies in a uniform dynamically-sized vector (numba List). 
 - **Proxy**: Create a proxy for a decorated function with specified signatures, enabling efficient JIT compilation and caching.
 - **Variable**: Pure Python framework of a graph calculation. JIT-compiled dispatchers can be invoked by it.  
+- **Vector**: Dynamically sized JIT-friendly container of scalars backed by numpy array.
 - **Work**: JIT-compatible unit of calculation work with dependencies, inner states, and custom calculation.
 
 ## Installation

--- a/numbox/core/bindings/abi.py
+++ b/numbox/core/bindings/abi.py
@@ -98,3 +98,115 @@ def _struct_bytes(ty, fn_name):
         f"{fn_name}: expected a struct-shaped type (Record, Tuple, "
         f"UniTuple, or NamedTuple), got {ty!r}."
     )
+
+
+_EIGHTBYTE_CLASS_INTEGER = "integer"
+_EIGHTBYTE_CLASS_SSE = "sse"
+
+
+def _iter_struct_fields(ty, fn_name):
+    """Yield ``(offset, size, is_float)`` for each scalar field of a
+    struct-shaped numba type. ``is_float`` is true for ``Float`` types
+    (float / double); the SysV ABI's "field is float ⇒ eightbyte is
+    SSE" mapping is the consumer's responsibility (see
+    ``_classify_eightbytes``). Size is needed to detect fields that
+    span the 8-byte eightbyte boundary.
+
+    For ``BaseTuple`` the fields are bit-packed sequentially with no
+    padding (mirrors ``_struct_bytes``'s ``sum(bitwidth)`` model). For
+    ``Record`` each ``_RecordField`` carries an explicit ``offset``
+    that already accounts for any C-layout padding gaps.
+    """
+    if isinstance(ty, nb_types.BaseTuple):
+        offset = 0
+        for ft in ty.types:
+            size = ft.bitwidth // 8
+            yield offset, size, isinstance(ft, nb_types.Float)
+            offset += size
+        return
+    if isinstance(ty, nb_types.Record):
+        for fld in ty.fields.values():
+            yield (
+                fld.offset,
+                fld.type.bitwidth // 8,
+                isinstance(fld.type, nb_types.Float),
+            )
+        return
+    raise TypingError(
+        f"{fn_name}: expected a struct-shaped type (Record, Tuple, "
+        f"UniTuple, or NamedTuple), got {ty!r}."
+    )
+
+
+def _classify_eightbytes(ty):
+    """Classify the two eightbytes of a 16-byte struct for SysV x86-64.
+
+    Returns ``(class_lo, class_hi)`` where each is
+    ``_EIGHTBYTE_CLASS_INTEGER`` (ints / pointers) or
+    ``_EIGHTBYTE_CLASS_SSE`` (float / double). SysV's per-eightbyte
+    rule: if any field in an eightbyte is SSE, the whole eightbyte is
+    SSE; otherwise INTEGER. (The full ABI has X87 / NO_CLASS / etc.;
+    our scope is fixed-size 16-byte aggregates of scalar integer-or-
+    float fields, which is what numbox bindings consume.)
+
+    Used by ``_call_lib_func`` together with
+    ``_is_canonical_int64_pair_layout`` to decide when a 16-byte by-
+    value arg needs repacking via memory bitcast to ``{i64, i64}`` to
+    work around llvmlite not modelling the eightbyte-packing rule (it
+    drops fields like the second ``i32`` in ``{i32, i32, i64}`` —
+    duckdb_interval).
+
+    Raises ``TypingError`` if ``ty`` is not a 16-byte struct-shaped
+    type — the caller should already have classified the size.
+    """
+    size = _struct_bytes(ty, "_classify_eightbytes")
+    if size != 16:
+        raise TypingError(
+            f"_classify_eightbytes: expected a 16-byte struct, got "
+            f"{size}-byte ({ty!r})."
+        )
+    cls_lo = _EIGHTBYTE_CLASS_INTEGER
+    cls_hi = _EIGHTBYTE_CLASS_INTEGER
+    for offset, size, is_float in _iter_struct_fields(
+            ty, "_classify_eightbytes"):
+        if not is_float:
+            continue
+        # SysV per-eightbyte rule: if any SSE field touches an
+        # eightbyte (even partially via a boundary span), the whole
+        # eightbyte is SSE. So a field at offsets [4, 12) makes BOTH
+        # eightbytes SSE -- not just one or the other.
+        if offset < 8:
+            cls_lo = _EIGHTBYTE_CLASS_SSE
+        if offset + size > 8:
+            cls_hi = _EIGHTBYTE_CLASS_SSE
+    return cls_lo, cls_hi
+
+
+def _is_canonical_int64_pair_layout(ty):
+    """Whether ``ty`` already lowers to LLVM ``{i64, i64}`` — i.e. two
+    64-bit integer fields at offsets 0 and 8 with no gaps. When True,
+    the SysV-x86-64 small-struct INT/INT path needs no repack: llvmlite
+    already emits the canonical eightbyte-pair shape.
+    """
+    if isinstance(ty, nb_types.BaseTuple):
+        return len(ty.types) == 2 and all(
+            isinstance(f, nb_types.Integer) and f.bitwidth == 64
+            for f in ty.types
+        )
+    if isinstance(ty, nb_types.Record):
+        if ty.size != 16:
+            return False
+        # Sort by offset so a Record built with fields declared in
+        # non-offset order (e.g. via numpy structured dtype with
+        # explicit `offsets`) is still recognized as canonical when
+        # the offsets sort to [0, 8].
+        flds = sorted(ty.fields.values(), key=lambda f: f.offset)
+        if len(flds) != 2:
+            return False
+        if [f.offset for f in flds] != [0, 8]:
+            return False
+        return all(
+            isinstance(f.type, nb_types.Integer) and f.type.bitwidth == 64
+            for f in flds
+        )
+    return False

--- a/numbox/core/bindings/abi.py
+++ b/numbox/core/bindings/abi.py
@@ -139,15 +139,18 @@ def _iter_struct_fields(ty, fn_name):
 
 
 def _classify_eightbytes(ty):
-    """Classify the two eightbytes of a 16-byte struct for SysV x86-64.
+    """Classify the two eightbytes of a 16-byte struct.
 
     Returns ``(class_lo, class_hi)`` where each is
     ``_EIGHTBYTE_CLASS_INTEGER`` (ints / pointers) or
-    ``_EIGHTBYTE_CLASS_SSE`` (float / double). SysV's per-eightbyte
-    rule: if any field in an eightbyte is SSE, the whole eightbyte is
-    SSE; otherwise INTEGER. (The full ABI has X87 / NO_CLASS / etc.;
-    our scope is fixed-size 16-byte aggregates of scalar integer-or-
-    float fields, which is what numbox bindings consume.)
+    ``_EIGHTBYTE_CLASS_SSE`` (float / double). The SysV-flavoured
+    per-eightbyte rule applies: if any field in an eightbyte is SSE
+    (float / double), the whole eightbyte is SSE; otherwise INTEGER.
+    The class names are SysV-flavoured but the helper drives the
+    repack path on both SysV x86-64 and AAPCS64. (The full SysV ABI
+    has X87 / NO_CLASS / etc.; our scope is fixed-size 16-byte
+    aggregates of scalar integer-or-float fields, which is what
+    numbox bindings consume.)
 
     Used by ``_call_lib_func`` together with
     ``_is_canonical_int64_pair_layout`` to decide when a 16-byte by-

--- a/numbox/core/bindings/call.py
+++ b/numbox/core/bindings/call.py
@@ -3,7 +3,7 @@ from llvmlite import ir as llir
 
 from numba.core.cgutils import get_or_insert_function
 from numba.core.errors import TypingError
-from numba.core.types import BaseTuple, NoneType
+from numba.core.types import BaseTuple, NoneType, Record
 from numba.extending import intrinsic
 
 from numbox.core.bindings.abi import (
@@ -50,8 +50,16 @@ def _call_lib_func(typingctx, func_name_ty, args_ty=NoneType):
       eightbyte repack on SysV / AAPCS64: the LLVM call is declared
       to return ``{i64, i64}`` and the result is unpacked back to
       the original LLVM type via memory bitcast.
-    - **>16-byte struct returns** -- raise ``TypingError``. No consumer
-      currently needs this; add it when one does.
+    - **>16-byte struct returns** -- ``sret`` (caller-allocated hidden
+      first arg, void return) on every platform. SysV x86-64 / AAPCS64
+      / Windows x64 all use indirect-result-location for this size
+      class; the codegen path is shared with the Windows ``<=16-byte``
+      non-register-passable case. ``Record`` returns are explicitly
+      rejected (``TypingError``): numba's ``RecordModel`` represents
+      values as raw pointers, so a stack-alloca sret slot would dangle
+      after the ``@njit`` function returns; safe support needs an NRT-
+      allocated buffer + integration with numba's record-ownership
+      model. Add when a consumer needs it.
 
     For C signatures of form ``func(T*)`` (pointer to struct) rather
     than ``func(T)`` lowered to a byval pointer by the ABI, use the
@@ -74,10 +82,15 @@ def _call_lib_func(typingctx, func_name_ty, args_ty=NoneType):
 
     ret_ty = func_sig.return_type
     ret_class = _classify(ret_ty)
-    if ret_class == _CLASS_STRUCT_LARGE:
+    if ret_class == _CLASS_STRUCT_LARGE and isinstance(ret_ty, Record):
         raise TypingError(
-            f"_call_lib_func: return struct >16 bytes is unsupported "
-            f"({func_name})"
+            f"_call_lib_func: Record returns >16 bytes are not yet "
+            f"supported ({func_name}). Numba's RecordModel represents "
+            f"values as raw pointers, so the natural stack-alloca sret "
+            f"slot would dangle after the @njit function returns. Safe "
+            f"support needs an NRT-allocated buffer hooked into numba's "
+            f"record-ownership model. Use a Tuple/UniTuple return shape "
+            f"instead, or open an issue if you need Record."
         )
 
     if args_ty == NoneType:
@@ -92,9 +105,13 @@ def _call_lib_func(typingctx, func_name_ty, args_ty=NoneType):
 
     plat = _current_platform()
     use_sret = (
-        ret_class == _CLASS_STRUCT_SMALL
-        and plat == _PLATFORM_WIN_X64
-        and not _is_windows_register_passable(_struct_bytes(ret_ty, "_call_lib_func"))
+        ret_class == _CLASS_STRUCT_LARGE
+        or (
+            ret_class == _CLASS_STRUCT_SMALL
+            and plat == _PLATFORM_WIN_X64
+            and not _is_windows_register_passable(
+                _struct_bytes(ret_ty, "_call_lib_func"))
+        )
     )
     needs_ret_repack = (
         ret_class == _CLASS_STRUCT_SMALL

--- a/numbox/core/bindings/call.py
+++ b/numbox/core/bindings/call.py
@@ -8,8 +8,10 @@ from numba.extending import intrinsic
 
 from numbox.core.bindings.abi import (
     _CLASS_SCALAR, _CLASS_STRUCT_SMALL, _CLASS_STRUCT_LARGE,
+    _EIGHTBYTE_CLASS_INTEGER,
     _PLATFORM_AAPCS64, _PLATFORM_SYSV_X86_64, _PLATFORM_WIN_X64,
-    _classify, _current_platform, _is_windows_register_passable,
+    _classify, _classify_eightbytes, _current_platform,
+    _is_canonical_int64_pair_layout, _is_windows_register_passable,
     _struct_bytes,
 )
 from numbox.core.bindings.signatures import signatures
@@ -29,7 +31,12 @@ def _call_lib_func(typingctx, func_name_ty, args_ty=NoneType):
       (LLVM's frontend lowers to register passing); on Windows x64,
       sizes 1/2/4/8 are passed by value in registers (per the Windows
       x64 ABI) and other sizes go by pointer (alloca + store + pass-
-      pointer).
+      pointer). On SysV x86-64 and AAPCS64, 16-byte aggregates whose
+      eightbytes are pure-INTEGER but whose LLVM type isn't already
+      ``{i64, i64}`` (e.g. ``{i32, i32, i64}`` -- duckdb_interval) are
+      repacked via memory bitcast before the call -- working around
+      llvmlite not modelling the eightbyte-packing rule, which
+      otherwise drops fields.
     - **>16-byte struct args** -- by pointer on every platform; on SysV
       x86-64 the ``byval`` attribute is added to the LLVM arg and the
       enclosing function gets ``optnone`` + ``noinline`` so the LLVM
@@ -39,7 +46,10 @@ def _call_lib_func(typingctx, func_name_ty, args_ty=NoneType):
     - **<=16-byte struct returns** -- direct on SysV x86-64 and AAPCS64;
       on Windows x64, sizes 1/2/4/8 return in RAX (direct) and other
       sizes use ``sret`` (caller-allocated hidden first arg, void
-      return).
+      return). 16-byte non-canonical INT/INT returns get the same
+      eightbyte repack on SysV / AAPCS64: the LLVM call is declared
+      to return ``{i64, i64}`` and the result is unpacked back to
+      the original LLVM type via memory bitcast.
     - **>16-byte struct returns** -- raise ``TypingError``. No consumer
       currently needs this; add it when one does.
 
@@ -86,6 +96,11 @@ def _call_lib_func(typingctx, func_name_ty, args_ty=NoneType):
         and plat == _PLATFORM_WIN_X64
         and not _is_windows_register_passable(_struct_bytes(ret_ty, "_call_lib_func"))
     )
+    needs_ret_repack = (
+        ret_class == _CLASS_STRUCT_SMALL
+        and not use_sret
+        and _needs_int_int_eightbyte_repack(ret_ty, plat)
+    )
 
     def codegen(context, builder, signature, arguments):
         if args_ty == NoneType:
@@ -129,6 +144,9 @@ def _call_lib_func(typingctx, func_name_ty, args_ty=NoneType):
                 )
             )
             if pass_by_value:
+                if _needs_int_int_eightbyte_repack(arg_ty, plat):
+                    val, arg_ll_ty = _repack_to_i64_pair(
+                        builder, val, arg_ll_ty)
                 ll_arg_tys.append(arg_ll_ty)
                 ll_arg_vals.append(val)
                 continue
@@ -141,6 +159,10 @@ def _call_lib_func(typingctx, func_name_ty, args_ty=NoneType):
 
         if use_sret:
             func_ll_ty = llir.FunctionType(llir.VoidType(), ll_arg_tys)
+        elif needs_ret_repack:
+            i64x2_ll_ty = llir.LiteralStructType(
+                [llir.IntType(64), llir.IntType(64)])
+            func_ll_ty = llir.FunctionType(i64x2_ll_ty, ll_arg_tys)
         else:
             func_ll_ty = llir.FunctionType(ret_ll_ty, ll_arg_tys)
         func_p = get_or_insert_function(builder.module, func_ll_ty, func_name)
@@ -156,7 +178,10 @@ def _call_lib_func(typingctx, func_name_ty, args_ty=NoneType):
         if use_sret:
             builder.call(func_p, ll_arg_vals)
             return builder.load(sret_ptr)
-        return builder.call(func_p, ll_arg_vals)
+        result = builder.call(func_p, ll_arg_vals)
+        if needs_ret_repack:
+            return _repack_from_i64_pair(builder, result, ret_ll_ty)
+        return result
 
     sig = ret_ty(func_name_ty, args_ty)
     return sig, codegen
@@ -169,6 +194,74 @@ def _emit_byval_call(builder, arg, arg_ll_ty, ret_type, func_name):
     func_ty_ll = llir.FunctionType(ret_type, [arg_ll_ty.as_pointer()])
     func_p = get_or_insert_function(builder.module, func_ty_ll, func_name)
     return builder.call(func_p, [stack_p])
+
+
+def _needs_int_int_eightbyte_repack(ty, plat):
+    """Whether a 16-byte by-value struct (arg or return) needs repack
+    to ``{i64, i64}`` before the call on the host's ABI.
+
+    Both SysV x86-64 and AAPCS64 are affected: llvmlite's small-struct
+    register lowering drops fields when both eightbytes are pure-
+    INTEGER but the LLVM type isn't already the canonical
+    ``{i64, i64}`` shape (e.g. ``{i32, i32, i64}`` — the duckdb_interval
+    layout — loses fields). Windows x64 is unaffected because 16-byte
+    aggregates fall outside the ``{1, 2, 4, 8}`` register-passable
+    set, so the call goes via alloca + pointer-pass and avoids the
+    register-coercion path entirely.
+    """
+    if plat not in (_PLATFORM_SYSV_X86_64, _PLATFORM_AAPCS64):
+        return False
+    if _struct_bytes(ty, "_call_lib_func") != 16:
+        return False
+    if _is_canonical_int64_pair_layout(ty):
+        return False
+    return _classify_eightbytes(ty) == (
+        _EIGHTBYTE_CLASS_INTEGER, _EIGHTBYTE_CLASS_INTEGER,
+    )
+
+
+def _repack_to_i64_pair(builder, val, orig_ll_ty):
+    """Repack a 16-byte struct value to ``{i64, i64}`` via memory bitcast.
+
+    Allocates a well-aligned ``{i64, i64}`` slot (8-byte alignment),
+    bitcasts it to ``orig_ll_ty*`` for the store, then loads the same
+    bytes back as ``{i64, i64}``. Storing into the bitcast pointer is
+    safe because the slot is over-aligned relative to ``orig_ll_ty``;
+    the subsequent ``{i64, i64}`` load is well-aligned, avoiding the
+    UB that an ``alloca(orig_ll_ty)`` slot (e.g. 4-byte aligned for
+    ``[4 x i32]``) would expose. Both eightbytes must already be
+    pure-INTEGER (caller checks via ``_needs_int_int_eightbyte_repack``);
+    the bitcast is a pure byte reinterpretation, no zext/shift
+    gymnastics required. Returns ``(repacked_val, repacked_ll_ty)``
+    for the caller to substitute into the call site.
+    See: https://github.com/numba/llvmlite/issues/300#issuecomment-327235846
+    """
+    i64x2_ll_ty = llir.LiteralStructType(
+        [llir.IntType(64), llir.IntType(64)])
+    slot = builder.alloca(i64x2_ll_ty)
+    slot_as_orig = builder.bitcast(slot, orig_ll_ty.as_pointer())
+    builder.store(val, slot_as_orig)
+    return builder.load(slot), i64x2_ll_ty
+
+
+def _repack_from_i64_pair(builder, i64_pair_val, target_ll_ty):
+    """Inverse of ``_repack_to_i64_pair``: convert a ``{i64, i64}``
+    return value back into ``target_ll_ty``.
+
+    Allocates a well-aligned ``{i64, i64}`` slot, stores the call
+    result, bitcasts the slot to ``target_ll_ty*``, and loads. Used
+    for the return-side eightbyte repack: when the C function returns
+    a 16-byte INT/INT struct that isn't canonical ``{i64, i64}``,
+    llvmlite has the same field-dropping issue on the return as on
+    the arg side -- so we declare the LLVM call returning
+    ``{i64, i64}`` and unpack it here.
+    """
+    i64x2_ll_ty = llir.LiteralStructType(
+        [llir.IntType(64), llir.IntType(64)])
+    slot = builder.alloca(i64x2_ll_ty)
+    builder.store(i64_pair_val, slot)
+    slot_as_target = builder.bitcast(slot, target_ll_ty.as_pointer())
+    return builder.load(slot_as_target)
 
 
 @intrinsic(prefer_literal=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ requires-python = ">=3.10"
 license = {file = "LICENSE"}
 keywords = ["llvmlite", "numba", "numpy"]
 authors = [
-  {name = "Mikhail Goykhman"}
+  {name = "NumbOx GitHub Repository Contributors"}
 ]
 readme = "README.md"
 

--- a/test/core/test_abi.py
+++ b/test/core/test_abi.py
@@ -7,9 +7,206 @@ def test_abi_imports():
 
     assert hasattr(abi, "_struct_bytes")
     assert hasattr(abi, "_classify")
+    assert hasattr(abi, "_classify_eightbytes")
+    assert hasattr(abi, "_is_canonical_int64_pair_layout")
+    assert hasattr(abi, "_EIGHTBYTE_CLASS_INTEGER")
+    assert hasattr(abi, "_EIGHTBYTE_CLASS_SSE")
     assert hasattr(abi, "_current_platform")
     assert hasattr(call, "_call_lib_func")
     assert hasattr(call, "_call_lib_func_byval")
+
+
+def test_classify_eightbytes_int_int_non_canonical():
+    """`Tuple([int32, int32, int64])` (the layout of duckdb_interval) has
+    two pure-INTEGER eightbytes. The lo eightbyte holds two i32 fields
+    (offsets 0, 4); the hi eightbyte holds one i64 (offset 8)."""
+    from numba.core import types
+    from numbox.core.bindings.abi import (
+        _EIGHTBYTE_CLASS_INTEGER, _classify_eightbytes,
+    )
+
+    ty = types.Tuple([types.int32, types.int32, types.int64])
+    assert _classify_eightbytes(ty) == (
+        _EIGHTBYTE_CLASS_INTEGER, _EIGHTBYTE_CLASS_INTEGER,
+    )
+
+
+def test_classify_eightbytes_int_int_canonical_pair():
+    """`UniTuple(int64, 2)` has the canonical `{i64, i64}` layout —
+    INT/INT eightbytes, no repack needed."""
+    from numba.core import types
+    from numbox.core.bindings.abi import (
+        _EIGHTBYTE_CLASS_INTEGER, _classify_eightbytes,
+    )
+
+    ty = types.UniTuple(types.int64, 2)
+    assert _classify_eightbytes(ty) == (
+        _EIGHTBYTE_CLASS_INTEGER, _EIGHTBYTE_CLASS_INTEGER,
+    )
+
+
+def test_classify_eightbytes_four_i32():
+    """`UniTuple(int32, 4)` has fields at offsets 0/4/8/12 — both
+    eightbytes are pure INTEGER, but the LLVM type isn't `{i64, i64}`."""
+    from numba.core import types
+    from numbox.core.bindings.abi import (
+        _EIGHTBYTE_CLASS_INTEGER, _classify_eightbytes,
+    )
+
+    ty = types.UniTuple(types.int32, 4)
+    assert _classify_eightbytes(ty) == (
+        _EIGHTBYTE_CLASS_INTEGER, _EIGHTBYTE_CLASS_INTEGER,
+    )
+
+
+def test_classify_eightbytes_sse_sse():
+    """`UniTuple(float64, 2)` has SSE eightbytes — lowered to XMM0/XMM1
+    on SysV x86-64. Repack to `{i64, i64}` would be wrong."""
+    from numba.core import types
+    from numbox.core.bindings.abi import (
+        _EIGHTBYTE_CLASS_SSE, _classify_eightbytes,
+    )
+
+    ty = types.UniTuple(types.float64, 2)
+    assert _classify_eightbytes(ty) == (
+        _EIGHTBYTE_CLASS_SSE, _EIGHTBYTE_CLASS_SSE,
+    )
+
+
+def test_classify_eightbytes_sse_int():
+    """`Tuple([float32, float32, int64])` has SSE in lo (two f32s),
+    INT in hi (one i64)."""
+    from numba.core import types
+    from numbox.core.bindings.abi import (
+        _EIGHTBYTE_CLASS_INTEGER, _EIGHTBYTE_CLASS_SSE,
+        _classify_eightbytes,
+    )
+
+    ty = types.Tuple([types.float32, types.float32, types.int64])
+    assert _classify_eightbytes(ty) == (
+        _EIGHTBYTE_CLASS_SSE, _EIGHTBYTE_CLASS_INTEGER,
+    )
+
+
+def test_classify_eightbytes_mixed_lo_eightbyte_is_sse():
+    """SysV rule: if any field in an eightbyte is SSE, the whole
+    eightbyte is SSE. `Tuple([int32, float32, int64])` has int+float
+    in lo → lo eightbyte is SSE."""
+    from numba.core import types
+    from numbox.core.bindings.abi import (
+        _EIGHTBYTE_CLASS_INTEGER, _EIGHTBYTE_CLASS_SSE,
+        _classify_eightbytes,
+    )
+
+    ty = types.Tuple([types.int32, types.float32, types.int64])
+    assert _classify_eightbytes(ty) == (
+        _EIGHTBYTE_CLASS_SSE, _EIGHTBYTE_CLASS_INTEGER,
+    )
+
+
+def test_classify_eightbytes_field_spans_eightbyte_boundary():
+    """An SSE field that straddles the 8-byte boundary makes BOTH
+    eightbytes SSE. ``Tuple([int32, float64, int32])`` has the
+    ``float64`` at offsets [4, 12) — touching both lo and hi
+    eightbytes — so the result is SSE/SSE per the SysV any-SSE-wins
+    rule, not SSE/INT. (Bytes 0–3 are i32 INTEGER but the SSE field
+    touching bytes 4–7 makes lo SSE; bytes 8–11 are part of the same
+    SSE field, making hi SSE; bytes 12–15 are i32 INTEGER but hi is
+    already SSE.)"""
+    from numba.core import types
+    from numbox.core.bindings.abi import (
+        _EIGHTBYTE_CLASS_SSE, _classify_eightbytes,
+    )
+
+    ty = types.Tuple([types.int32, types.float64, types.int32])
+    assert _classify_eightbytes(ty) == (
+        _EIGHTBYTE_CLASS_SSE, _EIGHTBYTE_CLASS_SSE,
+    )
+
+
+def test_classify_eightbytes_record_with_padding():
+    """`Record.make_c_struct([(a, int32), (b, int64)])` is 16B with a
+    4-byte gap (i32@0, pad, i64@8). Both eightbytes are pure INTEGER."""
+    from numba.core import types
+    from numbox.core.bindings.abi import (
+        _EIGHTBYTE_CLASS_INTEGER, _classify_eightbytes,
+    )
+
+    ty = types.Record.make_c_struct([("a", types.int32), ("b", types.int64)])
+    assert _classify_eightbytes(ty) == (
+        _EIGHTBYTE_CLASS_INTEGER, _EIGHTBYTE_CLASS_INTEGER,
+    )
+
+
+def test_classify_eightbytes_rejects_non_16b():
+    """The classifier is only meaningful for 16-byte aggregates (the size
+    where SysV may pass two eightbytes by-value in registers). Non-16B
+    inputs raise a clean `TypingError`."""
+    from numba.core import types
+    from numba.core.errors import TypingError
+    from numbox.core.bindings.abi import _classify_eightbytes
+
+    with pytest.raises(TypingError, match="16-byte"):
+        _classify_eightbytes(types.UniTuple(types.int64, 3))  # 24B
+    with pytest.raises(TypingError, match="16-byte"):
+        _classify_eightbytes(types.UniTuple(types.int32, 2))  # 8B
+
+
+def test_classify_eightbytes_rejects_non_struct():
+    """Scalar (non-struct) types raise a clean `TypingError`."""
+    from numba.core import types
+    from numba.core.errors import TypingError
+    from numbox.core.bindings.abi import _classify_eightbytes
+
+    with pytest.raises(TypingError, match="struct-shaped"):
+        _classify_eightbytes(types.int64)
+
+
+def test_is_canonical_int64_pair_layout_true_cases():
+    """`UniTuple(int64, 2)`, `Tuple([int64, int64])`, and `Tuple([uint64,
+    intp])` all lower to LLVM `{i64, i64}` — no repack needed."""
+    from numba.core import types
+    from numbox.core.bindings.abi import _is_canonical_int64_pair_layout
+
+    assert _is_canonical_int64_pair_layout(types.UniTuple(types.int64, 2))
+    assert _is_canonical_int64_pair_layout(
+        types.Tuple([types.int64, types.int64]))
+    assert _is_canonical_int64_pair_layout(
+        types.Tuple([types.uint64, types.intp]))
+
+
+def test_is_canonical_int64_pair_layout_false_cases():
+    """Anything not exactly two 64-bit integer fields at offsets 0/8 is
+    non-canonical — including `{i32, i32, i64}` (the duckdb_interval
+    layout that needs repack), `{i32 × 4}`, `{f64, f64}`, and 24-byte
+    aggregates."""
+    from numba.core import types
+    from numbox.core.bindings.abi import _is_canonical_int64_pair_layout
+
+    assert not _is_canonical_int64_pair_layout(
+        types.Tuple([types.int32, types.int32, types.int64]))
+    assert not _is_canonical_int64_pair_layout(
+        types.UniTuple(types.int32, 4))
+    assert not _is_canonical_int64_pair_layout(
+        types.UniTuple(types.float64, 2))
+    assert not _is_canonical_int64_pair_layout(
+        types.UniTuple(types.int64, 3))
+
+
+def test_is_canonical_int64_pair_layout_record():
+    """`Record.make_c_struct([(a, int64), (b, int64)])` lowers to
+    `{i64, i64}` — canonical. With smaller fields the LLVM type is
+    different and the helper returns False."""
+    from numba.core import types
+    from numbox.core.bindings.abi import _is_canonical_int64_pair_layout
+
+    rec_canonical = types.Record.make_c_struct([
+        ("a", types.int64), ("b", types.int64)])
+    assert _is_canonical_int64_pair_layout(rec_canonical)
+
+    rec_non_canonical = types.Record.make_c_struct([
+        ("a", types.int32), ("b", types.int64)])
+    assert not _is_canonical_int64_pair_layout(rec_non_canonical)
 
 
 def test_struct_bytes_supports_all_struct_types():
@@ -317,6 +514,268 @@ def test_call_lib_func_undefined_signature_raises():
     with pytest.raises((ValueError, TypingError), match="Undefined signature"):
         run()
     del keepalive
+
+
+def test_call_lib_func_int_int_struct_arg_round_trip(patch_signature):
+    """Round-trip a 16-byte ``{i32, i32, i64}`` struct (the
+    ``duckdb_interval`` shape) through ``_call_lib_func`` on every
+    supported ABI.
+
+    On SysV x86-64 the by-value path requires the new INT/INT
+    eightbyte repack — without it, llvmlite drops fields. On Windows
+    x64, 16B falls outside the ``{1, 2, 4, 8}`` register-passable
+    set so the call goes via alloca + pointer-pass. On AAPCS64 the
+    by-value path passes the struct in ``X0`` / ``X1`` directly.
+
+    If this test fails on AAPCS64 (ubuntu-arm or macOS-ARM64),
+    llvmlite has the same eightbyte-packing gap there too — extend
+    ``_needs_int_int_eightbyte_repack`` in
+    [`call.py`](../../numbox/core/bindings/call.py) to include
+    ``_PLATFORM_AAPCS64``.
+    """
+    import ctypes
+    import llvmlite.binding as ll
+    from numba import njit, types as nb_types
+    from numbox.core.bindings.call import _call_lib_func
+
+    class _IntervalC(ctypes.Structure):
+        _fields_ = [
+            ("a", ctypes.c_int32),
+            ("b", ctypes.c_int32),
+            ("c", ctypes.c_int64),
+        ]
+
+    received = {}
+
+    @ctypes.CFUNCTYPE(ctypes.c_int64, _IntervalC)
+    def echo(s):
+        received["a"] = s.a
+        received["b"] = s.b
+        received["c"] = s.c
+        return s.a + s.b + s.c
+
+    name = "numbox_test_int_int_eightbyte_round_trip"
+    addr = ctypes.cast(echo, ctypes.c_void_p).value
+    ll.add_symbol(name, addr)
+    arg_struct = nb_types.Tuple(
+        [nb_types.int32, nb_types.int32, nb_types.int64])
+    patch_signature(name, nb_types.int64(arg_struct))
+
+    @njit(nb_types.int64(nb_types.int32, nb_types.int32, nb_types.int64))
+    def run(a, b, c):
+        return _call_lib_func(name, ((a, b, c),))
+
+    result = run(7, 11, 1_000_000)
+
+    assert received == {"a": 7, "b": 11, "c": 1_000_000}, (
+        f"second i32 field was dropped by SysV by-value lowering: {received}"
+    )
+    assert result == 7 + 11 + 1_000_000
+    del echo  # keepalive
+
+
+@pytest.mark.skipif(
+    _platform_str() not in ("sysv_x86_64", "aapcs64"),
+    reason="return-side eightbyte repack only kicks in on SysV / AAPCS64",
+)
+def test_call_lib_func_int_int_return_uses_i64_pair_in_ir(patch_signature):
+    """For a 16B non-canonical INT/INT return on SysV x86-64 / AAPCS64,
+    the LLVM IR must declare the C function as returning ``{i64, i64}``,
+    not ``{i32, i32, i64}`` — sidestepping llvmlite's eightbyte-
+    packing gap on the return side. The numba-side return value is
+    then unpacked back to the original LLVM type via memory bitcast.
+
+    IR-only check rather than a true round-trip because Python ctypes
+    ``CFUNCTYPE`` callbacks cannot return ``Structure`` by value
+    ("invalid result type for callback function") — there's no clean
+    way to author a Python-side producer that returns a ``{i32, i32,
+    i64}`` struct via the platform ABI for a JIT'd caller to consume.
+    The arg-side counterpart
+    (``test_call_lib_func_int_int_struct_arg_round_trip``) already
+    provides end-to-end validation of the symmetric
+    ``_repack_to_i64_pair`` + ``_repack_from_i64_pair`` machinery.
+    """
+    from numba import njit, types as nb_types
+    from numbox.core.bindings.call import _call_lib_func
+
+    name = "numbox_test_int_int_eightbyte_return_ir"
+    keepalive = _register_test_symbol(name)
+    ret_struct = nb_types.Tuple(
+        [nb_types.int32, nb_types.int32, nb_types.int64])
+    patch_signature(name, ret_struct(nb_types.int32))
+
+    @njit
+    def run(x):
+        return _call_lib_func(name, (x,))
+
+    run.compile((nb_types.int32,))
+    ir_text = list(run.inspect_llvm().values())[0]
+    declare_line = next(
+        (line for line in ir_text.splitlines()
+         if "declare" in line and name in line),
+        None,
+    )
+    assert declare_line is not None, (
+        f"could not find declare line for {name} in IR:\n{ir_text}"
+    )
+    # The return type appears between `declare` and the function name.
+    # We want `{ i64, i64 }` (the canonical eightbyte pair), NOT
+    # `{ i32, i32, i64 }` (which would be llvmlite emitting the
+    # non-canonical layout that drops fields).
+    decl_prefix = declare_line.split('@' + name)[0]
+    assert "i64, i64" in decl_prefix, (
+        f"expected return type to be repacked to '{{i64, i64}}'; "
+        f"declare line was:\n{declare_line}"
+    )
+    assert "i32, i32, i64" not in decl_prefix, (
+        f"return type still shows non-canonical '{{i32, i32, i64}}' "
+        f"-- repack not applied; declare line was:\n{declare_line}"
+    )
+    del keepalive
+
+
+def test_call_lib_func_four_i32_struct_arg_round_trip(patch_signature):
+    """Round-trip a 16-byte ``UniTuple(int32, 4)`` struct (LLVM type
+    ``[4 x i32]``, 4-byte alignment) through ``_call_lib_func`` on
+    every supported ABI.
+
+    On SysV x86-64 / AAPCS64 this exercises the alignment-safe repack
+    path: ``_repack_to_i64_pair`` allocates a well-aligned ``{i64, i64}``
+    slot rather than an under-aligned ``[4 x i32]`` slot, so the
+    final ``{i64, i64}`` load doesn't trip undefined behavior on
+    stricter targets / optimization levels. On Windows the 16B path
+    goes via alloca + pointer-pass.
+    """
+    import ctypes
+    import llvmlite.binding as ll
+    from numba import njit, types as nb_types
+    from numbox.core.bindings.call import _call_lib_func
+
+    class _Quad32C(ctypes.Structure):
+        _fields_ = [
+            ("a", ctypes.c_int32),
+            ("b", ctypes.c_int32),
+            ("c", ctypes.c_int32),
+            ("d", ctypes.c_int32),
+        ]
+
+    received = {}
+
+    @ctypes.CFUNCTYPE(ctypes.c_int64, _Quad32C)
+    def echo(s):
+        received["a"] = s.a
+        received["b"] = s.b
+        received["c"] = s.c
+        received["d"] = s.d
+        return s.a + s.b + s.c + s.d
+
+    name = "numbox_test_four_i32_round_trip"
+    addr = ctypes.cast(echo, ctypes.c_void_p).value
+    ll.add_symbol(name, addr)
+    arg_struct = nb_types.UniTuple(nb_types.int32, 4)
+    patch_signature(name, nb_types.int64(arg_struct))
+
+    @njit(nb_types.int64(
+        nb_types.int32, nb_types.int32, nb_types.int32, nb_types.int32))
+    def run(a, b, c, d):
+        return _call_lib_func(name, ((a, b, c, d),))
+
+    result = run(101, 202, 303, 404)
+
+    assert received == {"a": 101, "b": 202, "c": 303, "d": 404}, (
+        f"4×i32 fields scrambled: {received}"
+    )
+    assert result == 101 + 202 + 303 + 404
+    del echo  # keepalive
+
+
+@pytest.mark.skipif(
+    _platform_str() != "sysv_x86_64",
+    reason="repack-skip rules are SysV x86-64 specific",
+)
+def test_call_lib_func_sse_eightbyte_arg_not_repacked(patch_signature):
+    """A 16B ``{double, double}`` arg has SSE eightbytes — passed in
+    XMM0/XMM1 on SysV x86-64. It must NOT be repacked to ``{i64, i64}``
+    (which would force GP registers RDI/RSI), so the LLVM declare line
+    keeps the ``double, double`` shape rather than ``i64, i64``.
+    """
+    from numba import njit, types as nb_types
+    from numbox.core.bindings.call import _call_lib_func
+
+    name = "numbox_test_sse_pair_no_repack"
+    keepalive = _register_test_symbol(name)
+    sse_struct = nb_types.UniTuple(nb_types.float64, 2)
+    patch_signature(name, nb_types.int32(sse_struct))
+
+    @njit
+    def run(x):
+        return _call_lib_func(name, (x,))
+
+    run.compile((sse_struct,))
+    ir_text = list(run.inspect_llvm().values())[0]
+    declare_line = next(
+        (line for line in ir_text.splitlines()
+         if "declare" in line and name in line),
+        None,
+    )
+    assert declare_line is not None, (
+        f"could not find declare line for {name} in IR:\n{ir_text}"
+    )
+    assert "double" in declare_line, (
+        f"expected SSE pair to keep its double-typed arg in declare "
+        f"(numba lowers UniTuple(float64, 2) to '[2 x double]'); "
+        f"got:\n{declare_line}"
+    )
+    assert "i64" not in declare_line, (
+        f"SSE pair must not be repacked to a 64-bit-integer-typed arg "
+        f"(would force GP registers instead of XMM); declare line "
+        f"was:\n{declare_line}"
+    )
+    del keepalive
+
+
+def test_call_lib_func_canonical_int64_pair_round_trip(patch_signature):
+    """A canonical 16B ``UniTuple(int64, 2)`` round-trips correctly
+    through ``_call_lib_func`` on every supported ABI — regression
+    guard that the canonical-skip in
+    ``_needs_int_int_eightbyte_repack`` doesn't break the by-value
+    path on SysV x86-64 / AAPCS64 or the alloca + pointer-pass path
+    on Windows x64. This is the arg-side complement to the existing
+    ``test_call_lib_func_lldiv_via_unified`` (which exercises the
+    return side of canonical 16B). Numbduck's ``duckdb_hugeint`` and
+    ``duckdb_uhugeint`` bind wrappers will rely on this path.
+    """
+    import ctypes
+    import llvmlite.binding as ll
+    from numba import njit, types as nb_types
+    from numbox.core.bindings.call import _call_lib_func
+
+    class _PairC(ctypes.Structure):
+        _fields_ = [("lo", ctypes.c_int64), ("hi", ctypes.c_int64)]
+
+    received = {}
+
+    @ctypes.CFUNCTYPE(ctypes.c_int64, _PairC)
+    def echo(s):
+        received["lo"] = s.lo
+        received["hi"] = s.hi
+        return s.hi
+
+    name = "numbox_test_canonical_i64_pair_round_trip"
+    addr = ctypes.cast(echo, ctypes.c_void_p).value
+    ll.add_symbol(name, addr)
+    arg_struct = nb_types.UniTuple(nb_types.int64, 2)
+    patch_signature(name, nb_types.int64(arg_struct))
+
+    @njit(nb_types.int64(nb_types.int64, nb_types.int64))
+    def run(lo, hi):
+        return _call_lib_func(name, ((lo, hi),))
+
+    result = run(0x0123456789ABCDEF, -42)
+
+    assert received == {"lo": 0x0123456789ABCDEF, "hi": -42}
+    assert result == -42
+    del echo  # keepalive
 
 
 def test_call_lib_func_byval_undefined_signature_raises():

--- a/test/core/test_abi.py
+++ b/test/core/test_abi.py
@@ -816,15 +816,17 @@ def test_call_lib_func_missing_llvm_symbol_raises(patch_signature):
         run()
 
 
-def test_call_lib_func_large_return_struct_raises(patch_signature):
-    """`_call_lib_func` raises when the C function returns a struct >16
-    bytes — that path is unsupported.
+def test_call_lib_func_large_return_uses_sret_in_ir(patch_signature):
+    """A >16-byte struct return is lowered as ``sret``: the LLVM declare
+    line for the C symbol must be ``void`` returning, with the hidden
+    first arg flagged ``sret`` (caller-allocated buffer pointer). Same
+    pattern on every platform — SysV x86-64, AAPCS64, and Windows x64
+    all use indirect-result-location for >16-byte aggregates.
     """
     from numba import njit, types as nb_types
-    from numba.core.errors import TypingError
     from numbox.core.bindings.call import _call_lib_func
 
-    name = "numbox_test_large_ret"
+    name = "numbox_test_large_ret_sret_ir"
     keepalive = _register_test_symbol(name)
     big_ret = nb_types.UniTuple(nb_types.int64, 3)
     patch_signature(name, big_ret(nb_types.int32))
@@ -833,6 +835,212 @@ def test_call_lib_func_large_return_struct_raises(patch_signature):
     def run(x):
         return _call_lib_func(name, (x,))
 
-    with pytest.raises(TypingError, match="return struct >16 bytes"):
+    run.compile((nb_types.int32,))
+    ir_text = list(run.inspect_llvm().values())[0]
+    declare_line = next(
+        (line for line in ir_text.splitlines()
+         if "declare" in line and name in line),
+        None,
+    )
+    assert declare_line is not None, (
+        f"could not find declare line for {name} in IR:\n{ir_text}"
+    )
+    assert "declare void" in declare_line, (
+        f"expected 'declare void' for sret return; got:\n{declare_line}"
+    )
+    assert "sret(" in declare_line, (
+        f"expected 'sret(' attribute on hidden first arg; got:\n{declare_line}"
+    )
+    del keepalive
+
+
+@pytest.mark.skipif(
+    _platform_str() not in ("sysv_x86_64", "win_x64"),
+    reason=(
+        "Round-trip relies on a Python ctypes callback receiving the "
+        "sret hidden first arg in the same register as a normal first "
+        "arg. True on SysV x86-64 (RDI) and Windows x64 (RCX). On "
+        "AAPCS64 the sret pointer goes in x8 (indirect-result-location "
+        "register), separate from x0 — ctypes thunks read args in "
+        "x0/x1 order, so the buffer pointer never reaches the callback "
+        "and the test segfaults. The IR-only tests still pin sret "
+        "lowering on every platform; numbduck's real C consumers "
+        "(duckdb_get_decimal/_varint) follow the AAPCS64 ABI directly "
+        "and exercise this path on AAPCS64 in their own CI."
+    ),
+)
+def test_call_lib_func_large_return_round_trip_unituple_24b(patch_signature):
+    """Round-trip a 24-byte ``UniTuple(int64, 3)`` return through
+    ``_call_lib_func``. The test C callback is declared as
+    ``void(_BigC*, int64)`` -- exactly the sret-lowered shape -- and
+    writes three i64 fields into the caller-allocated buffer. Verifies
+    the full sret round-trip on SysV x86-64 and Windows x64: alloca,
+    hidden first arg, callee write-through-pointer, caller load.
+    """
+    import ctypes
+    import llvmlite.binding as ll
+    from numba import njit, types as nb_types
+    from numbox.core.bindings.call import _call_lib_func
+
+    class _BigC(ctypes.Structure):
+        _fields_ = [
+            ("a", ctypes.c_int64),
+            ("b", ctypes.c_int64),
+            ("c", ctypes.c_int64),
+        ]
+
+    received = {}
+
+    @ctypes.CFUNCTYPE(None, ctypes.POINTER(_BigC), ctypes.c_int64)
+    def echo(out_p, x):
+        out_p[0].a = x
+        out_p[0].b = x + 1
+        out_p[0].c = x + 2
+        received["x"] = x
+
+    name = "numbox_test_large_ret_unituple_3xi64"
+    addr = ctypes.cast(echo, ctypes.c_void_p).value
+    ll.add_symbol(name, addr)
+    ret_struct = nb_types.UniTuple(nb_types.int64, 3)
+    patch_signature(name, ret_struct(nb_types.int64))
+
+    @njit
+    def run(x):
+        return _call_lib_func(name, (x,))
+
+    a, b, c = run(100)
+    assert received == {"x": 100}
+    assert (a, b, c) == (100, 101, 102)
+    del echo  # keepalive
+
+
+def test_call_lib_func_large_return_record_rejected(patch_signature):
+    """A >16-byte ``Record`` return is explicitly rejected with
+    ``TypingError``. Numba's ``RecordModel`` represents values as raw
+    ``[N x i8]*`` pointers, so the natural stack-alloca sret slot
+    would dangle after the ``@njit`` function returns and Python-side
+    boxing would dereference freed memory. Safe support needs NRT-
+    allocated storage hooked into numba's record-ownership model -- a
+    larger lift than this PR takes on, with no current consumer to
+    validate against (numbduck uses ``Tuple``, not ``Record``).
+    Tuple/UniTuple returns with the same byte layout work end-to-end
+    via the round-trip and ``uses_sret_in_ir`` tests above.
+    """
+    from numba import njit, types as nb_types
+    from numba.core.errors import TypingError
+    from numbox.core.bindings.call import _call_lib_func
+
+    name = "numbox_test_large_ret_record_rejected"
+    keepalive = _register_test_symbol(name)
+    rec_ty = nb_types.Record.make_c_struct([
+        ("a", nb_types.int32),
+        ("b", nb_types.int64),
+        ("c", nb_types.int64),
+    ])
+    patch_signature(name, rec_ty(nb_types.int32))
+
+    @njit
+    def run(x):
+        return _call_lib_func(name, (x,))
+
+    with pytest.raises(TypingError, match="Record returns >16 bytes"):
         run.compile((nb_types.int32,))
+    del keepalive
+
+
+@pytest.mark.skipif(
+    _platform_str() not in ("sysv_x86_64", "win_x64"),
+    reason=(
+        "Same AAPCS64 sret/x8 ctypes-callback mismatch documented on "
+        "the UniTuple round-trip. IR-only coverage of the LARGE-return "
+        "path on AAPCS64 lives in the *_uses_sret_in_ir tests."
+    ),
+)
+def test_call_lib_func_large_return_round_trip_varint_shaped(patch_signature):
+    """Round-trip a 17-byte varint-shaped ``Tuple([intp, uint64, int8])``
+    return -- the layout numbduck uses for ``duckdb_get_varint``. Numba
+    ``BaseTuple`` is bit-packed (8+8+1=17B no padding), so the matching
+    ctypes side uses ``_pack_=1`` to suppress the trailing alignment
+    padding a default C struct would add (which would round to 24B).
+    Pins the LARGE-return path on a non-uniform struct ending in a
+    1-byte field.
+    """
+    import ctypes
+    import llvmlite.binding as ll
+    from numba import njit, types as nb_types
+    from numbox.core.bindings.call import _call_lib_func
+
+    class _VarintC(ctypes.Structure):
+        _pack_ = 1
+        _fields_ = [
+            ("a", ctypes.c_int64),
+            ("b", ctypes.c_uint64),
+            ("c", ctypes.c_int8),
+        ]
+    assert ctypes.sizeof(_VarintC) == 17
+
+    received = {}
+
+    @ctypes.CFUNCTYPE(None, ctypes.POINTER(_VarintC), ctypes.c_int32)
+    def echo(out_p, x):
+        out_p[0].a = -x
+        out_p[0].b = x * 7
+        out_p[0].c = x % 128
+        received["x"] = x
+
+    name = "numbox_test_large_ret_varint_shaped"
+    addr = ctypes.cast(echo, ctypes.c_void_p).value
+    ll.add_symbol(name, addr)
+    ret_struct = nb_types.Tuple([nb_types.intp, nb_types.uint64, nb_types.int8])
+    patch_signature(name, ret_struct(nb_types.int32))
+
+    @njit
+    def run(x):
+        return _call_lib_func(name, (x,))
+
+    a, b, c = run(13)
+    assert received == {"x": 13}
+    assert (a, b, c) == (-13, 91, 13)
+    del echo  # keepalive
+
+
+def test_call_lib_func_large_return_decimal_shaped_uses_sret_in_ir(patch_signature):
+    """An 18-byte decimal-shaped ``Tuple([uint8, uint8, uint64, int64])``
+    return -- the layout numbduck uses for ``duckdb_get_decimal`` -- is
+    classified as ``_CLASS_STRUCT_LARGE`` (size > 16) and lowered via
+    sret. IR-only check; numbduck's bit-packed tuple layout doesn't
+    match any standard C struct alignment for this shape, so a real
+    round-trip would require ``_pack_=1``. The varint test already
+    exercises the value-path; this test just pins the codegen for the
+    decimal shape numbduck specifically depends on.
+    """
+    from numba import njit, types as nb_types
+    from numbox.core.bindings.call import _call_lib_func
+
+    name = "numbox_test_large_ret_decimal_shape_ir"
+    keepalive = _register_test_symbol(name)
+    decimal_ret = nb_types.Tuple([
+        nb_types.uint8, nb_types.uint8, nb_types.uint64, nb_types.int64])
+    patch_signature(name, decimal_ret(nb_types.int32))
+
+    @njit
+    def run(x):
+        return _call_lib_func(name, (x,))
+
+    run.compile((nb_types.int32,))
+    ir_text = list(run.inspect_llvm().values())[0]
+    declare_line = next(
+        (line for line in ir_text.splitlines()
+         if "declare" in line and name in line),
+        None,
+    )
+    assert declare_line is not None, (
+        f"could not find declare line for {name} in IR:\n{ir_text}"
+    )
+    assert "declare void" in declare_line, (
+        f"expected 'declare void' for sret return; got:\n{declare_line}"
+    )
+    assert "sret(" in declare_line, (
+        f"expected 'sret(' on hidden first arg; got:\n{declare_line}"
+    )
     del keepalive

--- a/test/core/test_abi.py
+++ b/test/core/test_abi.py
@@ -527,11 +527,9 @@ def test_call_lib_func_int_int_struct_arg_round_trip(patch_signature):
     set so the call goes via alloca + pointer-pass. On AAPCS64 the
     by-value path passes the struct in ``X0`` / ``X1`` directly.
 
-    If this test fails on AAPCS64 (ubuntu-arm or macOS-ARM64),
-    llvmlite has the same eightbyte-packing gap there too — extend
-    ``_needs_int_int_eightbyte_repack`` in
-    [`call.py`](../../numbox/core/bindings/call.py) to include
-    ``_PLATFORM_AAPCS64``.
+    If this test fails on AAPCS64 (ubuntu-arm or macOS-ARM64), that
+    indicates a remaining ABI/lowering issue despite the existing
+    INT/INT eightbyte repack handling for that platform.
     """
     import ctypes
     import llvmlite.binding as ll


### PR DESCRIPTION
## Summary

Sync fork's `main` with `upstream/main`, bringing in merged [Goykhman/numbox#11](https://github.com/Goykhman/numbox/pull/11) (SysV x86-64 / AAPCS64 INT/INT eightbyte repack + `sret` >16-byte struct return support) plus tag [`0.5.11`](https://github.com/Goykhman/numbox/releases/tag/0.5.11).

## Conflicts

None — `git merge upstream/main` was clean. Upstream changes touched `numbox/core/bindings/{abi,call}.py`, `test/core/test_abi.py`, `pyproject.toml`, `LICENSE`, and `README.md`; fork-only files (`CLAUDE.md`, `.github/workflows/numbox_ci.yml`, `.github/workflows/minimax_code_review.yml`) were not touched.

## Verification

`git diff upstream/main..HEAD` shows exactly the expected fork-only delta — 3 files:
- `CLAUDE.md` (fork-only project doc)
- `.github/workflows/numbox_ci.yml` (extended matrix + per-Python numba pins + macOS runner)
- `.github/workflows/minimax_code_review.yml` (fork-only minimax review)
