### PR TITLE
ci: force minimax to run on node24 via env override

### DIFF
--- a/.github/workflows/minimax_code_review.yml
+++ b/.github/workflows/minimax_code_review.yml
@@ -11,6 +11,8 @@ jobs:
   review:
     name: MiniMax Code Review
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     steps:
       - name: Code Review
         uses: tarmojussila/minimax-code-review@v0.4.0


### PR DESCRIPTION
## What

Set job-scoped `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` on the [`MiniMax Code Review`](.github/workflows/minimax_code_review.yml) job so the action runs on node24 ahead of GitHub's 2026-06-02 forced switch.

## Why

Upstream `tarmojussila/minimax-code-review` still declares `using: "node20"` at `v0.4.0` (latest). The previous bump from `v0.3.0 → v0.4.0` only picked up new features; the runtime warning persists. The `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` env var is GitHub's documented opt-in to run a `node20`-declared action on `node24` now.

## Risk + revert

If the action's code uses APIs deprecated/removed in node24, the minimax job will fail. Low probability (most node20 actions run fine on node24), but unverified.

Revert by removing the `env:` block on `minimax_code_review.yml`. Drop the override entirely once upstream ships a node24 release.

## Notes

- Job-scoped (not workflow-scoped), so blast radius is the single minimax review job.
- Same change to follow in `nelson2005/numbox` if the trial works here, or vice versa.
