### PR TITLE
ci: add link-check and doc-codeblock-flake8 workflows

### DIFF
--- a/.github/scripts/extract_codeblocks.py
+++ b/.github/scripts/extract_codeblocks.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Lint Python code blocks inside .rst / .md docs with flake8.
+
+Extracts every ``.. code-block:: python`` (or ``.. code:: python``) from .rst
+files and every ```` ```python ```` fenced block from .md files, then passes
+each block to ``flake8`` via stdin with ``--stdin-display-name=<path>:<line>``
+so any reported violation maps back to the original source location.
+
+Usage:
+    extract_codeblocks.py PATH [PATH ...] [--max-line-length N] [--flake8 EXE]
+
+Each PATH may be a file or a directory; directories are walked recursively.
+Exits with the worst flake8 return code seen (0 if all clean, non-zero otherwise).
+"""
+import argparse
+import re
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+
+RST_DIRECTIVE = re.compile(r'^([ \t]*)\.\.\s+(?:code-block|code)::\s*python\b')
+MD_FENCE = re.compile(r'^([ \t]*)```python\s*$')
+
+
+def extract_rst_blocks(text):
+    lines = text.splitlines(keepends=True)
+    n = len(lines)
+    i = 0
+    while i < n:
+        m = RST_DIRECTIVE.match(lines[i].rstrip('\n'))
+        if not m:
+            i += 1
+            continue
+        directive_indent = len(m.group(1))
+        j = i + 1
+        while j < n:
+            ln = lines[j].rstrip('\n')
+            if not ln.strip():
+                j += 1
+                continue
+            this_indent = len(ln) - len(ln.lstrip())
+            if this_indent > directive_indent and ln.lstrip().startswith(':'):
+                j += 1
+                continue
+            break
+        body_start = None
+        body_indent = None
+        body = []
+        while j < n:
+            ln = lines[j]
+            stripped = ln.rstrip('\n')
+            if not stripped.strip():
+                if body_start is not None:
+                    body.append(ln)
+                j += 1
+                continue
+            this_indent = len(stripped) - len(stripped.lstrip())
+            if body_start is None:
+                if this_indent > directive_indent:
+                    body_start = j + 1
+                    body_indent = this_indent
+                    body.append(ln)
+                    j += 1
+                else:
+                    break
+            else:
+                if this_indent < body_indent:
+                    break
+                body.append(ln)
+                j += 1
+        while body and not body[-1].strip():
+            body.pop()
+        if body:
+            yield body_start, textwrap.dedent(''.join(body))
+        i = max(j, i + 1)
+
+
+def extract_md_blocks(text):
+    lines = text.splitlines(keepends=True)
+    n = len(lines)
+    i = 0
+    while i < n:
+        m = MD_FENCE.match(lines[i].rstrip('\n'))
+        if not m:
+            i += 1
+            continue
+        body_start = i + 2
+        body = []
+        i += 1
+        while i < n:
+            if lines[i].rstrip('\n').strip() == '```':
+                break
+            body.append(lines[i])
+            i += 1
+        i += 1
+        if body:
+            yield body_start, textwrap.dedent(''.join(body))
+
+
+SKIP_DIRS = {'venv', '.venv', 'venv313', '_build', '.doctrees', 'node_modules', '.git', '__pycache__', 'plans'}
+
+
+def _walk(root, suffix):
+    for sub in sorted(root.rglob(f'*{suffix}')):
+        if any(part in SKIP_DIRS for part in sub.parts):
+            continue
+        yield sub
+
+
+def iter_files(paths):
+    for raw in paths:
+        p = Path(raw)
+        if p.is_file():
+            kind = {'.rst': 'rst', '.md': 'md'}.get(p.suffix)
+            if kind:
+                yield p, kind
+        elif p.is_dir():
+            for sub in _walk(p, '.rst'):
+                yield sub, 'rst'
+            for sub in _walk(p, '.md'):
+                yield sub, 'md'
+
+
+DOC_SNIPPET_IGNORE = 'E302,E303,E305,W292,W391'
+
+
+def lint_block(code, label, max_line_length, extend_ignore, flake8_exe):
+    proc = subprocess.run(
+        [flake8_exe, f'--max-line-length={max_line_length}',
+         f'--extend-ignore={extend_ignore}',
+         f'--stdin-display-name={label}', '-'],
+        input=code, text=True, capture_output=True,
+    )
+    if proc.stdout:
+        sys.stdout.write(proc.stdout)
+    if proc.stderr:
+        sys.stderr.write(proc.stderr)
+    return proc.returncode
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument('paths', nargs='+')
+    ap.add_argument('--max-line-length', type=int, default=120)
+    ap.add_argument('--extend-ignore', default=DOC_SNIPPET_IGNORE,
+                    help=f'flake8 codes to ignore beyond defaults (default: {DOC_SNIPPET_IGNORE} — '
+                         'blank-line rules that do not apply to short snippets). Pass empty string to disable.')
+    ap.add_argument('--flake8', default='flake8')
+    args = ap.parse_args(argv)
+
+    worst = 0
+    any_blocks = False
+    for path, kind in iter_files(args.paths):
+        text = path.read_text(encoding='utf-8')
+        blocks = extract_rst_blocks(text) if kind == 'rst' else extract_md_blocks(text)
+        for start_line, code in blocks:
+            any_blocks = True
+            label = f'{path}:{start_line}'
+            rc = lint_block(code, label, args.max_line_length, args.extend_ignore, args.flake8)
+            if rc > worst:
+                worst = rc
+    if not any_blocks:
+        print('extract_codeblocks: no Python code blocks found in given paths', file=sys.stderr)
+    return worst
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/.github/workflows/doc-codeblock-flake8.yml
+++ b/.github/workflows/doc-codeblock-flake8.yml
@@ -17,11 +17,6 @@ jobs:
 
       - run: pip install flake8
 
-      - name: Fetch extract_codeblocks.py
-        run: |
-          curl -fsSL -o /tmp/extract_codeblocks.py \
-            https://raw.githubusercontent.com/nelson2005/config/main/templates/scripts/extract_codeblocks.py
-
       - name: Lint Python blocks in .rst and .md
         run: |
           shopt -s globstar nullglob
@@ -33,4 +28,8 @@ jobs:
             echo "No docs/ or top-level README to scan; skipping."
             exit 0
           fi
-          python /tmp/extract_codeblocks.py "${paths[@]}"
+          if [[ ! -f .github/scripts/extract_codeblocks.py ]]; then
+            echo "::error::Missing .github/scripts/extract_codeblocks.py. Copy it from nelson2005/config templates/scripts/extract_codeblocks.py."
+            exit 1
+          fi
+          python .github/scripts/extract_codeblocks.py "${paths[@]}"

--- a/.github/workflows/doc-codeblock-flake8.yml
+++ b/.github/workflows/doc-codeblock-flake8.yml
@@ -1,0 +1,36 @@
+name: doc-codeblock-flake8
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  doc-codeblock-flake8:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - run: pip install flake8
+
+      - name: Fetch extract_codeblocks.py
+        run: |
+          curl -fsSL -o /tmp/extract_codeblocks.py \
+            https://raw.githubusercontent.com/nelson2005/config/main/templates/scripts/extract_codeblocks.py
+
+      - name: Lint Python blocks in .rst and .md
+        run: |
+          shopt -s globstar nullglob
+          paths=()
+          for d in docs README.md README.rst; do
+            [[ -e "$d" ]] && paths+=("$d")
+          done
+          if [[ ${#paths[@]} -eq 0 ]]; then
+            echo "No docs/ or top-level README to scan; skipping."
+            exit 0
+          fi
+          python /tmp/extract_codeblocks.py "${paths[@]}"

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,65 @@
+name: link-check
+
+on:
+  pull_request:
+  schedule:
+    - cron: '17 6 * * 1'
+  workflow_dispatch:
+
+jobs:
+  lychee:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Determine scope
+        id: scope
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            git fetch origin "${{ github.base_ref }}" --depth=1
+            changed=$(git diff --name-only --diff-filter=AM "origin/${{ github.base_ref }}"...HEAD \
+              | grep -E '\.(rst|md|py)$' || true)
+            if [[ -z "$changed" ]]; then
+              echo "files=" >> "$GITHUB_OUTPUT"
+              echo "No .rst/.md/.py files changed in this PR; skipping link check."
+            else
+              echo "files<<EOF" >> "$GITHUB_OUTPUT"
+              echo "$changed" >> "$GITHUB_OUTPUT"
+              echo "EOF" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            { echo "files<<EOF"; find . -type f \( -name '*.rst' -o -name '*.md' -o -name '*.py' \) \
+              -not -path './.git/*' -not -path './venv/*' -not -path './*/venv*/*'; echo EOF; } >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Lychee
+        if: steps.scope.outputs.files != ''
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: >-
+            --no-progress
+            --max-concurrency 4
+            --max-retries 2
+            --retry-wait-time 5
+            --timeout 20
+            --accept 200,206,429
+            --exclude-mail
+            --exclude-path .git
+            --exclude-path venv
+            ${{ steps.scope.outputs.files }}
+          fail: true
+          format: markdown
+          output: ./lychee-report.md
+
+      - name: Upload report
+        if: always() && steps.scope.outputs.files != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: lychee-report
+          path: lychee-report.md
+          if-no-files-found: ignore

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -23,10 +23,12 @@ jobs:
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             git fetch origin "${{ github.base_ref }}" --depth=1
             changed=$(git diff --name-only --diff-filter=AM "origin/${{ github.base_ref }}"...HEAD \
-              | grep -E '\.(rst|md|py)$' || true)
+              | grep -E '\.(rst|md|py)$' \
+              | grep -vE '^\.github/' \
+              || true)
             if [[ -z "$changed" ]]; then
               echo "files=" >> "$GITHUB_OUTPUT"
-              echo "No .rst/.md/.py files changed in this PR; skipping link check."
+              echo "No documentation files (.rst/.md/.py outside .github/) changed in this PR; skipping link check."
             else
               echo "files<<EOF" >> "$GITHUB_OUTPUT"
               echo "$changed" >> "$GITHUB_OUTPUT"
@@ -34,7 +36,8 @@ jobs:
             fi
           else
             { echo "files<<EOF"; find . -type f \( -name '*.rst' -o -name '*.md' -o -name '*.py' \) \
-              -not -path './.git/*' -not -path './venv/*' -not -path './*/venv*/*'; echo EOF; } >> "$GITHUB_OUTPUT"
+              -not -path './.git/*' -not -path './venv/*' -not -path './*/venv*/*' \
+              -not -path './.github/*'; echo EOF; } >> "$GITHUB_OUTPUT"
           fi
 
       - name: Lychee

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -48,7 +48,7 @@ jobs:
             --retry-wait-time 5
             --timeout 20
             --accept 200,206,429
-            --exclude-mail
+            --exclude '^mailto:'
             --exclude-path .git
             --exclude-path venv
             ${{ steps.scope.outputs.files }}


### PR DESCRIPTION
## Summary

Adopts two cross-project doc-quality guardrails from [nelson2005/config](https://github.com/nelson2005/config) (`templates/.github/workflows/`):

- [`link-check.yml`](https://github.com/nelson2005/config/blob/main/templates/.github/workflows/link-check.yml) — [lychee](https://github.com/lycheeverse/lychee-action) on PR diff (`.rst`/`.md`/`.py`) plus weekly cron and manual dispatch.
- [`doc-codeblock-flake8.yml`](https://github.com/nelson2005/config/blob/main/templates/.github/workflows/doc-codeblock-flake8.yml) — extracts Python code blocks from `.rst` and `.md`, fetches [`extract_codeblocks.py`](https://github.com/nelson2005/config/blob/main/templates/scripts/extract_codeblocks.py) from nelson2005/config main, runs `flake8 --max-line-length=120` with snippet-appropriate ignores.

Both additive; no existing workflow modified.

## Motivation

Would have caught the two issues Goykhman flagged on [Goykhman/numbox#12](https://github.com/Goykhman/numbox/pull/12):
- 404 link to `opensource.apple.com/source/Libc/Libc-1439.40.11/...` in `docs/numbox.core.bindings.rst`
- Unused `types` import inside a Sphinx code-block in the same file
