### PR TITLE
ci: add DeepSeek code review workflow

### DIFF
--- a/.github/workflows/deepseek_code_review.yml
+++ b/.github/workflows/deepseek_code_review.yml
@@ -1,0 +1,18 @@
+name: DeepSeek Code Review
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: hustcer/deepseek-review@v1
+        with:
+          chat-token: ${{ secrets.CHAT_TOKEN }}
+          model: deepseek-v4-pro
+          exclude-patterns: 'docs/**,*.md,CLAUDE.md,docs/plans/**,.github/**'


### PR DESCRIPTION
## Summary
Adds a third automated PR reviewer alongside [MiniMax](.github/workflows/minimax_code_review.yml), gemini-code-assist (GitHub App), and copilot-pull-request-reviewer (GitHub App). Posts a structured review as a PR comment via [`hustcer/deepseek-review@v1`](https://github.com/hustcer/deepseek-review).

Uses [`deepseek-v4-pro`](https://api-docs.deepseek.com/news/news260424) (the larger / more thorough V4 variant, 1.6T params). Excludes `docs/**`, `*.md`, `CLAUDE.md`, `docs/plans/**`, and `.github/**` to keep the review focused on code.

Requires repo secret `CHAT_TOKEN` (a DeepSeek API key) before the action can post anything.