### PR TITLE
ci: add .pre-commit-config.yaml (flake8 + lychee)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,29 @@
+# Local pre-commit hooks for catching lint + link issues before they hit CI.
+# See top of the PR body / project docs for one-time setup instructions.
+
+repos:
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.3.0
+    hooks:
+      - id: flake8
+        args: [--max-line-length=127, --max-complexity=10]
+
+  - repo: local
+    hooks:
+      - id: lychee
+        name: lychee link check
+        description: |
+          Verifies links in changed .md / .rst / .py files. Requires
+          `lychee` on PATH (cargo install lychee, or release binary).
+        entry: lychee
+        language: system
+        files: '\.(md|rst|py)$'
+        exclude: '^(\.github/|venv/)'
+        args:
+          - '--no-progress'
+          - '--max-retries=2'
+          - '--retry-wait-time=5'
+          - '--timeout=20'
+          - '--accept=200,206,429'
+          - '--exclude=^mailto:'
+        pass_filenames: true


### PR DESCRIPTION
## Summary
Author-time hooks so lint + broken-link issues are caught at ``git commit`` instead of waiting for PR CI.

Two hooks:
- [`flake8`](https://github.com/pycqa/flake8) — same args as ``numbox_ci.yml``: ``--max-line-length=127 --max-complexity=10``.
- [`lychee`](https://github.com/lycheeverse/lychee) (local hook) — same scan as ``link-check.yml``, on staged ``.md`` / ``.rst`` / ``.py`` files.

Motivation: PR #28 caught a broken link the buildout introduced, but only because link-check fires on ``pull_request`` events — every push in between went unchecked. With pre-commit installed locally, the same check runs at commit time.

## Setup (one-time per dev machine)
```bash
pip install pre-commit
pre-commit install
cargo install lychee   # or download a release binary
```

Per-commit bypass: ``git commit --no-verify``.