### PR TITLE
ci: bump actions/* to node24 versions

### DIFF
--- a/.github/workflows/doc-codeblock-flake8.yml
+++ b/.github/workflows/doc-codeblock-flake8.yml
@@ -9,9 +9,9 @@ jobs:
   doc-codeblock-flake8:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,9 +11,9 @@ jobs:
   build-docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -13,7 +13,7 @@ jobs:
       contents: read
       issues: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -61,7 +61,7 @@ jobs:
 
       - name: Upload report
         if: always() && steps.scope.outputs.files != ''
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: lychee-report
           path: lychee-report.md

--- a/.github/workflows/minimax_code_review.yml
+++ b/.github/workflows/minimax_code_review.yml
@@ -13,6 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Code Review
-        uses: tarmojussila/minimax-code-review@v0.3.0
+        uses: tarmojussila/minimax-code-review@v0.4.0
         with:
           MINIMAX_API_KEY: ${{ secrets.MINIMAX_API_KEY }}

--- a/.github/workflows/numbox_ci.yml
+++ b/.github/workflows/numbox_ci.yml
@@ -77,9 +77,9 @@ jobs:
     runs-on: "${{ matrix.arch }}"
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "${{ matrix.python-version }}"
     - name: Determine version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -37,7 +37,7 @@ jobs:
           python -m build --wheel
 
       - name: Upload distributions
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release-dists
           path: dist/
@@ -57,7 +57,7 @@ jobs:
 
     steps:
       - name: Retrieve release distributions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: release-dists
           path: dist/


### PR DESCRIPTION
## What

Bump pinned action versions. Primary goal: workflows run on **node24** before GitHub forces the default on **2026-06-02** and removes `node20` on **2026-09-16**.

| Action | Was | Now | Runtime at pin |
|---|---|---|---|
| [`actions/checkout`](https://github.com/actions/checkout/releases/tag/v6.0.0) | `@v4` | `@v6` | node24 |
| [`actions/setup-python`](https://github.com/actions/setup-python/releases/tag/v6.0.0) | `@v5` | `@v6` | node24 |
| [`actions/upload-artifact`](https://github.com/actions/upload-artifact/releases/tag/v7.0.0) | `@v4` | `@v7` | node24 (ESM) |
| [`actions/download-artifact`](https://github.com/actions/download-artifact/releases/tag/v8.0.0) | `@v4` | `@v8` | node24 (ESM) |
| [`tarmojussila/minimax-code-review`](https://github.com/tarmojussila/minimax-code-review/releases/tag/v0.4.0) | `@v0.3.0` | `@v0.4.0` | **still node20** — picks up exclude-patterns + max-diff-char-limit features |

13 line changes across [`numbox_ci.yml`](.github/workflows/numbox_ci.yml), [`release.yml`](.github/workflows/release.yml), [`docs.yml`](.github/workflows/docs.yml), [`doc-codeblock-flake8.yml`](.github/workflows/doc-codeblock-flake8.yml), [`link-check.yml`](.github/workflows/link-check.yml), [`minimax_code_review.yml`](.github/workflows/minimax_code_review.yml).

## Third-party actions audited

| Action | Runtime | Conclusion |
|---|---|---|
| `peaceiris/actions-gh-pages@v4` | node24 | Already on node24 |
| `lycheeverse/lychee-action@v2` | composite | No node runtime |
| `pypa/gh-action-pypi-publish@release/v1` | composite | No node runtime |

After this lands, the only remaining `node20` deprecation warning in CI logs will come from `tarmojussila/minimax-code-review` (still node20 in v0.4.0; revisit when upstream ships node24).

## Notes

- Fork-only change — no upstream PR (`.github/workflows/` files are excluded from upstream per `CLAUDE.md`).
- Same playbook to follow in `nelson2005/numbduck` and `nelson2005/numbarrow`.
