### PR TITLE
Add Bindings: implementation gotchas section to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,24 @@ def func_name(x):
 3. Function names must match the C library names exactly
 4. Args passed as tuple literal to `_call_lib_func`
 
+### Bindings: implementation gotchas
+
+These have caught cleanly-reasoned designs more than once. Apply to all new bindings, intrinsics, and platform-aware additions.
+
+**Symbol resolution must use extern refs, not literal addresses.** [`ll.address_of_symbol(name)`](https://llvmlite.readthedocs.io/en/latest/user-guide/binding/modules.html) at lowering time returns the *current process's* runtime address — useful only as a presence check. Baking that int into LLVM IR breaks `cache=True` because ASLR randomizes the address per process and cached objects are meant to survive across runs and machines. The correct pattern, used by [`_call_lib_func`](numbox/core/bindings/call.py) itself: emit an extern declaration with [`get_or_insert_function(builder.module, func_ll_ty, func_name)`](numbox/core/bindings/call.py#L185) and let llvmlite's JIT linker resolve the name at link time. The [literal-address check](numbox/core/bindings/call.py#L76) earlier in the intrinsic is *only* a presence assertion; `func_p_as_int` is never consumed by codegen. The same extern-ref pattern works for data symbols (`@stdout = external global ptr`) and for accessor functions whose return value is per-thread ([`__errno_location`](https://man7.org/linux/man-pages/man3/errno.3.html), `__error`, `_errno`).
+
+**Reuse the existing pointer/string helpers; don't reinvent.** Already in [`numbox/utils/lowlevel.py`](numbox/utils/lowlevel.py):
+
+- [`array_data_p(arr) -> intp`](numbox/utils/lowlevel.py#L297) — numpy array data pointer (signed). Python- and `@njit`-callable.
+- [`get_str_from_p_as_int(p) -> unicode_type`](numbox/utils/lowlevel.py#L148) — read NUL-terminated C string at address `p` into a Python `unicode_type`. Capped at [`MAX_STR_LENGTH`](numbox/core/configurations.py) (= `2**31 - 1`; the cap bounds the `carray` view, the loop exits on first NUL). `@njit`-callable.
+- [`get_unicode_data_p(s) -> intp`](numbox/utils/lowlevel.py#L174) — pointer to a Python unicode's data payload (null-terminated). `@njit`-callable.
+
+These are the canonical primitives for C-string interop. New bindings should compose them, not reimplement byte loops or pointer casts. **Before designing anything that touches strings, pointers, or buffer ownership, read [`numbox/utils/lowlevel.py`](numbox/utils/lowlevel.py) end-to-end first.**
+
+**Public surface is star-imported.** [`numbox/core/bindings/__init__.py`](numbox/core/bindings/__init__.py) does `from numbox.core.bindings._c import *` (and same for `_math`, `_sqlite`). Anything at top level without a leading underscore is part of the public API. Keep new intrinsics private (`_`-prefixed); keep user-facing wrappers public.
+
+**Platform-variable C types — `long`, `time_t`, `size_t`.** `long` is 64-bit on POSIX (LP64) but 32-bit on Windows x64 (LLP64); `time_t` size varies historically; `size_t` is 64-bit on all current 64-bit CI platforms. A `signatures` entry that uses `int64` for `long` will silently corrupt registers on Windows. Functions affected: `fseek`/`ftell`/`fsetpos`/`fgetpos`, `time`/`clock`, `strtol`/`strtoul`. Either dispatch per platform (option-(ii) style: different symbol or signature per platform) or omit the function from the batch and document as a follow-up. Don't ship a uniform-`int64` signature that's correct on POSIX and wrong on Windows.
+
 ### Core Modules
 
 - **`core/any/`** — type erasure: wraps any value into uniform type


### PR DESCRIPTION
Adds the "Bindings: implementation gotchas" section to CLAUDE.md as foundational reference for the upcoming libc bindings expansion work (target 0.5.12; design doc at [`docs/plans/2026-05-11-libc-bindings-expansion-design.md`](https://github.com/nelson2005/numbox/blob/feature/libc-bindings-expansion/docs/plans/2026-05-11-libc-bindings-expansion-design.md) on `feature/libc-bindings-expansion`).

Originally intended as a second commit on [#16](https://github.com/nelson2005/numbox/pull/16) but committed after that PR had already merged — splitting out cleanly here.

Three gotchas, in their own section between "Adding a New Binding" and "Core Modules":

1. **Symbol resolution must use extern refs**, not literal addresses. [`get_or_insert_function(builder.module, …, func_name)`](https://github.com/nelson2005/numbox/blob/main/numbox/core/bindings/call.py#L185) is the correct pattern; [`ll.address_of_symbol(name)`](https://github.com/nelson2005/numbox/blob/main/numbox/core/bindings/call.py#L76) is *only* a presence check. ASLR + `cache=True` would corrupt cached objects if literal addresses landed in IR.
2. **Reuse existing pointer/string helpers** in [`numbox/utils/lowlevel.py`](https://github.com/nelson2005/numbox/blob/main/numbox/utils/lowlevel.py): [`array_data_p`](https://github.com/nelson2005/numbox/blob/main/numbox/utils/lowlevel.py#L297), [`get_str_from_p_as_int`](https://github.com/nelson2005/numbox/blob/main/numbox/utils/lowlevel.py#L148), [`get_unicode_data_p`](https://github.com/nelson2005/numbox/blob/main/numbox/utils/lowlevel.py#L174). Don't reinvent.
3. **Platform-variable C types** (`long`, `time_t`, `size_t`) require per-platform dispatch when they differ in size — Windows LLP64 vs POSIX LP64 is the live trap. A uniform `int64` signature for `long` would silently corrupt registers on Windows.
