### PR TITLE
ci: add security_scan workflow (gitleaks + bandit + pip-audit)

### DIFF
--- a/.github/workflows/security_scan.yml
+++ b/.github/workflows/security_scan.yml
@@ -1,0 +1,40 @@
+name: security_scan
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+  security-events: write
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0    # gitleaks needs full history to scan past commits
+
+      - name: gitleaks (secret scanning)
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install scanners + project
+        run: |
+          python -m pip install --upgrade pip
+          pip install bandit pip-audit
+          pip install -e .
+
+      - name: bandit (source-code security linter)
+        run: bandit -r numbox -ll
+
+      - name: pip-audit (dependency CVE scan)
+        run: pip-audit


### PR DESCRIPTION
## Summary
PR-triggered security scanner workflow. Three steps:

- [`gitleaks/gitleaks-action@v2`](https://github.com/gitleaks/gitleaks-action) — secret scanning across full git history, catches custom-shape secrets that GitHub native scanning may miss.
- [`bandit -r numbox -ll`](https://bandit.readthedocs.io/) — Python source-code security linter (insecure patterns: hardcoded passwords, weak crypto, eval/exec, etc.). Scoped to ``numbox/`` only since test code uses ``assert`` legitimately.
- [`pip-audit`](https://pypi.org/project/pip-audit/) — dependency CVE scan against the [OSV database](https://osv.dev/). Auto-detects ``pyproject.toml``.

Complementary to GitHub native [secret_scanning + push_protection](https://github.com/nelson2005/numbox/settings/security_analysis) (already on), Dependabot vulnerability alerts (already on), and CodeQL default-setup (just configured via API).

Notice-only — no auto-PRs (per repo preference).