### PR TITLE
SQLite UDAF/window registration helpers (register_aggregate / register_window)

### DIFF
--- a/.github/scripts/extract_codeblocks.py
+++ b/.github/scripts/extract_codeblocks.py
@@ -99,7 +99,8 @@ def extract_md_blocks(text):
             yield body_start, textwrap.dedent(''.join(body))
 
 
-SKIP_DIRS = {'venv', '.venv', 'venv313', '_build', '.doctrees', 'node_modules', '.git', '__pycache__', 'plans'}
+SKIP_DIRS = {'venv', '.venv', 'venv313', '_build', '.doctrees', 'node_modules',
+             '.git', '__pycache__', 'plans', 'superpowers'}
 
 
 def _walk(root, suffix):

--- a/.github/workflows/doc-codeblock-flake8.yml
+++ b/.github/workflows/doc-codeblock-flake8.yml
@@ -20,12 +20,22 @@ jobs:
       - name: Lint Python blocks in .rst and .md
         run: |
           shopt -s globstar nullglob
+          # Internal planning/spec docs hold illustrative partial snippets, not
+          # runnable examples; lint only user-facing docs (.rst) and READMEs.
           paths=()
-          for d in docs README.md README.rst; do
-            [[ -e "$d" ]] && paths+=("$d")
+          if [[ -d docs ]]; then
+            while IFS= read -r f; do paths+=("$f"); done < <(
+              find docs -type f \( -name '*.rst' -o -name '*.md' \) \
+                -not -path 'docs/superpowers/*' \
+                -not -path 'docs/plans/*' \
+                -not -path 'docs/_build/*'
+            )
+          fi
+          for f in README.md README.rst; do
+            [[ -e "$f" ]] && paths+=("$f")
           done
           if [[ ${#paths[@]} -eq 0 ]]; then
-            echo "No docs/ or top-level README to scan; skipping."
+            echo "No docs to scan (planning dirs excluded); skipping."
             exit 0
           fi
           if [[ ! -f .github/scripts/extract_codeblocks.py ]]; then

--- a/.github/workflows/doc-codeblock-flake8.yml
+++ b/.github/workflows/doc-codeblock-flake8.yml
@@ -21,7 +21,8 @@ jobs:
         run: |
           shopt -s globstar nullglob
           # Internal planning/spec docs hold illustrative partial snippets, not
-          # runnable examples; lint only user-facing docs (.rst) and READMEs.
+          # runnable examples; lint user-facing docs (.rst and .md) and READMEs,
+          # excluding the planning/spec and build dirs below.
           paths=()
           if [[ -d docs ]]; then
             while IFS= read -r f; do paths+=("$f"); done < <(

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -40,6 +40,9 @@ jobs:
               -not -path './.github/*'; echo EOF; } >> "$GITHUB_OUTPUT"
           fi
 
+      # git.musl-libc.org is excluded: lychee's reqwest/rustls client cannot
+      # complete a request to that cgit server (curl succeeds), so it reports a
+      # false TIMEOUT. The link stays valid in the docs; we just don't check it.
       - name: Lychee
         if: steps.scope.outputs.files != ''
         uses: lycheeverse/lychee-action@v2
@@ -49,9 +52,10 @@ jobs:
             --max-concurrency 4
             --max-retries 2
             --retry-wait-time 5
-            --timeout 120
+            --timeout 20
             --accept 200,206,429
             --exclude '^mailto:'
+            --exclude 'git\.musl-libc\.org'
             --exclude-path .git
             --exclude-path venv
             ${{ steps.scope.outputs.files }}

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -49,7 +49,7 @@ jobs:
             --max-concurrency 4
             --max-retries 2
             --retry-wait-time 5
-            --timeout 20
+            --timeout 120
             --accept 200,206,429
             --exclude '^mailto:'
             --exclude-path .git

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ numbox — a toolbox of low-level utilities for working with numba. Provides typ
 - Venv: `python3.12 -m venv venv && venv/bin/pip install -e . flake8 pytest`
 - Install: `pip install -e .`
 - Test: `pytest`
-- Lint: `flake8` (config in `.flake8`: max-line-length=127, default rules, per-file F403/F405 ignore for `test/core/test_bindings.py`)
+- Lint: `flake8` (config in `.flake8`: max-line-length=127, excludes `venv`/`build`/`dist`, per-file F403/F405 ignore for `test/core/test_bindings.py`). **`.flake8` is fork-only** — `upstream/main` (so `upstream-pr/*` branches) ships no flake8 config; its CI gate is `flake8 . --select=E9,F63,F7,F82,F401` (line-length is advisory `--exit-zero`). When verifying an upstream-pr branch locally, plain `flake8 .` misleads (no config → 79-char default, and it scans `venv`); replicate the upstream gate with `flake8 $(git ls-files '*.py') --select=E9,F63,F7,F82,F401`.
 - Docs: `cd docs && make html` (Sphinx)
 - Python: >=3.10 (CI tests 3.10–3.14; local venv pinned to 3.12)
 - Key dependency: `numba>=0.60.0,<0.66.0` (matches `pyproject.toml`; use `numba==0.60.0` locally)

--- a/docs/numbox.core.bindings.rst
+++ b/docs/numbox.core.bindings.rst
@@ -584,6 +584,14 @@ numbox.core.bindings._sqlite_udf
    :show-inheritance:
    :undoc-members:
 
+numbox.core.bindings._sqlite_udf_helpers
+----------------------------------------
+
+.. automodule:: numbox.core.bindings._sqlite_udf_helpers
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
 numbox.core.bindings.call
 -------------------------
 

--- a/docs/superpowers/plans/2026-05-29-sqlite-udaf-registration-helper.md
+++ b/docs/superpowers/plans/2026-05-29-sqlite-udaf-registration-helper.md
@@ -1,0 +1,867 @@
+# SQLite UDAF Registration Helper — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers-extended-cc:subagent-driven-development (recommended) or superpowers-extended-cc:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `register_aggregate` / `register_window` helpers that generate the SQLite UDAF/window callbacks (xStep/xInverse/xValue/xFinal) — the `aggregate_context` + meminfo lifecycle — so callers write only their `@njit` `init`/`step`/`finalize` (+ `inverse`/`value`) state logic.
+
+**Architecture:** Mechanism **B** (selected by the spec's S1–S4 spike re-review). Per-UDAF callback source is generated with the state type and user functions **baked in as module globals** (so calls inline), written to a **content-addressed anchor file** under numba's cache dir via `numbox.utils.preprocessing` (reusing the `make_structref` recipe), and the `@njit(cache=True)` impls cache across processes. The anchor's content hash folds a **cloudpickle of the user functions' code objects** (co_consts-sensitive) so editing a body — including a numeric literal — invalidates correctly. Thin per-UDAF `@cfunc` trampolines forward into the cached impls; a keep-alive handle holds them.
+
+**Tech Stack:** numba 0.65.1 (`njit`/`cfunc`, structref, `numba.core.serialize.cloudpickle`), numbox phase-2 sqlite bindings + `meminfo` bridge + `preprocessing.py` anchors, pytest.
+
+**Spec:** `docs/superpowers/specs/2026-05-29-sqlite-udaf-registration-helper-design.md`
+
+**Branch / sequencing:** Implement on `feat/sqlite-udaf-helper` (off `feat/sqlite-udf`, which carries the unmerged phase-2 modules). Upstream-PR strategy (wait for #17 vs rebase) is decided separately at integration time.
+
+---
+
+## File structure
+
+- **Create** `numbox/core/bindings/_sqlite_udf_helpers.py` — the helper: source templates, digest, codegen+anchor+exec, `register_aggregate`, `register_window`, `_UDAFHandle`. One responsibility: turn user state-logic functions into registered SQLite UDAFs.
+- **Modify** `numbox/core/bindings/__init__.py` — add the star-import so `register_aggregate`/`register_window` join the public bindings API.
+- **Create** `test/core/test_sqlite_udf_helpers.py` — parity, leak, no-collision, deterministic, cross-process cache, invalidation tests.
+- **Modify** `docs/numbox.core.bindings.rst` — `automodule` section + family-list entry for the new module (mandatory docs per CLAUDE.md).
+
+---
+
+### Task 1: Aggregate registration helper (`register_aggregate`) + codegen/anchor/digest/handle
+
+**Goal:** A working `register_aggregate(db, name, n_arg, state_type, init, step, finalize, *, deterministic=False)` that registers a structref-backed aggregate UDAF whose result matches the hand-written phase-2 pattern, including the empty-group path.
+
+**Files:**
+- Create: `numbox/core/bindings/_sqlite_udf_helpers.py`
+- Test: `test/core/test_sqlite_udf_helpers.py`
+
+**Acceptance Criteria:**
+- [ ] `register_aggregate` registers a `SUM` UDAF; `SELECT my_sum(v) FROM t` over `[1..5]` yields `15`.
+- [ ] An empty table yields `0` (empty-group path: `aggregate_context` returns NULL → finalize a fresh `init()` state, no release).
+- [ ] `state_type` that is not a `StructRef` instance raises `TypeError` at registration.
+- [ ] The returned handle keeps the `cfunc`s + user fns alive (registration survives a `gc.collect()` before the query).
+
+**Verify:** `/home/erik/projects/numbox/venv/bin/python -m pytest test/core/test_sqlite_udf_helpers.py -k "aggregate" -v` → 2 passed
+
+**Steps:**
+
+- [ ] **Step 1: Clean caches (project rule), then write the failing tests**
+
+Run first (project rule — clean numba + pycache before any pytest run):
+```bash
+/home/erik/projects/numbox/venv/bin/python -c "import shutil, pathlib; shutil.rmtree(pathlib.Path.home()/'.cache'/'numba', ignore_errors=True); [shutil.rmtree(p, ignore_errors=True) for p in pathlib.Path('/home/erik/projects/numbox').rglob('__pycache__')]; print('cleared')"
+```
+
+Create `test/core/test_sqlite_udf_helpers.py`:
+```python
+"""Tests for the structref-backed SQLite UDAF/window registration helpers."""
+import gc
+from ctypes import addressof, c_int64
+
+import numpy as np
+from numba import carray, cfunc, njit, types
+from numba.core import types as nb_types
+from numba.experimental import structref
+
+from numbox.core.bindings._sqlite_conn import sqlite3_close, sqlite3_open
+from numbox.core.bindings._sqlite_constants import SQLITE_OK, SQLITE_UTF8
+from numbox.core.bindings._sqlite_exec import sqlite3_exec
+from numbox.core.bindings._sqlite_result import sqlite3_result_int, sqlite3_result_int64
+from numbox.core.bindings._sqlite_udf import (
+    sqlite3_create_function_v2,
+    sqlite3_user_data,
+)
+from numbox.core.bindings._sqlite_udf_helpers import register_aggregate
+from numbox.core.bindings._sqlite_value import sqlite3_value_int64
+from numbox.utils.cstrings import c_string
+from numbox.utils.lowlevel import _cast_int_to_void_p
+
+
+# --- state type (module-level => importable, stable __module__) ---
+@structref.register
+class SumStateType(nb_types.StructRef):
+    def preprocess_fields(self, fields):
+        return tuple((n, nb_types.unliteral(t)) for n, t in fields)
+
+
+class SumState(structref.StructRefProxy):
+    def __new__(cls, total):
+        return structref.StructRefProxy.__new__(cls, total)
+
+
+structref.define_proxy(SumState, SumStateType, ["total"])
+sum_state_type = SumStateType([("total", nb_types.int64)])
+
+
+@njit
+def sum_init():
+    return SumState(nb_types.int64(0))
+
+
+@njit
+def sum_step(state, ctx, argc, argv_pp):
+    args = carray(_cast_int_to_void_p(argv_pp), (argc,), dtype=np.intp)
+    state.total += sqlite3_value_int64(args[0])
+
+
+@njit
+def sum_finalize(state, ctx):
+    sqlite3_result_int64(ctx, state.total)
+
+
+# --- test plumbing ---
+def _open_memory():
+    db_p = c_int64(0)
+    with c_string(":memory:") as name_p:
+        assert sqlite3_open(name_p, addressof(db_p)) == SQLITE_OK
+    return db_p.value
+
+
+def _make_table(db, values):
+    with c_string("CREATE TABLE t(v INTEGER)") as p:
+        assert sqlite3_exec(db, p, 0, 0, 0) == SQLITE_OK
+    for v in values:
+        with c_string("INSERT INTO t VALUES (%d)" % v) as p:
+            assert sqlite3_exec(db, p, 0, 0, 0) == SQLITE_OK
+
+
+def _read1_int64(db, select_sql):
+    """Route a scalar SELECT through a capture UDF that stores arg0 into a
+    numpy buffer; returns (value, keepalive)."""
+    buf = np.zeros(1, dtype=np.int64)
+
+    @cfunc(types.void(types.intp, types.int32, types.intp))
+    def cap_cb(ctx, argc, argv):
+        ud = sqlite3_user_data(ctx)
+        args = carray(_cast_int_to_void_p(argv), (argc,), dtype=np.intp)
+        o = carray(_cast_int_to_void_p(ud), (1,), dtype=np.int64)
+        o[0] = sqlite3_value_int64(args[0])
+        sqlite3_result_int(ctx, 0)
+
+    with c_string("__cap") as cp:
+        assert sqlite3_create_function_v2(
+            db, cp, 1, SQLITE_UTF8, buf.ctypes.data, cap_cb.address, 0, 0, 0) == SQLITE_OK
+    with c_string(select_sql) as sp:
+        assert sqlite3_exec(db, sp, 0, 0, 0) == SQLITE_OK
+    return int(buf[0]), cap_cb
+
+
+def test_aggregate_sum():
+    db = _open_memory()
+    _make_table(db, [1, 2, 3, 4, 5])
+    h = register_aggregate(db, "my_sum", 1, sum_state_type,
+                           sum_init, sum_step, sum_finalize)
+    gc.collect()  # handle must keep callbacks alive
+    val, _cap = _read1_int64(db, "SELECT __cap(my_sum(v)) FROM t")
+    sqlite3_close(db)
+    assert val == 15
+    assert h is not None
+
+
+def test_aggregate_empty_group():
+    db = _open_memory()
+    _make_table(db, [])
+    h = register_aggregate(db, "my_sum", 1, sum_state_type,
+                           sum_init, sum_step, sum_finalize)
+    val, _cap = _read1_int64(db, "SELECT __cap(my_sum(v)) FROM t")
+    sqlite3_close(db)
+    assert val == 0
+    assert h is not None
+
+
+def test_aggregate_bad_state_type():
+    import pytest
+    db = _open_memory()
+    with pytest.raises(TypeError):
+        register_aggregate(db, "bad", 1, object(), sum_init, sum_step, sum_finalize)
+    sqlite3_close(db)
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `/home/erik/projects/numbox/venv/bin/python -m pytest test/core/test_sqlite_udf_helpers.py -k aggregate -v`
+Expected: FAIL — `ModuleNotFoundError: numbox.core.bindings._sqlite_udf_helpers`.
+
+- [ ] **Step 3: Write the helper module (aggregate path)**
+
+Create `numbox/core/bindings/_sqlite_udf_helpers.py`:
+```python
+"""Higher-level registration helpers for structref-backed SQLite UDAFs.
+
+``register_aggregate`` / ``register_window`` generate the SQLite callback
+functions (xStep/xInverse/xValue/xFinal) that perform the per-group state
+lifecycle -- ``sqlite3_aggregate_context`` allocation + NULL guard, the single
+intp slot, init-on-first-step via ``export_meminfo``, ``borrow_structref``, and
+the release-in-xFinal-but-NOT-xValue rule -- so callers write only their
+``@njit`` ``init``/``step``/``finalize`` (and ``inverse``/``value`` for windows)
+state logic.
+
+Mechanism (see docs/superpowers/specs/2026-05-29-sqlite-udaf-registration-helper-design.md):
+per-UDAF callback source is generated with the state type and the user functions
+baked in as module globals (so the calls inline), written to a content-addressed
+anchor file under numba's cache dir (reusing numbox.utils.preprocessing), and the
+``@njit(cache=True)`` impls cache across processes. The anchor's content hash
+folds a cloudpickle of the user functions' code objects so editing a body --
+including a numeric literal -- invalidates correctly.
+
+**Caller requirements.** The state-type class and the ``@njit`` functions MUST
+live in an importable module (stable ``__module__``, not ``__main__``); this is a
+precondition for numba caching of any generated code that references them.
+"""
+import ctypes
+import hashlib
+from inspect import getmodule
+
+import numba
+from numba import cfunc, types
+from numba.core.serialize import cloudpickle
+from numba.core.types import StructRef
+
+import numbox
+from numbox.core.bindings._sqlite_conn import sqlite3_errmsg
+from numbox.core.bindings._sqlite_constants import (
+    SQLITE_DETERMINISTIC,
+    SQLITE_OK,
+    SQLITE_UTF8,
+)
+from numbox.core.bindings._sqlite_udf import (
+    sqlite3_create_function_v2,
+    sqlite3_create_window_function,
+)
+from numbox.utils.cstrings import c_string
+from numbox.utils.preprocessing import (
+    _anchor_path,
+    _materialize_anchor,
+    _orphan_anchor_sweep,
+)
+
+# These names are referenced by the GENERATED anchor source; importing them here
+# puts them in this module's __dict__, which seeds the exec namespace below.
+import numpy as np  # noqa: F401
+from numba import carray, njit  # noqa: F401
+from numbox.core.bindings._sqlite_udf import sqlite3_aggregate_context  # noqa: F401
+from numbox.utils.lowlevel import _cast_int_to_void_p  # noqa: F401
+from numbox.utils.meminfo import (  # noqa: F401
+    borrow_structref,
+    export_meminfo,
+    release_meminfo,
+)
+
+__all__ = ["register_aggregate", "register_window"]
+
+_ANCHOR_SUBDIR = "numbox-sqlite-udaf"
+_orphan_anchor_sweep(_ANCHOR_SUBDIR)
+
+
+def _file_anchor():
+    """Identity handle whose module __dict__ (this module's globals, incl.
+    ``__name__``) seeds the generated code's exec namespace. Mirrors
+    ``numbox.utils.highlevel.make_structref``; the ``__name__`` is required or
+    the warm cache reload aborts in numba's Environment rebuild."""
+    raise NotImplementedError
+
+
+# Generated-source templates. Baked global names: _state_type, _init, _step,
+# _finalize, _inverse, _value. Each impl is @njit(cache=True) so it caches
+# cross-process; the user fns inline because they are module globals here.
+_XSTEP_SRC = '''
+@njit(cache=True)
+def _xstep_impl(ctx, argc, argv_pp):
+    agg = sqlite3_aggregate_context(ctx, 8)
+    if agg == 0:
+        return
+    slot = carray(_cast_int_to_void_p(agg), (1,), dtype=np.intp)
+    if slot[0] == 0:
+        slot[0] = export_meminfo(_init())
+    _step(borrow_structref(_state_type, slot[0]), ctx, argc, argv_pp)
+'''
+
+_XFINAL_SRC = '''
+@njit(cache=True)
+def _xfinal_impl(ctx):
+    agg = sqlite3_aggregate_context(ctx, 0)
+    if agg == 0:
+        _finalize(_init(), ctx)
+        return
+    slot = carray(_cast_int_to_void_p(agg), (1,), dtype=np.intp)
+    if slot[0] == 0:
+        _finalize(_init(), ctx)
+        return
+    _finalize(borrow_structref(_state_type, slot[0]), ctx)
+    release_meminfo(slot[0])
+'''
+
+
+class _UDAFHandle:
+    """Keeps the generated ``cfunc`` callbacks (and the user functions they bake
+    in) alive. SQLite holds raw pointers to the cfuncs; if this handle is
+    garbage-collected the pointers dangle and the next call segfaults. **The
+    caller MUST retain the returned handle for as long as the UDAF is used.**"""
+    __slots__ = ("_keep",)
+
+    def __init__(self, *objs):
+        self._keep = objs
+
+
+def _validate_state_type(state_type):
+    if not isinstance(state_type, StructRef):
+        raise TypeError(
+            "state_type must be a numba StructRef instance "
+            "(e.g. MyStateType([('x', int64)])), got %r" % (state_type,))
+
+
+def _digest(state_type, fns):
+    """Content hash that invalidates when the state type, the user functions
+    (co_consts-sensitive, via cloudpickle of the code object -- NOT bare
+    co_code), or the numba/numbox versions change."""
+    h = hashlib.sha256()
+    h.update(repr(state_type).encode("utf-8"))
+    h.update(numba.__version__.encode("utf-8"))
+    h.update((numbox.__version__ or "").encode("utf-8"))
+    for fn in fns:
+        py = getattr(fn, "py_func", fn)
+        h.update(cloudpickle.dumps(py.__code__))
+    return h.hexdigest()[:16]
+
+
+def _compile_callbacks(stem, srcs, state_type, fns):
+    """Generate + content-address-anchor + exec the @njit(cache=True) impls.
+
+    ``fns`` maps generated global names (``_init``, ``_step``, ...) to user
+    callables. Returns the exec namespace (contains ``_xstep_impl`` etc.)."""
+    digest = _digest(state_type, list(fns.values()))
+    code_txt = "# udaf-digest: %s\n%s" % (digest, "".join(srcs))
+    ns = {**getmodule(_file_anchor).__dict__, "_state_type": state_type, **fns}
+    anchor = _anchor_path(_ANCHOR_SUBDIR, stem, code_txt)
+    _materialize_anchor(anchor, code_txt)
+    code = compile(code_txt, str(anchor), mode="exec")
+    exec(code, ns)  # nosec B102 - JIT codegen of internal source
+    return ns
+
+
+def _raise_rc(db, name, rc):
+    msg_p = sqlite3_errmsg(db)
+    detail = ""
+    if msg_p:
+        detail = ": " + ctypes.cast(
+            msg_p, ctypes.c_char_p).value.decode("utf-8", "replace")
+    raise RuntimeError(
+        "sqlite3 UDAF registration failed for %r (rc=%d)%s" % (name, rc, detail))
+
+
+def _stem(prefix, name):
+    return prefix + "".join(c if c.isalnum() else "_" for c in name)
+
+
+def register_aggregate(db, name, n_arg, state_type, init, step, finalize,
+                       *, deterministic=False):
+    """Register a structref-backed aggregate UDAF.
+
+    :param db: connection pointer (intp), as returned by ``sqlite3_open``.
+    :param name: SQL function name (str); the C-string lifetime is handled here.
+    :param n_arg: argument count, or -1 for variadic.
+    :param state_type: the numba structref *instance* type for per-group state.
+    :param init: ``@njit`` ``() -> state`` returning a fresh state.
+    :param step: ``@njit`` ``(state, ctx, argc, argv_pp)`` updating state.
+    :param finalize: ``@njit`` ``(state, ctx)`` writing the result.
+    :param deterministic: OR-in ``SQLITE_DETERMINISTIC``.
+    :returns: a keep-alive handle the caller MUST retain (see ``_UDAFHandle``).
+    """
+    _validate_state_type(state_type)
+    ns = _compile_callbacks(
+        _stem("udaf_", name), [_XSTEP_SRC, _XFINAL_SRC], state_type,
+        {"_init": init, "_step": step, "_finalize": finalize})
+    xstep_impl = ns["_xstep_impl"]
+    xfinal_impl = ns["_xfinal_impl"]
+
+    @cfunc(types.void(types.intp, types.int32, types.intp))
+    def step_cb(ctx, argc, argv):
+        xstep_impl(ctx, argc, argv)
+
+    @cfunc(types.void(types.intp))
+    def final_cb(ctx):
+        xfinal_impl(ctx)
+
+    flags = SQLITE_UTF8 | (SQLITE_DETERMINISTIC if deterministic else 0)
+    with c_string(name) as name_p:
+        rc = sqlite3_create_function_v2(
+            db, name_p, n_arg, flags, 0, 0,
+            step_cb.address, final_cb.address, 0)
+    if rc != SQLITE_OK:
+        _raise_rc(db, name, rc)
+    return _UDAFHandle(step_cb, final_cb, xstep_impl, xfinal_impl,
+                       init, step, finalize)
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `/home/erik/projects/numbox/venv/bin/python -m pytest test/core/test_sqlite_udf_helpers.py -k aggregate -v`
+Expected: PASS (`test_aggregate_sum`, `test_aggregate_empty_group`, `test_aggregate_bad_state_type`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /home/erik/projects/numbox add numbox/core/bindings/_sqlite_udf_helpers.py test/core/test_sqlite_udf_helpers.py
+git -C /home/erik/projects/numbox commit -m "feat(udaf): register_aggregate helper (content-addressed codegen + meminfo lifecycle)"
+```
+
+---
+
+### Task 2: Window registration helper (`register_window`)
+
+**Goal:** Add `register_window(db, name, n_arg, state_type, init, step, inverse, value, finalize, *, deterministic=False)`, owning the `xInverse`/`xValue` callbacks and the release-in-`xFinal`-but-not-`xValue` rule.
+
+**Files:**
+- Modify: `numbox/core/bindings/_sqlite_udf_helpers.py` (add `_XINVERSE_SRC`, `_XVALUE_SRC`, `register_window`)
+- Test: `test/core/test_sqlite_udf_helpers.py` (add window test)
+
+**Acceptance Criteria:**
+- [ ] A running-sum window (`ROWS BETWEEN 1 PRECEDING AND CURRENT ROW`) over `[1..5]` yields `[1, 3, 5, 7, 9]`.
+- [ ] `xValue` reads the running result without releasing; `xFinal` releases once (covered by the leak test in Task 3).
+
+**Verify:** `/home/erik/projects/numbox/venv/bin/python -m pytest test/core/test_sqlite_udf_helpers.py -k window -v` → 1 passed
+
+**Steps:**
+
+- [ ] **Step 1: Write the failing window test**
+
+Append to `test/core/test_sqlite_udf_helpers.py`:
+```python
+from numbox.core.bindings._sqlite_udf_helpers import register_window  # noqa: E402
+
+
+@njit
+def w_inverse(state, ctx, argc, argv_pp):
+    args = carray(_cast_int_to_void_p(argv_pp), (argc,), dtype=np.intp)
+    state.total -= sqlite3_value_int64(args[0])
+
+
+@njit
+def w_value(state, ctx):
+    sqlite3_result_int64(ctx, state.total)
+
+
+def _read_window(db, select_sql, nrows):
+    meta = np.zeros(nrows + 1, dtype=np.int64)  # meta[0]=count, meta[1:]=values
+
+    @cfunc(types.void(types.intp, types.int32, types.intp))
+    def wcap_cb(ctx, argc, argv):
+        ud = sqlite3_user_data(ctx)
+        m = carray(_cast_int_to_void_p(ud), (nrows + 1,), dtype=np.int64)
+        i = m[0]
+        args = carray(_cast_int_to_void_p(argv), (argc,), dtype=np.intp)
+        m[1 + i] = sqlite3_value_int64(args[0])
+        m[0] = i + 1
+        sqlite3_result_int(ctx, 0)
+
+    with c_string("__wcap") as cp:
+        assert sqlite3_create_function_v2(
+            db, cp, 1, SQLITE_UTF8, meta.ctypes.data, wcap_cb.address, 0, 0, 0) == SQLITE_OK
+    with c_string(select_sql) as sp:
+        assert sqlite3_exec(db, sp, 0, 0, 0) == SQLITE_OK
+    return [int(meta[1 + i]) for i in range(int(meta[0]))], wcap_cb
+
+
+def test_window_running_sum():
+    db = _open_memory()
+    _make_table(db, [1, 2, 3, 4, 5])
+    h = register_window(db, "my_wsum", 1, sum_state_type,
+                        sum_init, sum_step, w_inverse, w_value, sum_finalize)
+    sql = ("SELECT __wcap(my_wsum(v) OVER "
+           "(ORDER BY v ROWS BETWEEN 1 PRECEDING AND CURRENT ROW)) "
+           "FROM t ORDER BY v")
+    vals, _cap = _read_window(db, sql, 5)
+    sqlite3_close(db)
+    assert vals == [1, 3, 5, 7, 9]
+    assert h is not None
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `/home/erik/projects/numbox/venv/bin/python -m pytest test/core/test_sqlite_udf_helpers.py -k window -v`
+Expected: FAIL — `ImportError: cannot import name 'register_window'`.
+
+- [ ] **Step 3: Add window templates + `register_window`**
+
+In `numbox/core/bindings/_sqlite_udf_helpers.py`, add after `_XFINAL_SRC`:
+```python
+_XINVERSE_SRC = '''
+@njit(cache=True)
+def _xinverse_impl(ctx, argc, argv_pp):
+    agg = sqlite3_aggregate_context(ctx, 0)
+    if agg == 0:
+        return
+    slot = carray(_cast_int_to_void_p(agg), (1,), dtype=np.intp)
+    if slot[0] == 0:
+        return
+    _inverse(borrow_structref(_state_type, slot[0]), ctx, argc, argv_pp)
+'''
+
+_XVALUE_SRC = '''
+@njit(cache=True)
+def _xvalue_impl(ctx):
+    agg = sqlite3_aggregate_context(ctx, 0)
+    if agg == 0:
+        _value(_init(), ctx)
+        return
+    slot = carray(_cast_int_to_void_p(agg), (1,), dtype=np.intp)
+    if slot[0] == 0:
+        _value(_init(), ctx)
+        return
+    _value(borrow_structref(_state_type, slot[0]), ctx)
+'''
+```
+
+Add at the end of the module:
+```python
+def register_window(db, name, n_arg, state_type, init, step, inverse, value,
+                    finalize, *, deterministic=False):
+    """Register a structref-backed window UDAF.
+
+    Same as :func:`register_aggregate` plus ``inverse(state, ctx, argc,
+    argv_pp)`` (un-applies a row; state already exists) and ``value(state,
+    ctx)`` (emits the running result WITHOUT releasing). Only ``xFinal``
+    releases the meminfo.
+    """
+    _validate_state_type(state_type)
+    ns = _compile_callbacks(
+        _stem("wudaf_", name),
+        [_XSTEP_SRC, _XINVERSE_SRC, _XVALUE_SRC, _XFINAL_SRC], state_type,
+        {"_init": init, "_step": step, "_inverse": inverse,
+         "_value": value, "_finalize": finalize})
+    xstep_impl = ns["_xstep_impl"]
+    xinverse_impl = ns["_xinverse_impl"]
+    xvalue_impl = ns["_xvalue_impl"]
+    xfinal_impl = ns["_xfinal_impl"]
+
+    @cfunc(types.void(types.intp, types.int32, types.intp))
+    def step_cb(ctx, argc, argv):
+        xstep_impl(ctx, argc, argv)
+
+    @cfunc(types.void(types.intp, types.int32, types.intp))
+    def inverse_cb(ctx, argc, argv):
+        xinverse_impl(ctx, argc, argv)
+
+    @cfunc(types.void(types.intp))
+    def value_cb(ctx):
+        xvalue_impl(ctx)
+
+    @cfunc(types.void(types.intp))
+    def final_cb(ctx):
+        xfinal_impl(ctx)
+
+    flags = SQLITE_UTF8 | (SQLITE_DETERMINISTIC if deterministic else 0)
+    with c_string(name) as name_p:
+        rc = sqlite3_create_window_function(
+            db, name_p, n_arg, flags, 0,
+            step_cb.address, final_cb.address,
+            value_cb.address, inverse_cb.address, 0)
+    if rc != SQLITE_OK:
+        _raise_rc(db, name, rc)
+    return _UDAFHandle(step_cb, inverse_cb, value_cb, final_cb,
+                       xstep_impl, xinverse_impl, xvalue_impl, xfinal_impl,
+                       init, step, inverse, value, finalize)
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `/home/erik/projects/numbox/venv/bin/python -m pytest test/core/test_sqlite_udf_helpers.py -k window -v`
+Expected: PASS (`test_window_running_sum`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /home/erik/projects/numbox add numbox/core/bindings/_sqlite_udf_helpers.py test/core/test_sqlite_udf_helpers.py
+git -C /home/erik/projects/numbox commit -m "feat(udaf): register_window helper (xInverse/xValue, release-in-xFinal-only)"
+```
+
+---
+
+### Task 3: Memory-safety & correctness guards
+
+**Goal:** Lock in the lifecycle's memory safety and per-UDAF independence: meminfo balance, no cross-UDAF contamination, and `deterministic=True`.
+
+**Files:**
+- Test: `test/core/test_sqlite_udf_helpers.py` (add three tests)
+
+**Acceptance Criteria:**
+- [ ] Over many aggregate+window runs, `mi_alloc == mi_free` (the `export`/`release` balance and release-in-`xFinal`-only rule hold).
+- [ ] Two distinct aggregates (`sum` and `sum-of-doubles`) sharing `sum_state_type` give correct independent results (`15` and `30`).
+- [ ] `deterministic=True` registers cleanly and computes correctly.
+
+**Verify:** `/home/erik/projects/numbox/venv/bin/python -m pytest test/core/test_sqlite_udf_helpers.py -k "leak or distinct or deterministic" -v` → 3 passed
+
+**Steps:**
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `test/core/test_sqlite_udf_helpers.py`:
+```python
+@njit
+def sum2_step(state, ctx, argc, argv_pp):  # distinct body => distinct anchor
+    args = carray(_cast_int_to_void_p(argv_pp), (argc,), dtype=np.intp)
+    state.total += 2 * sqlite3_value_int64(args[0])
+
+
+def test_two_distinct_aggregates_no_collision():
+    db = _open_memory()
+    _make_table(db, [1, 2, 3, 4, 5])
+    h1 = register_aggregate(db, "my_sum", 1, sum_state_type,
+                            sum_init, sum_step, sum_finalize)
+    h2 = register_aggregate(db, "my_sum2", 1, sum_state_type,
+                            sum_init, sum2_step, sum_finalize)
+    v1, _c1 = _read1_int64(db, "SELECT __cap(my_sum(v)) FROM t")
+    v2, _c2 = _read1_int64(db, "SELECT __cap(my_sum2(v)) FROM t")
+    sqlite3_close(db)
+    assert (v1, v2) == (15, 30)
+    assert h1 is not None and h2 is not None
+
+
+def test_deterministic_flag():
+    db = _open_memory()
+    _make_table(db, [1, 2, 3, 4, 5])
+    h = register_aggregate(db, "my_sum_det", 1, sum_state_type,
+                           sum_init, sum_step, sum_finalize, deterministic=True)
+    val, _cap = _read1_int64(db, "SELECT __cap(my_sum_det(v)) FROM t")
+    sqlite3_close(db)
+    assert val == 15
+    assert h is not None
+
+
+def test_no_meminfo_leak():
+    """The helper-generated lifecycle must preserve export/release balance."""
+    from numba.core.runtime import nrt
+    _nrt = nrt._nrt
+    if not hasattr(_nrt, "memsys_enable_stats"):
+        import pytest
+        pytest.skip("NRT allocation stats unavailable")
+    _nrt.memsys_enable_stats()
+    test_aggregate_sum()          # warm up JIT / one-time allocs
+    test_window_running_sum()
+    before = nrt.rtsys.get_allocation_stats()
+    for _ in range(10):
+        test_aggregate_sum()
+        test_window_running_sum()
+    after = nrt.rtsys.get_allocation_stats()
+    allocated = after.mi_alloc - before.mi_alloc
+    freed = after.mi_free - before.mi_free
+    assert allocated == freed, "meminfo imbalance: %d alloc, %d free" % (allocated, freed)
+```
+
+- [ ] **Step 2: Run to verify status**
+
+Run: `/home/erik/projects/numbox/venv/bin/python -m pytest test/core/test_sqlite_udf_helpers.py -k "leak or distinct or deterministic" -v`
+Expected: these exercise existing Task 1/2 code; if any FAIL it indicates a real lifecycle bug (e.g., missing `release_meminfo` ⇒ leak test fails; shared-anchor collision ⇒ distinct test gives wrong value). Fix in `_sqlite_udf_helpers.py` until they PASS. (No new product code is expected if Tasks 1–2 are correct.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /home/erik/projects/numbox add test/core/test_sqlite_udf_helpers.py
+git -C /home/erik/projects/numbox commit -m "test(udaf): meminfo-leak, no-collision, and deterministic guards"
+```
+
+---
+
+### Task 4: Cross-process caching + invalidation guards
+
+**Goal:** Prove the load-bearing B claims hold end-to-end: the generated impls warm-HIT the cross-process cache (no unbounded `.nbc` growth), and editing a user function's numeric literal invalidates correctly (no stale machine code).
+
+**Files:**
+- Test: `test/core/test_sqlite_udf_helpers.py` (add two subprocess-based tests + a generated driver)
+
+**Acceptance Criteria:**
+- [ ] A warm second process does **not** add a new impl `.nbc` (stable count) — guards against the rejected C failure mode (unbounded growth).
+- [ ] Editing `step` so only a numeric literal changes (`*2` → `*3`) makes a fresh process compute the **new** result (not a stale cached one) — guards the co_consts-sensitive digest.
+
+**Verify:** `/home/erik/projects/numbox/venv/bin/python -m pytest test/core/test_sqlite_udf_helpers.py -k "xprocess or invalidation" -v` → 2 passed
+
+**Steps:**
+
+- [ ] **Step 1: Write the failing subprocess tests**
+
+Append to `test/core/test_sqlite_udf_helpers.py`:
+```python
+import os                                            # noqa: E402
+import subprocess                                    # noqa: E402
+import sys                                           # noqa: E402
+import textwrap                                      # noqa: E402
+
+
+# A self-contained driver: defines a state type + sum UDAF in an importable
+# module, registers it, runs SELECT sum(v), prints the result. {MULT} is the
+# step multiplier (1 normally; flipped to prove invalidation).
+_DRIVER = textwrap.dedent('''
+    from ctypes import addressof, c_int64
+    import numpy as np
+    from numba import carray, cfunc, njit, types
+    from numba.core import types as nb_types
+    from numba.experimental import structref
+    from numbox.core.bindings._sqlite_conn import sqlite3_close, sqlite3_open
+    from numbox.core.bindings._sqlite_constants import SQLITE_OK, SQLITE_UTF8
+    from numbox.core.bindings._sqlite_exec import sqlite3_exec
+    from numbox.core.bindings._sqlite_result import sqlite3_result_int, sqlite3_result_int64
+    from numbox.core.bindings._sqlite_udf import sqlite3_create_function_v2, sqlite3_user_data
+    from numbox.core.bindings._sqlite_udf_helpers import register_aggregate
+    from numbox.core.bindings._sqlite_value import sqlite3_value_int64
+    from numbox.utils.cstrings import c_string
+    from numbox.utils.lowlevel import _cast_int_to_void_p
+
+    @structref.register
+    class StT(nb_types.StructRef):
+        def preprocess_fields(self, fields):
+            return tuple((n, nb_types.unliteral(t)) for n, t in fields)
+    class St(structref.StructRefProxy):
+        def __new__(cls, total):
+            return structref.StructRefProxy.__new__(cls, total)
+    structref.define_proxy(St, StT, ["total"])
+    st = StT([("total", nb_types.int64)])
+
+    @njit
+    def s_init():
+        return St(nb_types.int64(0))
+    @njit
+    def s_step(state, ctx, argc, argv_pp):
+        a = carray(_cast_int_to_void_p(argv_pp), (argc,), dtype=np.intp)
+        state.total += {MULT} * sqlite3_value_int64(a[0])
+    @njit
+    def s_fin(state, ctx):
+        sqlite3_result_int64(ctx, state.total)
+
+    db_p = c_int64(0)
+    with c_string(":memory:") as n:
+        sqlite3_open(n, addressof(db_p))
+    db = db_p.value
+    with c_string("CREATE TABLE t(v INTEGER)") as p:
+        sqlite3_exec(db, p, 0, 0, 0)
+    for v in (1, 2, 3, 4, 5):
+        with c_string("INSERT INTO t VALUES (%d)" % v) as p:
+            sqlite3_exec(db, p, 0, 0, 0)
+    h = register_aggregate(db, "f", 1, st, s_init, s_step, s_fin)
+    buf = np.zeros(1, dtype=np.int64)
+    @cfunc(types.void(types.intp, types.int32, types.intp))
+    def cap(ctx, argc, argv):
+        ud = sqlite3_user_data(ctx)
+        a = carray(_cast_int_to_void_p(argv), (argc,), dtype=np.intp)
+        o = carray(_cast_int_to_void_p(ud), (1,), dtype=np.int64)
+        o[0] = sqlite3_value_int64(a[0]); sqlite3_result_int(ctx, 0)
+    with c_string("cap") as cp:
+        sqlite3_create_function_v2(db, cp, 1, SQLITE_UTF8, buf.ctypes.data, cap.address, 0, 0, 0)
+    with c_string("SELECT cap(f(v)) FROM t") as sp:
+        sqlite3_exec(db, sp, 0, 0, 0)
+    print("RESULT", int(buf[0]))
+''')
+
+
+def _run_driver(tmp_path, cache_dir, mult):
+    script = tmp_path / ("drv_%d.py" % mult)
+    script.write_text(_DRIVER.replace("{MULT}", str(mult)))
+    env = dict(os.environ, NUMBA_CACHE_DIR=str(cache_dir))
+    out = subprocess.run([sys.executable, str(script)], env=env,
+                         capture_output=True, text=True, timeout=600)
+    assert out.returncode == 0, out.stderr
+    line = [ln for ln in out.stdout.splitlines() if ln.startswith("RESULT")][0]
+    return int(line.split()[1])
+
+
+def _count_nbc(cache_dir):
+    return sum(1 for _ in cache_dir.rglob("*.nbc"))
+
+
+def test_xprocess_cache_no_growth(tmp_path):
+    cache = tmp_path / "nbcache"
+    cache.mkdir()
+    assert _run_driver(tmp_path, cache, 1) == 15      # cold: compiles + writes cache
+    n_cold = _count_nbc(cache)
+    assert n_cold > 0
+    assert _run_driver(tmp_path, cache, 1) == 15      # warm: must reuse, not append
+    assert _count_nbc(cache) == n_cold, "warm run grew the cache (C failure mode)"
+
+
+def test_invalidation_on_literal_edit(tmp_path):
+    cache = tmp_path / "nbcache"
+    cache.mkdir()
+    assert _run_driver(tmp_path, cache, 1) == 15       # step: += 1*v  => 15
+    assert _run_driver(tmp_path, cache, 3) == 45       # step: += 3*v  => 45 (not stale 15)
+```
+
+- [ ] **Step 2: Run to verify status**
+
+Run: `/home/erik/projects/numbox/venv/bin/python -m pytest test/core/test_sqlite_udf_helpers.py -k "xprocess or invalidation" -v`
+Expected: PASS if Task 1's digest uses the co_consts-sensitive `cloudpickle.dumps(py.__code__)`. If `test_invalidation_on_literal_edit` FAILS (returns 15 for `mult=3`), the digest is wrong (likely reverted to `co_code`) — fix `_digest` in `_sqlite_udf_helpers.py`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /home/erik/projects/numbox add test/core/test_sqlite_udf_helpers.py
+git -C /home/erik/projects/numbox commit -m "test(udaf): cross-process cache reuse + co_consts invalidation guards"
+```
+
+---
+
+### Task 5: Public API wiring + docs
+
+**Goal:** Expose `register_aggregate`/`register_window` on the public bindings API and document the new module; full lint + test + docs build green.
+
+**Files:**
+- Modify: `numbox/core/bindings/__init__.py`
+- Modify: `docs/numbox.core.bindings.rst`
+
+**Acceptance Criteria:**
+- [ ] `from numbox.core.bindings import register_aggregate, register_window` works.
+- [ ] `docs/numbox.core.bindings.rst` has an `automodule` section for `_sqlite_udf_helpers` and a family-list entry.
+- [ ] `flake8 --max-line-length=127 numbox/core/bindings/_sqlite_udf_helpers.py test/core/test_sqlite_udf_helpers.py` is clean.
+- [ ] Sphinx build exits 0.
+
+**Verify:** `cd /home/erik/projects/numbox/docs && /home/erik/projects/numbox/venv/bin/sphinx-build -b html . _build/html` → exit 0; and `/home/erik/projects/numbox/venv/bin/python -c "from numbox.core.bindings import register_aggregate, register_window; print('ok')"` → `ok`
+
+**Steps:**
+
+- [ ] **Step 1: Wire the star-import**
+
+In `numbox/core/bindings/__init__.py`, add after the `_sqlite_udf` line (line 13):
+```python
+from numbox.core.bindings._sqlite_udf_helpers import *  # noqa: F401, F403
+```
+
+- [ ] **Step 2: Verify import**
+
+Run: `/home/erik/projects/numbox/venv/bin/python -c "from numbox.core.bindings import register_aggregate, register_window; print('ok')"`
+Expected: `ok`
+
+- [ ] **Step 3: Add the docs section**
+
+In `docs/numbox.core.bindings.rst`, mirror the existing per-module `automodule` blocks (e.g. the `_sqlite_udf` one) and add, in the "Modules" area:
+```rst
+SQLite UDAF registration helpers
+--------------------------------
+
+.. automodule:: numbox.core.bindings._sqlite_udf_helpers
+   :members:
+   :undoc-members:
+   :show-inheritance:
+```
+Also add `_sqlite_udf_helpers` to the "Bindings module conventions" family list in the same file (follow the exact format of the neighbouring entries — read the file first and match it).
+
+- [ ] **Step 4: Lint + docs build + full suite**
+
+Run:
+```bash
+/home/erik/projects/numbox/venv/bin/python -m flake8 --max-line-length=127 numbox/core/bindings/_sqlite_udf_helpers.py test/core/test_sqlite_udf_helpers.py
+cd /home/erik/projects/numbox/docs && /home/erik/projects/numbox/venv/bin/sphinx-build -b html . _build/html
+/home/erik/projects/numbox/venv/bin/python -c "import shutil, pathlib; shutil.rmtree(pathlib.Path.home()/'.cache'/'numba', ignore_errors=True); [shutil.rmtree(p, ignore_errors=True) for p in pathlib.Path('/home/erik/projects/numbox').rglob('__pycache__')]; print('cleared')"
+cd /home/erik/projects/numbox && /home/erik/projects/numbox/venv/bin/python -m pytest test/core/test_sqlite_udf_helpers.py -v --durations=20
+```
+Expected: flake8 clean (no output); sphinx exit 0; pytest all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /home/erik/projects/numbox add numbox/core/bindings/__init__.py docs/numbox.core.bindings.rst
+git -C /home/erik/projects/numbox commit -m "feat(udaf): export register_aggregate/register_window + docs"
+```
+
+---
+
+## Notes for the implementer
+
+- **Always use the venv python** (`/home/erik/projects/numbox/venv/bin/python`) for every python/pytest/flake8/sphinx call — never bare `python`.
+- **Clean caches before each pytest run** (numba `~/.cache/numba` + `__pycache__`) per project rule, via the python one-liner shown in Task 1 Step 1 (never `find -exec rm`).
+- **The digest MUST stay co_consts-sensitive** (`cloudpickle.dumps(py.__code__)`). Reverting to `co_code` reintroduces the stale-cache bug Task 4 guards against (verified in spec spike S3).
+- **Do not seed the exec namespace with a bare `{}`** — it must carry `__name__` (we use `getmodule(_file_anchor).__dict__`), or warm cache reload crashes (spec spike S1).
+- The state-type class and user `@njit` functions used by callers must live in an importable module (the tests define them at module scope for this reason).

--- a/docs/superpowers/plans/2026-05-29-sqlite-udaf-registration-helper.md
+++ b/docs/superpowers/plans/2026-05-29-sqlite-udaf-registration-helper.md
@@ -59,16 +59,19 @@ from numba import carray, cfunc, njit, types
 from numba.core import types as nb_types
 from numba.experimental import structref
 
-from numbox.core.bindings._sqlite_conn import sqlite3_close, sqlite3_open
-from numbox.core.bindings._sqlite_constants import SQLITE_OK, SQLITE_UTF8
-from numbox.core.bindings._sqlite_exec import sqlite3_exec
-from numbox.core.bindings._sqlite_result import sqlite3_result_int, sqlite3_result_int64
-from numbox.core.bindings._sqlite_udf import (
+from numbox.core.bindings import (
+    SQLITE_OK,
+    SQLITE_UTF8,
+    sqlite3_close,
     sqlite3_create_function_v2,
+    sqlite3_exec,
+    sqlite3_open,
+    sqlite3_result_int,
+    sqlite3_result_int64,
     sqlite3_user_data,
+    sqlite3_value_int64,
 )
 from numbox.core.bindings._sqlite_udf_helpers import register_aggregate
-from numbox.core.bindings._sqlite_value import sqlite3_value_int64
 from numbox.utils.cstrings import c_string
 from numbox.utils.lowlevel import _cast_int_to_void_p
 
@@ -692,13 +695,11 @@ _DRIVER = textwrap.dedent('''
     from numba import carray, cfunc, njit, types
     from numba.core import types as nb_types
     from numba.experimental import structref
-    from numbox.core.bindings._sqlite_conn import sqlite3_close, sqlite3_open
-    from numbox.core.bindings._sqlite_constants import SQLITE_OK, SQLITE_UTF8
-    from numbox.core.bindings._sqlite_exec import sqlite3_exec
-    from numbox.core.bindings._sqlite_result import sqlite3_result_int, sqlite3_result_int64
-    from numbox.core.bindings._sqlite_udf import sqlite3_create_function_v2, sqlite3_user_data
+    from numbox.core.bindings import (
+        SQLITE_OK, SQLITE_UTF8, sqlite3_close, sqlite3_create_function_v2,
+        sqlite3_exec, sqlite3_open, sqlite3_result_int, sqlite3_result_int64,
+        sqlite3_user_data, sqlite3_value_int64)
     from numbox.core.bindings._sqlite_udf_helpers import register_aggregate
-    from numbox.core.bindings._sqlite_value import sqlite3_value_int64
     from numbox.utils.cstrings import c_string
     from numbox.utils.lowlevel import _cast_int_to_void_p
 
@@ -865,3 +866,5 @@ git -C /home/erik/projects/numbox commit -m "feat(udaf): export register_aggrega
 - **The digest MUST stay co_consts-sensitive** (`cloudpickle.dumps(py.__code__)`). Reverting to `co_code` reintroduces the stale-cache bug Task 4 guards against (verified in spec spike S3).
 - **Do not seed the exec namespace with a bare `{}`** — it must carry `__name__` (we use `getmodule(_file_anchor).__dict__`), or warm cache reload crashes (spec spike S1).
 - The state-type class and user `@njit` functions used by callers must live in an importable module (the tests define them at module scope for this reason).
+- **Test imports use the public package surface** (`from numbox.core.bindings import ...`) for the phase-2 bindings, matching the post-`7d92682` convention. `register_aggregate`/`register_window` are the exception — import them from `numbox.core.bindings._sqlite_udf_helpers` directly, because they don't reach the public surface until the `__init__` wiring in Task 5.
+- **Keep the `@njit(cache=True)` impl + thin `@cfunc` trampoline split — do not collapse to a bare `@cfunc`.** The `@njit(cache=True)` impl is the cross-process-cached unit (its baked-in globals inline at full per-row speed); the per-UDAF `@cfunc` cannot be the cache boundary, since a cfunc keyed on a dispatcher argument gets an ASLR-randomized cross-process key (the rejected mechanism C / spec spike S2 failure). This is structurally different from the phase-2 *test* probes, where the wrapped `@njit` is never independently compiled so a bare `@cfunc` is equivalent — the layering queried on upstream PR #17.

--- a/docs/superpowers/plans/2026-05-29-sqlite-udaf-registration-helper.md.tasks.json
+++ b/docs/superpowers/plans/2026-05-29-sqlite-udaf-registration-helper.md.tasks.json
@@ -1,0 +1,42 @@
+{
+  "planPath": "docs/superpowers/plans/2026-05-29-sqlite-udaf-registration-helper.md",
+  "specPath": "docs/superpowers/specs/2026-05-29-sqlite-udaf-registration-helper-design.md",
+  "branch": "feat/sqlite-udaf-helper",
+  "tasks": [
+    {
+      "id": 7,
+      "subject": "Task 1: register_aggregate helper + codegen/anchor/digest/handle",
+      "status": "pending",
+      "description": "**Goal:** Working register_aggregate(db, name, n_arg, state_type, init, step, finalize, *, deterministic=False) registering a structref-backed aggregate UDAF incl. the empty-group path.\n\n**Files:** Create numbox/core/bindings/_sqlite_udf_helpers.py; Test test/core/test_sqlite_udf_helpers.py\n\n**Acceptance Criteria:** SUM over [1..5]==15; empty table==0; non-StructRef state_type -> TypeError; handle keeps callbacks alive across gc.collect().\n\n**Verify:** /home/erik/projects/numbox/venv/bin/python -m pytest test/core/test_sqlite_udf_helpers.py -k aggregate -v\n\nCritical: digest co_consts-sensitive (cloudpickle.dumps(py.__code__)), NOT co_code; exec ns must carry __name__ (getmodule(_file_anchor).__dict__).\n\n```json:metadata\n{\"files\": [\"numbox/core/bindings/_sqlite_udf_helpers.py\", \"test/core/test_sqlite_udf_helpers.py\"], \"verifyCommand\": \"/home/erik/projects/numbox/venv/bin/python -m pytest test/core/test_sqlite_udf_helpers.py -k aggregate -v\", \"acceptanceCriteria\": [\"SUM over [1..5] yields 15\", \"empty table yields 0\", \"non-StructRef state_type raises TypeError\", \"handle keeps callbacks alive across gc.collect()\"]}\n```"
+    },
+    {
+      "id": 8,
+      "subject": "Task 2: register_window helper (xInverse/xValue, release-in-xFinal-only)",
+      "status": "pending",
+      "blockedBy": [7],
+      "description": "**Goal:** register_window(db, name, n_arg, state_type, init, step, inverse, value, finalize, *, deterministic=False), owning xInverse/xValue + release-in-xFinal-but-not-xValue.\n\n**Files:** Modify numbox/core/bindings/_sqlite_udf_helpers.py (add _XINVERSE_SRC, _XVALUE_SRC, register_window); Test test/core/test_sqlite_udf_helpers.py\n\n**Acceptance Criteria:** running-sum window over [1..5] yields [1,3,5,7,9]; xValue does not release, only xFinal releases.\n\n**Verify:** /home/erik/projects/numbox/venv/bin/python -m pytest test/core/test_sqlite_udf_helpers.py -k window -v\n\n```json:metadata\n{\"files\": [\"numbox/core/bindings/_sqlite_udf_helpers.py\", \"test/core/test_sqlite_udf_helpers.py\"], \"verifyCommand\": \"/home/erik/projects/numbox/venv/bin/python -m pytest test/core/test_sqlite_udf_helpers.py -k window -v\", \"acceptanceCriteria\": [\"running-sum window over [1..5] yields [1,3,5,7,9]\", \"xValue does not release; only xFinal releases\"]}\n```"
+    },
+    {
+      "id": 9,
+      "subject": "Task 3: Memory-safety & correctness guards (leak, no-collision, deterministic)",
+      "status": "pending",
+      "blockedBy": [8],
+      "description": "**Goal:** Lock in meminfo balance, per-UDAF independence, and deterministic=True.\n\n**Files:** Test test/core/test_sqlite_udf_helpers.py (three tests)\n\n**Acceptance Criteria:** mi_alloc==mi_free over many runs; two distinct aggregates yield 15 and 30 independently; deterministic=True yields 15.\n\n**Verify:** /home/erik/projects/numbox/venv/bin/python -m pytest test/core/test_sqlite_udf_helpers.py -k \"leak or distinct or deterministic\" -v\n\n```json:metadata\n{\"files\": [\"test/core/test_sqlite_udf_helpers.py\"], \"verifyCommand\": \"/home/erik/projects/numbox/venv/bin/python -m pytest test/core/test_sqlite_udf_helpers.py -k \\\"leak or distinct or deterministic\\\" -v\", \"acceptanceCriteria\": [\"mi_alloc == mi_free over many runs\", \"two distinct aggregates yield 15 and 30 independently\", \"deterministic=True yields 15\"]}\n```"
+    },
+    {
+      "id": 10,
+      "subject": "Task 4: Cross-process caching + invalidation guards",
+      "status": "pending",
+      "blockedBy": [7],
+      "description": "**Goal:** Prove generated impls warm-HIT the cross-process cache (no .nbc growth) and a numeric-literal edit invalidates correctly.\n\n**Files:** Test test/core/test_sqlite_udf_helpers.py (two subprocess tests + generated driver)\n\n**Acceptance Criteria:** warm second process adds no new impl .nbc (stable count); literal edit *2->*3 yields 45 in a fresh process, not stale 15.\n\n**Verify:** /home/erik/projects/numbox/venv/bin/python -m pytest test/core/test_sqlite_udf_helpers.py -k \"xprocess or invalidation\" -v\n\n```json:metadata\n{\"files\": [\"test/core/test_sqlite_udf_helpers.py\"], \"verifyCommand\": \"/home/erik/projects/numbox/venv/bin/python -m pytest test/core/test_sqlite_udf_helpers.py -k \\\"xprocess or invalidation\\\" -v\", \"acceptanceCriteria\": [\"warm second process adds no new impl .nbc (stable count)\", \"literal edit *2->*3 yields 45 in a fresh process, not stale 15\"]}\n```"
+    },
+    {
+      "id": 11,
+      "subject": "Task 5: Public API wiring + docs",
+      "status": "pending",
+      "blockedBy": [8, 10],
+      "description": "**Goal:** Export register_aggregate/register_window on the public bindings API + document the module; lint + test + docs build green.\n\n**Files:** Modify numbox/core/bindings/__init__.py; Modify docs/numbox.core.bindings.rst\n\n**Acceptance Criteria:** importable from numbox.core.bindings; automodule + family entry in rst; flake8 clean at max-line-length=127; sphinx-build exit 0; full test file passes with --durations=20.\n\n**Verify:** cd /home/erik/projects/numbox/docs && /home/erik/projects/numbox/venv/bin/sphinx-build -b html . _build/html (exit 0); python -c import register_aggregate, register_window\n\n```json:metadata\n{\"files\": [\"numbox/core/bindings/__init__.py\", \"docs/numbox.core.bindings.rst\"], \"verifyCommand\": \"/home/erik/projects/numbox/venv/bin/python -m flake8 --max-line-length=127 numbox/core/bindings/_sqlite_udf_helpers.py test/core/test_sqlite_udf_helpers.py && cd /home/erik/projects/numbox/docs && /home/erik/projects/numbox/venv/bin/sphinx-build -b html . _build/html\", \"acceptanceCriteria\": [\"register_aggregate/register_window importable from numbox.core.bindings\", \"automodule + family entry added to docs rst\", \"flake8 clean at max-line-length=127\", \"sphinx-build exits 0\"]}\n```"
+    }
+  ],
+  "lastUpdated": "2026-05-29"
+}

--- a/docs/superpowers/plans/2026-05-29-sqlite-udaf-registration-helper.md.tasks.json
+++ b/docs/superpowers/plans/2026-05-29-sqlite-udaf-registration-helper.md.tasks.json
@@ -6,6 +6,7 @@
     {
       "id": 7,
       "model": "opus",
+      "effort": "xhigh",
       "subject": "Task 1: register_aggregate helper + codegen/anchor/digest/handle",
       "status": "pending",
       "description": "**Goal:** Working register_aggregate(db, name, n_arg, state_type, init, step, finalize, *, deterministic=False) registering a structref-backed aggregate UDAF incl. the empty-group path.\n\n**Files:** Create numbox/core/bindings/_sqlite_udf_helpers.py; Test test/core/test_sqlite_udf_helpers.py\n\n**Acceptance Criteria:** SUM over [1..5]==15; empty table==0; non-StructRef state_type -> TypeError; handle keeps callbacks alive across gc.collect().\n\n**Verify:** /home/erik/projects/numbox/venv/bin/python -m pytest test/core/test_sqlite_udf_helpers.py -k aggregate -v\n\nCritical: digest co_consts-sensitive (cloudpickle.dumps(py.__code__)), NOT co_code; exec ns must carry __name__ (getmodule(_file_anchor).__dict__).\n\n```json:metadata\n{\"files\": [\"numbox/core/bindings/_sqlite_udf_helpers.py\", \"test/core/test_sqlite_udf_helpers.py\"], \"verifyCommand\": \"/home/erik/projects/numbox/venv/bin/python -m pytest test/core/test_sqlite_udf_helpers.py -k aggregate -v\", \"acceptanceCriteria\": [\"SUM over [1..5] yields 15\", \"empty table yields 0\", \"non-StructRef state_type raises TypeError\", \"handle keeps callbacks alive across gc.collect()\"]}\n```"
@@ -13,6 +14,7 @@
     {
       "id": 8,
       "model": "opus",
+      "effort": "xhigh",
       "subject": "Task 2: register_window helper (xInverse/xValue, release-in-xFinal-only)",
       "status": "pending",
       "blockedBy": [7],
@@ -21,6 +23,7 @@
     {
       "id": 9,
       "model": "opus",
+      "effort": "xhigh",
       "subject": "Task 3: Memory-safety & correctness guards (leak, no-collision, deterministic)",
       "status": "pending",
       "blockedBy": [8],
@@ -29,6 +32,7 @@
     {
       "id": 10,
       "model": "opus",
+      "effort": "xhigh",
       "subject": "Task 4: Cross-process caching + invalidation guards",
       "status": "pending",
       "blockedBy": [7],
@@ -37,6 +41,7 @@
     {
       "id": 11,
       "model": "opus",
+      "effort": "xhigh",
       "subject": "Task 5: Public API wiring + docs",
       "status": "pending",
       "blockedBy": [8, 10],

--- a/docs/superpowers/plans/2026-05-29-sqlite-udaf-registration-helper.md.tasks.json
+++ b/docs/superpowers/plans/2026-05-29-sqlite-udaf-registration-helper.md.tasks.json
@@ -34,7 +34,7 @@
       "model": "opus",
       "effort": "xhigh",
       "subject": "Task 4: Cross-process caching + invalidation guards",
-      "status": "pending",
+      "status": "completed",
       "blockedBy": [7],
       "description": "**Goal:** Prove generated impls warm-HIT the cross-process cache (no .nbc growth) and a numeric-literal edit invalidates correctly.\n\n**Files:** Test test/core/test_sqlite_udf_helpers.py (two subprocess tests + generated driver)\n\n**Acceptance Criteria:** warm second process adds no new impl .nbc (stable count); literal edit *2->*3 yields 45 in a fresh process, not stale 15.\n\n**Verify:** /home/erik/projects/numbox/venv/bin/python -m pytest test/core/test_sqlite_udf_helpers.py -k \"xprocess or invalidation\" -v\n\n```json:metadata\n{\"files\": [\"test/core/test_sqlite_udf_helpers.py\"], \"verifyCommand\": \"/home/erik/projects/numbox/venv/bin/python -m pytest test/core/test_sqlite_udf_helpers.py -k \\\"xprocess or invalidation\\\" -v\", \"acceptanceCriteria\": [\"warm second process adds no new impl .nbc (stable count)\", \"literal edit *2->*3 yields 45 in a fresh process, not stale 15\"]}\n```"
     },
@@ -48,5 +48,5 @@
       "description": "**Goal:** Export register_aggregate/register_window on the public bindings API + document the module; lint + test + docs build green.\n\n**Files:** Modify numbox/core/bindings/__init__.py; Modify docs/numbox.core.bindings.rst\n\n**Acceptance Criteria:** importable from numbox.core.bindings; automodule + family entry in rst; flake8 clean at max-line-length=127; sphinx-build exit 0; full test file passes with --durations=20.\n\n**Verify:** cd /home/erik/projects/numbox/docs && /home/erik/projects/numbox/venv/bin/sphinx-build -b html . _build/html (exit 0); python -c import register_aggregate, register_window\n\n```json:metadata\n{\"files\": [\"numbox/core/bindings/__init__.py\", \"docs/numbox.core.bindings.rst\"], \"verifyCommand\": \"/home/erik/projects/numbox/venv/bin/python -m flake8 --max-line-length=127 numbox/core/bindings/_sqlite_udf_helpers.py test/core/test_sqlite_udf_helpers.py && cd /home/erik/projects/numbox/docs && /home/erik/projects/numbox/venv/bin/sphinx-build -b html . _build/html\", \"acceptanceCriteria\": [\"register_aggregate/register_window importable from numbox.core.bindings\", \"automodule + family entry added to docs rst\", \"flake8 clean at max-line-length=127\", \"sphinx-build exits 0\"]}\n```"
     }
   ],
-  "lastUpdated": "2026-05-29T22:37:05Z"
+  "lastUpdated": "2026-05-30T16:54:07Z"
 }

--- a/docs/superpowers/plans/2026-05-29-sqlite-udaf-registration-helper.md.tasks.json
+++ b/docs/superpowers/plans/2026-05-29-sqlite-udaf-registration-helper.md.tasks.json
@@ -8,7 +8,7 @@
       "model": "opus",
       "effort": "xhigh",
       "subject": "Task 1: register_aggregate helper + codegen/anchor/digest/handle",
-      "status": "pending",
+      "status": "completed",
       "description": "**Goal:** Working register_aggregate(db, name, n_arg, state_type, init, step, finalize, *, deterministic=False) registering a structref-backed aggregate UDAF incl. the empty-group path.\n\n**Files:** Create numbox/core/bindings/_sqlite_udf_helpers.py; Test test/core/test_sqlite_udf_helpers.py\n\n**Acceptance Criteria:** SUM over [1..5]==15; empty table==0; non-StructRef state_type -> TypeError; handle keeps callbacks alive across gc.collect().\n\n**Verify:** /home/erik/projects/numbox/venv/bin/python -m pytest test/core/test_sqlite_udf_helpers.py -k aggregate -v\n\nCritical: digest co_consts-sensitive (cloudpickle.dumps(py.__code__)), NOT co_code; exec ns must carry __name__ (getmodule(_file_anchor).__dict__).\n\n```json:metadata\n{\"files\": [\"numbox/core/bindings/_sqlite_udf_helpers.py\", \"test/core/test_sqlite_udf_helpers.py\"], \"verifyCommand\": \"/home/erik/projects/numbox/venv/bin/python -m pytest test/core/test_sqlite_udf_helpers.py -k aggregate -v\", \"acceptanceCriteria\": [\"SUM over [1..5] yields 15\", \"empty table yields 0\", \"non-StructRef state_type raises TypeError\", \"handle keeps callbacks alive across gc.collect()\"]}\n```"
     },
     {
@@ -48,5 +48,5 @@
       "description": "**Goal:** Export register_aggregate/register_window on the public bindings API + document the module; lint + test + docs build green.\n\n**Files:** Modify numbox/core/bindings/__init__.py; Modify docs/numbox.core.bindings.rst\n\n**Acceptance Criteria:** importable from numbox.core.bindings; automodule + family entry in rst; flake8 clean at max-line-length=127; sphinx-build exit 0; full test file passes with --durations=20.\n\n**Verify:** cd /home/erik/projects/numbox/docs && /home/erik/projects/numbox/venv/bin/sphinx-build -b html . _build/html (exit 0); python -c import register_aggregate, register_window\n\n```json:metadata\n{\"files\": [\"numbox/core/bindings/__init__.py\", \"docs/numbox.core.bindings.rst\"], \"verifyCommand\": \"/home/erik/projects/numbox/venv/bin/python -m flake8 --max-line-length=127 numbox/core/bindings/_sqlite_udf_helpers.py test/core/test_sqlite_udf_helpers.py && cd /home/erik/projects/numbox/docs && /home/erik/projects/numbox/venv/bin/sphinx-build -b html . _build/html\", \"acceptanceCriteria\": [\"register_aggregate/register_window importable from numbox.core.bindings\", \"automodule + family entry added to docs rst\", \"flake8 clean at max-line-length=127\", \"sphinx-build exits 0\"]}\n```"
     }
   ],
-  "lastUpdated": "2026-05-29"
+  "lastUpdated": "2026-05-29T22:37:05Z"
 }

--- a/docs/superpowers/plans/2026-05-29-sqlite-udaf-registration-helper.md.tasks.json
+++ b/docs/superpowers/plans/2026-05-29-sqlite-udaf-registration-helper.md.tasks.json
@@ -5,12 +5,14 @@
   "tasks": [
     {
       "id": 7,
+      "model": "opus",
       "subject": "Task 1: register_aggregate helper + codegen/anchor/digest/handle",
       "status": "pending",
       "description": "**Goal:** Working register_aggregate(db, name, n_arg, state_type, init, step, finalize, *, deterministic=False) registering a structref-backed aggregate UDAF incl. the empty-group path.\n\n**Files:** Create numbox/core/bindings/_sqlite_udf_helpers.py; Test test/core/test_sqlite_udf_helpers.py\n\n**Acceptance Criteria:** SUM over [1..5]==15; empty table==0; non-StructRef state_type -> TypeError; handle keeps callbacks alive across gc.collect().\n\n**Verify:** /home/erik/projects/numbox/venv/bin/python -m pytest test/core/test_sqlite_udf_helpers.py -k aggregate -v\n\nCritical: digest co_consts-sensitive (cloudpickle.dumps(py.__code__)), NOT co_code; exec ns must carry __name__ (getmodule(_file_anchor).__dict__).\n\n```json:metadata\n{\"files\": [\"numbox/core/bindings/_sqlite_udf_helpers.py\", \"test/core/test_sqlite_udf_helpers.py\"], \"verifyCommand\": \"/home/erik/projects/numbox/venv/bin/python -m pytest test/core/test_sqlite_udf_helpers.py -k aggregate -v\", \"acceptanceCriteria\": [\"SUM over [1..5] yields 15\", \"empty table yields 0\", \"non-StructRef state_type raises TypeError\", \"handle keeps callbacks alive across gc.collect()\"]}\n```"
     },
     {
       "id": 8,
+      "model": "opus",
       "subject": "Task 2: register_window helper (xInverse/xValue, release-in-xFinal-only)",
       "status": "pending",
       "blockedBy": [7],
@@ -18,6 +20,7 @@
     },
     {
       "id": 9,
+      "model": "opus",
       "subject": "Task 3: Memory-safety & correctness guards (leak, no-collision, deterministic)",
       "status": "pending",
       "blockedBy": [8],
@@ -25,6 +28,7 @@
     },
     {
       "id": 10,
+      "model": "opus",
       "subject": "Task 4: Cross-process caching + invalidation guards",
       "status": "pending",
       "blockedBy": [7],
@@ -32,6 +36,7 @@
     },
     {
       "id": 11,
+      "model": "opus",
       "subject": "Task 5: Public API wiring + docs",
       "status": "pending",
       "blockedBy": [8, 10],

--- a/docs/superpowers/plans/2026-05-29-sqlite-udaf-registration-helper.md.tasks.json
+++ b/docs/superpowers/plans/2026-05-29-sqlite-udaf-registration-helper.md.tasks.json
@@ -25,7 +25,7 @@
       "model": "opus",
       "effort": "xhigh",
       "subject": "Task 3: Memory-safety & correctness guards (leak, no-collision, deterministic)",
-      "status": "pending",
+      "status": "completed",
       "blockedBy": [8],
       "description": "**Goal:** Lock in meminfo balance, per-UDAF independence, and deterministic=True.\n\n**Files:** Test test/core/test_sqlite_udf_helpers.py (three tests)\n\n**Acceptance Criteria:** mi_alloc==mi_free over many runs; two distinct aggregates yield 15 and 30 independently; deterministic=True yields 15.\n\n**Verify:** /home/erik/projects/numbox/venv/bin/python -m pytest test/core/test_sqlite_udf_helpers.py -k \"leak or distinct or deterministic\" -v\n\n```json:metadata\n{\"files\": [\"test/core/test_sqlite_udf_helpers.py\"], \"verifyCommand\": \"/home/erik/projects/numbox/venv/bin/python -m pytest test/core/test_sqlite_udf_helpers.py -k \\\"leak or distinct or deterministic\\\" -v\", \"acceptanceCriteria\": [\"mi_alloc == mi_free over many runs\", \"two distinct aggregates yield 15 and 30 independently\", \"deterministic=True yields 15\"]}\n```"
     },
@@ -48,5 +48,5 @@
       "description": "**Goal:** Export register_aggregate/register_window on the public bindings API + document the module; lint + test + docs build green.\n\n**Files:** Modify numbox/core/bindings/__init__.py; Modify docs/numbox.core.bindings.rst\n\n**Acceptance Criteria:** importable from numbox.core.bindings; automodule + family entry in rst; flake8 clean at max-line-length=127; sphinx-build exit 0; full test file passes with --durations=20.\n\n**Verify:** cd /home/erik/projects/numbox/docs && /home/erik/projects/numbox/venv/bin/sphinx-build -b html . _build/html (exit 0); python -c import register_aggregate, register_window\n\n```json:metadata\n{\"files\": [\"numbox/core/bindings/__init__.py\", \"docs/numbox.core.bindings.rst\"], \"verifyCommand\": \"/home/erik/projects/numbox/venv/bin/python -m flake8 --max-line-length=127 numbox/core/bindings/_sqlite_udf_helpers.py test/core/test_sqlite_udf_helpers.py && cd /home/erik/projects/numbox/docs && /home/erik/projects/numbox/venv/bin/sphinx-build -b html . _build/html\", \"acceptanceCriteria\": [\"register_aggregate/register_window importable from numbox.core.bindings\", \"automodule + family entry added to docs rst\", \"flake8 clean at max-line-length=127\", \"sphinx-build exits 0\"]}\n```"
     }
   ],
-  "lastUpdated": "2026-05-30T18:51:59Z"
+  "lastUpdated": "2026-05-30T19:28:03Z"
 }

--- a/docs/superpowers/plans/2026-05-29-sqlite-udaf-registration-helper.md.tasks.json
+++ b/docs/superpowers/plans/2026-05-29-sqlite-udaf-registration-helper.md.tasks.json
@@ -16,7 +16,7 @@
       "model": "opus",
       "effort": "xhigh",
       "subject": "Task 2: register_window helper (xInverse/xValue, release-in-xFinal-only)",
-      "status": "pending",
+      "status": "completed",
       "blockedBy": [7],
       "description": "**Goal:** register_window(db, name, n_arg, state_type, init, step, inverse, value, finalize, *, deterministic=False), owning xInverse/xValue + release-in-xFinal-but-not-xValue.\n\n**Files:** Modify numbox/core/bindings/_sqlite_udf_helpers.py (add _XINVERSE_SRC, _XVALUE_SRC, register_window); Test test/core/test_sqlite_udf_helpers.py\n\n**Acceptance Criteria:** running-sum window over [1..5] yields [1,3,5,7,9]; xValue does not release, only xFinal releases.\n\n**Verify:** /home/erik/projects/numbox/venv/bin/python -m pytest test/core/test_sqlite_udf_helpers.py -k window -v\n\n```json:metadata\n{\"files\": [\"numbox/core/bindings/_sqlite_udf_helpers.py\", \"test/core/test_sqlite_udf_helpers.py\"], \"verifyCommand\": \"/home/erik/projects/numbox/venv/bin/python -m pytest test/core/test_sqlite_udf_helpers.py -k window -v\", \"acceptanceCriteria\": [\"running-sum window over [1..5] yields [1,3,5,7,9]\", \"xValue does not release; only xFinal releases\"]}\n```"
     },
@@ -48,5 +48,5 @@
       "description": "**Goal:** Export register_aggregate/register_window on the public bindings API + document the module; lint + test + docs build green.\n\n**Files:** Modify numbox/core/bindings/__init__.py; Modify docs/numbox.core.bindings.rst\n\n**Acceptance Criteria:** importable from numbox.core.bindings; automodule + family entry in rst; flake8 clean at max-line-length=127; sphinx-build exit 0; full test file passes with --durations=20.\n\n**Verify:** cd /home/erik/projects/numbox/docs && /home/erik/projects/numbox/venv/bin/sphinx-build -b html . _build/html (exit 0); python -c import register_aggregate, register_window\n\n```json:metadata\n{\"files\": [\"numbox/core/bindings/__init__.py\", \"docs/numbox.core.bindings.rst\"], \"verifyCommand\": \"/home/erik/projects/numbox/venv/bin/python -m flake8 --max-line-length=127 numbox/core/bindings/_sqlite_udf_helpers.py test/core/test_sqlite_udf_helpers.py && cd /home/erik/projects/numbox/docs && /home/erik/projects/numbox/venv/bin/sphinx-build -b html . _build/html\", \"acceptanceCriteria\": [\"register_aggregate/register_window importable from numbox.core.bindings\", \"automodule + family entry added to docs rst\", \"flake8 clean at max-line-length=127\", \"sphinx-build exits 0\"]}\n```"
     }
   ],
-  "lastUpdated": "2026-05-30T16:54:07Z"
+  "lastUpdated": "2026-05-30T18:51:59Z"
 }

--- a/docs/superpowers/plans/2026-05-29-sqlite-udaf-registration-helper.md.tasks.json
+++ b/docs/superpowers/plans/2026-05-29-sqlite-udaf-registration-helper.md.tasks.json
@@ -43,10 +43,10 @@
       "model": "opus",
       "effort": "xhigh",
       "subject": "Task 5: Public API wiring + docs",
-      "status": "pending",
+      "status": "completed",
       "blockedBy": [8, 10],
       "description": "**Goal:** Export register_aggregate/register_window on the public bindings API + document the module; lint + test + docs build green.\n\n**Files:** Modify numbox/core/bindings/__init__.py; Modify docs/numbox.core.bindings.rst\n\n**Acceptance Criteria:** importable from numbox.core.bindings; automodule + family entry in rst; flake8 clean at max-line-length=127; sphinx-build exit 0; full test file passes with --durations=20.\n\n**Verify:** cd /home/erik/projects/numbox/docs && /home/erik/projects/numbox/venv/bin/sphinx-build -b html . _build/html (exit 0); python -c import register_aggregate, register_window\n\n```json:metadata\n{\"files\": [\"numbox/core/bindings/__init__.py\", \"docs/numbox.core.bindings.rst\"], \"verifyCommand\": \"/home/erik/projects/numbox/venv/bin/python -m flake8 --max-line-length=127 numbox/core/bindings/_sqlite_udf_helpers.py test/core/test_sqlite_udf_helpers.py && cd /home/erik/projects/numbox/docs && /home/erik/projects/numbox/venv/bin/sphinx-build -b html . _build/html\", \"acceptanceCriteria\": [\"register_aggregate/register_window importable from numbox.core.bindings\", \"automodule + family entry added to docs rst\", \"flake8 clean at max-line-length=127\", \"sphinx-build exits 0\"]}\n```"
     }
   ],
-  "lastUpdated": "2026-05-30T19:28:03Z"
+  "lastUpdated": "2026-05-30T19:35:31Z"
 }

--- a/docs/superpowers/specs/2026-05-29-sqlite-udaf-registration-helper-design.md
+++ b/docs/superpowers/specs/2026-05-29-sqlite-udaf-registration-helper-design.md
@@ -1,7 +1,7 @@
 # SQLite UDAF Registration Helper — Design
 
 **Date:** 2026-05-29
-**Status:** Design approved; pending spec review → implementation plan
+**Status:** Design approved; mechanism spike resolved (B selected, 2026-05-29); pending spec review → implementation plan
 **Builds on:** Phase 2 SQLite UDF/UDAF/window bindings (currently on `feat/sqlite-udf`; upstream PR #17 BLOCKED)
 
 ## Goal
@@ -33,7 +33,7 @@ state logic (`init` / `step` / `finalize`, plus `inverse` / `value` for windows)
 | Abstraction level | **Thin (lifecycle-only)** — user does their own value reads / result writes |
 | Scope | **Aggregate + window** (window's release-in-`xFinal`-only rule is the highest-value case) |
 | Entry-point shape | **Two functions** returning a **keep-alive handle** |
-| Wrapper mechanism | **C-primary** (shared cached lifecycle + thin trampolines); **B fallback** (anchored codegen), gated by a spike |
+| Wrapper mechanism | **B — content-addressed anchored codegen** (selected by spike 2026-05-29). C (shared lifecycle + dispatcher args) rejected: no stable cross-process cache |
 | Caching | **Yes** — consistent with every phase-1/phase-2 binding |
 | Empty groups | Helper finalizes a fresh `init()` state; user's `finalize`/`value` always receives a valid state |
 
@@ -126,84 +126,64 @@ regression guards.
 
 ## Mechanism
 
-### C-primary: shared cached lifecycle + thin trampolines
+**Selected: B — content-addressed anchored codegen.** Resolved by the spike on
+2026-05-29 (results below); C (a shared lifecycle parameterized by dispatcher args)
+was rejected because its overloads have no stable cross-process cache key.
 
-Four **static** `@njit(cache=True)` functions live in the helper module — the
-lifecycle, parameterized by `state_type` (a `TypeRef` argument, exactly as
-`borrow_structref` already takes it) and the user functions (passed as values):
+For each registration the helper generates the callback source as text per UDAF,
+**baking `state_type` and the user's `init`/`step`/`finalize` (+ `inverse`/`value` for
+windows) as constants** — so the user-fn calls **inline** (full per-row speed, finding
+2 below) — injects those into the exec namespace, and writes the source to a
+**content-addressed anchor file** via `numbox/utils/preprocessing.py`'s
+`_anchor_path`/`_materialize_anchor` (new subdir `numbox-sqlite-udaf`). Each distinct
+UDAF therefore gets a stable, bounded cross-process cache key. The generated callbacks
+are `cfunc(cache=True)`. The lifecycle bodies are exactly the four bullets under "What
+the helper owns".
 
-```python
-_agg_step(state_type, init, step,      ctx, argc, argv_pp)
-_agg_inverse(state_type, inverse,      ctx, argc, argv_pp)
-_agg_value(state_type, init, value,    ctx)
-_agg_final(state_type, init, finalize, ctx)
-```
-
-Because `state_type`/`init`/`step` are **arguments**, numba specializes each UDAF
-into a **distinct overload** (distinct `TypeRef`, distinct function types) under the
-module's own filename, so numba's **normal per-overload cache** handles it — no
-content-addressing, no anchor files. Invalidation is **automatic**: the user
-functions are genuine compile dependencies, so editing `step` restamps and recompiles.
-The expensive compilation (lifecycle + the user's `@njit(cache=True)` logic) is cached
-across cold starts.
-
-Per registration, the helper builds the trivial `cfunc`s SQLite needs — each binds
-this UDAF's `state_type` + user fns and forwards into the cached lifecycle:
-
-```python
-_step_cb = cfunc(types.void(types.intp, types.int32, types.intp))(
-    lambda ctx, argc, argv: _agg_step(state_type, init, step, ctx, argc, argv))
-```
-
-These trampolines share an identical C signature across UDAFs, so they cannot be
-cache-shared — they are **`cache=False`**. That is acceptable: each body is a single
-forwarding call and the callee loads from cache, so per-process recompile cost is
-negligible. Registration then calls `sqlite3_create_function_v2` (aggregate) or
+Registration then calls `sqlite3_create_function_v2` (aggregate) or
 `sqlite3_create_window_function` (window) with
 `flags = SQLITE_UTF8 | (SQLITE_DETERMINISTIC if deterministic)`, `p_app=0`,
 `xDestroy=0`; the handle keeps the `cfunc`s and user-fn references alive.
 
-### Why this resolves the caching hazard
+### Correctness requirement: invalidation (validated as necessary by the spike)
 
-Dynamically generated numba callbacks collide in the cache because numba keys an
-overload on `(filename, firstlineno, bytecode, signature)`, and **all four callbacks
-share the identical C signature** `void(intp, int32, intp)` (or `void(intp)`). A naive
-closure makes it worse — the wrapper's *code object is byte-identical* across every
-UDAF, only the captured freevars differ — so numba would serve the wrong cached
-machine code. C **dissolves** this by lifting the per-UDAF variation into
-signature-differentiating arguments. (The alternative, B, *works around* the symptom
-with content-addressed filenames.)
+The content-address digest **must fold in a hash of the user functions' bytecode plus
+the `state_type` repr** — two reasons: (1) two byte-identical generated blocks for
+different UDAFs must not collide; (2) the user functions are **inlined** into the
+wrapper but live in the *user's* module, not the anchor file, so without the dep-hash,
+editing `step` would not change the anchor file and numba would serve a stale wrapper
+that inlined the old `step`. (`make_structref` needs no such hash because its generated
+code is self-contained; the UDAF wrapper inlines external deps, so it does.)
 
-### B fallback: anchored codegen
+### Rejected alternative: C — shared lifecycle + dispatcher args
 
-If the spike rules C out, fall back to generating each callback's source as text per
-UDAF, injecting `state_type`/user fns into the exec namespace, writing to a
-content-addressed anchor file via `numbox/utils/preprocessing.py`'s
-`_anchor_path`/`_materialize_anchor` (new subdir `numbox-sqlite-udaf`), and
-`cfunc(cache=True)`. **Correctness requirement:** the digest must fold in a hash of
-the user functions' bytecode + the `state_type` repr, both so two byte-identical
-generated blocks don't collide and so editing `step` invalidates — numba will not see
-the user fns as dependencies of generated text on its own.
+A single shared `@njit(cache=True)` lifecycle parameterized by `state_type` (a
+`TypeRef` arg) and the user fns (dispatcher args), with thin per-UDAF `cfunc`
+trampolines forwarding into it. Far less machinery, and the spike showed it composes
+and inlines at full speed — but it has **no stable cross-process cache key**: the
+lifecycle recompiles on every cold start and the on-disk cache grows unbounded.
+Caching is a core repo convention and an explicit goal here, so C's simplicity does
+not justify losing it.
 
-The **public API and user contract are identical** under C or B; the choice is purely
-internal.
+### Spike results (resolved 2026-05-29, numba 0.65.1)
 
-### Spike (first implementation task) and decision rule
+Built the C skeleton (sum aggregate, real sqlite) and measured:
 
-C rests on numba behavior to be **verified, not assumed**. Build the C skeleton for a
-`sum` aggregate and measure:
+1. **Composition — PASS.** Two distinct UDAFs sharing one `state_type` register and
+   compute correctly (15, 30); the shared lifecycle specializes per function identity
+   (2 overloads, no cross-UDAF collision).
+2. **Per-row cost — baked constants inline at full speed.** Tight-loop ns/iter:
+   baked-global **0.829**; dispatcher-arg **0.829** (1.00×, fully inlined);
+   FunctionType (`.as_func`) **1.845** (2.23×, indirect). ⇒ never use `.as_func` for
+   the callbacks; B's baked constants inline exactly like a global.
+3. **Cross-process caching — the decider** (`NUMBA_DEBUG_CACHE=1`, cold then warm
+   process): a dispatcher-arg lifecycle **misses** on the warm run and appends a new
+   `.nbc` (unstable key, unbounded growth); a baked-global lifecycle (the shape B
+   generates) **hits** the warm run and reuses its single `.nbc`.
 
-1. **Composition + caching** — a `cfunc` trampoline calling a cached `@njit` lifecycle
-   with `TypeRef` + function-value args composes, runs correctly, and the lifecycle
-   *loads from cache* on a second process.
-2. **Per-row cost** — whether the user-fn call inlines or is indirect. Passing the user
-   fns as **njit dispatchers** (each its own compile-time `Dispatcher` type) may yield
-   both clean caching *and* an inlinable direct call; passing them as `.as_func`
-   function-values is definitely indirect. Measure the per-row delta on a realistic
-   aggregate.
-
-**Decision rule:** ship **C** unless the spike shows it cannot compose, or the
-indirect-call cost is material on a realistic aggregate — in which case fall back to **B**.
+**Decision: implement B** — it gets both inlining (finding 2) and stable, bounded
+cross-process caching (finding 3), at the cost of the anchor machinery numbox already
+ships for `make_structref`.
 
 ## Placement
 
@@ -223,9 +203,8 @@ indirect-call cost is material on a realistic aggregate — in which case fall b
   `sqlite3_errmsg(db)` decoded immediately (phase-2 errmsg-lifetime gotcha).
 - **Input validation (raised at registration, clear messages):** `state_type` is a
   structref instance type; `register_window` received all five callbacks; the user
-  functions are passable into the lifecycle (if the spike selects the dispatcher path
-  and a function lacks the required form, say so explicitly rather than emit a cryptic
-  numba typing error).
+  functions are `@njit` and bakeable into the generated wrapper (raise a clear error
+  rather than emit a cryptic numba typing error from the generated code).
 - **Runtime (inside callbacks):** NULL `aggregate_context` (OOM) ⇒ early return, matching
   the phase-2 tests. Empty group is **not** an error — it is the `init()`-fresh-state path.
 - **Keep-alive:** the handle docstring states loudly that dropping it frees the callback
@@ -251,7 +230,8 @@ safety.
 6. **flake8 clean** at `--max-line-length=127`; runs in existing `numbox_ci`
    (which already includes `--durations=20`).
 
-Tests 4–5 plus the spike are the C-vs-B decision evidence.
+Tests 4–5 are the regression guards for B's per-UDAF specialization and stable
+cross-process caching (the spike that selected B is recorded under "Mechanism").
 
 ## Dependencies & sequencing
 

--- a/docs/superpowers/specs/2026-05-29-sqlite-udaf-registration-helper-design.md
+++ b/docs/superpowers/specs/2026-05-29-sqlite-udaf-registration-helper-design.md
@@ -1,7 +1,7 @@
 # SQLite UDAF Registration Helper — Design
 
 **Date:** 2026-05-29
-**Status:** Design approved; mechanism spike resolved (B selected, 2026-05-29); pending spec review → implementation plan
+**Status:** Design approved; mechanism re-reviewed in depth across numbox/numbduck/CRE and verified by spikes S1–S4 (B selected, 2026-05-29); pending spec review → implementation plan
 **Builds on:** Phase 2 SQLite UDF/UDAF/window bindings (currently on `feat/sqlite-udf`; upstream PR #17 BLOCKED)
 
 ## Goal
@@ -145,45 +145,104 @@ Registration then calls `sqlite3_create_function_v2` (aggregate) or
 `flags = SQLITE_UTF8 | (SQLITE_DETERMINISTIC if deterministic)`, `p_app=0`,
 `xDestroy=0`; the handle keeps the `cfunc`s and user-fn references alive.
 
-### Correctness requirement: invalidation (validated as necessary by the spike)
+### Correctness requirement: invalidation (validated by spike S3)
 
-The content-address digest **must fold in a hash of the user functions' bytecode plus
-the `state_type` repr** — two reasons: (1) two byte-identical generated blocks for
-different UDAFs must not collide; (2) the user functions are **inlined** into the
-wrapper but live in the *user's* module, not the anchor file, so without the dep-hash,
-editing `step` would not change the anchor file and numba would serve a stale wrapper
-that inlined the old `step`. (`make_structref` needs no such hash because its generated
-code is self-contained; the UDAF wrapper inlines external deps, so it does.)
+The content-address digest **must fold in a co_consts-sensitive serialization of the
+user functions — `inspect.getsource(fn)` or `cloudpickle.dumps(fn)`, NOT bare
+`fn.__code__.co_code`** — plus the `state_type` repr and the numbox + numba versions.
+Two reasons: (1) two distinct UDAFs must not collide; (2) the user functions are
+**inlined** into the wrapper but live in the *user's* module, not the anchor file, so
+without folding their definition into the digest, editing `step` would not change the
+anchor file and numba would serve a stale wrapper that inlined the old `step`.
+
+`co_code` is **not** sufficient and is a real correctness trap (spike S3, confirmed on
+numba 0.65.1): a numeric-literal-only edit such as `state.total += x*2` → `x*3` leaves
+`co_code` **byte-identical** (the literal moves in `co_consts`, which `LOAD_CONST`
+indexes), so a `co_code` digest produces a **false warm cache HIT that runs stale `*2`
+machine code** (observed: result 30 where 45 was expected). `cloudpickle.dumps` /
+`inspect.getsource` capture `co_consts` and invalidate correctly while still HITting for
+an unchanged body. This is the same `co_consts` blind spot that `preprocessing.py`'s
+anchor mechanism exists to defeat for the *generated* source; the user fns are an
+*external* dependency, so they need the dependency-hash explicitly. (CRE's
+`unique_hash_v` / `_py_func_unq` does exactly this — folds `co_code` **and** cloudpickle
+bytes **and** `cre.__version__`; it only walks first-level deps, so document that a user
+`step` calling other `@njit` helpers is only invalidated to first level unless the hash
+recurses.)
+
+### B implementation requirements (validated by spikes S1/S3)
+
+1. **Exec namespace must carry `__name__`** (S1). Exec-ing the generated source into a
+   bare `{}` writes the cold `.nbc` but **crashes on warm reload** —
+   `Environment._rebuild_env` → `importlib.import_module(None)` → `AttributeError`,
+   because `Environment.can_cache()` is False when `'__name__'` is absent from globals.
+   Mirror numbox's `make_structref` / `@proxy` exec pattern, which seeds the namespace
+   with `inspect.getmodule(func).__dict__` (so `__name__` and the real module globals
+   are present).
+2. **The user's `state_type` must live in an importable module** with a stable
+   `__module__` (not `__main__`). This is a precondition for *any* cached approach —
+   numbduck's `irr.py` documents that a `__main__`-defined state type warm-fails type
+   inference ("No conversion from …StateType"). Validate or document.
+3. **Orphan sweep:** register the new `numbox-sqlite-udaf` anchor subdir with
+   `preprocessing.py`'s `_orphan_anchor_sweep`, and consider an age-based sweep of
+   *superseded* `_<oldhash>.py` anchors — repeated edits to `step` accrete one stale
+   anchor + `.nbc` per edit (unbounded across edits; CRE has the same growth and does
+   not sweep, so this is a "nice to have", not a blocker).
 
 ### Rejected alternative: C — shared lifecycle + dispatcher args
 
 A single shared `@njit(cache=True)` lifecycle parameterized by `state_type` (a
 `TypeRef` arg) and the user fns (dispatcher args), with thin per-UDAF `cfunc`
-trampolines forwarding into it. Far less machinery, and the spike showed it composes
-and inlines at full speed — but it has **no stable cross-process cache key**: the
-lifecycle recompiles on every cold start and the on-disk cache grows unbounded.
-Caching is a core repo convention and an explicit goal here, so C's simplicity does
-not justify losing it.
+trampolines. Far less machinery, and it composes and inlines at full speed — but it is
+**structurally uncacheable cross-process** (spike S2). `str(typeof(step))` literally
+embeds `hex(id(step.py_func))` — the ASLR-randomized heap address of the function — and
+numba folds that into the overload **index key** (the signature tuple), so every process
+computes a different key → guaranteed warm miss + unbounded `.nbc` growth. No cache
+stamp or custom locator can fix this: the broken piece is the index key, not the
+validity stamp. (Passing the user fns as `FunctionType` / `.as_func` values *does* give
+a stable key, but then the call is **indirect** — see mechanism E. You get stable-cache
+XOR inlining, never both, from any argument-passing form.)
 
-### Spike results (resolved 2026-05-29, numba 0.65.1)
+### Verification record — deep re-review (2026-05-29, numba 0.65.1)
 
-Built the C skeleton (sum aggregate, real sqlite) and measured:
+The mechanism space was mapped across numbox, numbduck, and DannyWeitekamp's
+Cognitive-Rule-Engine (CRE), then verified with live spikes:
 
-1. **Composition — PASS.** Two distinct UDAFs sharing one `state_type` register and
-   compute correctly (15, 30); the shared lifecycle specializes per function identity
-   (2 overloads, no cross-UDAF collision).
-2. **Per-row cost — baked constants inline at full speed.** Tight-loop ns/iter:
-   baked-global **0.829**; dispatcher-arg **0.829** (1.00×, fully inlined);
-   FunctionType (`.as_func`) **1.845** (2.23×, indirect). ⇒ never use `.as_func` for
-   the callbacks; B's baked constants inline exactly like a global.
-3. **Cross-process caching — the decider** (`NUMBA_DEBUG_CACHE=1`, cold then warm
-   process): a dispatcher-arg lifecycle **misses** on the warm run and appends a new
-   `.nbc` (unstable key, unbounded growth); a baked-global lifecycle (the shape B
-   generates) **hits** the warm run and reuses its single `.nbc`.
+- **CRE precedent.** `define_CREFunc` (`cre/func.py:2187`) — "user supplies a function,
+  wrap+cache it", the exact analog of this helper — *is* mechanism B: it codegens source,
+  writes it to a content-hash-named file (`source_to_cache`), `import_from_cached`s it,
+  with the hash folding the user fns' bytecode + cloudpickle + `cre.__version__`
+  (`unique_hash_v`, `_py_func_unq`). CRE uses the indirect first-class-function path
+  **only** for runtime *composition* of CREFunc instances (which can't be codegen'd at
+  define time, and which it amortizes over a composition tree); our registration is a
+  define-time operation, so B is the right analog.
+- **numbduck precedent.** `irr.py` / Welford UDAFs already hand-write exactly the
+  per-callback `@njit`-impl + `@cfunc`-trampoline shape that B generates.
 
-**Decision: implement B** — it gets both inlining (finding 2) and stable, bounded
-cross-process caching (finding 3), at the cost of the anchor machinery numbox already
-ships for `make_structref`.
+Spikes (all on numba 0.65.1, isolated `NUMBA_CACHE_DIR`, cold-then-warm subprocesses
+under `NUMBA_DEBUG_CACHE=1`):
+
+| Spike | Hypothesis | Verdict |
+|-------|------------|---------|
+| **S1** | B (baked-global codegen, anchored, `cfunc(cache=True)`) warm-HITs cross-process on a real SQLite SUM UDAF, user fn inlined | **confirmed** — warm HIT (`.nbc` stable at 1), `sqlite3_value_int64`+NRT inlined into the impl, aggregate `==31`, `mi_alloc==mi_free` |
+| **S2** | No argument-passing form (dispatcher / `.as_func` / cfunc-object) gives both warm-HIT and inlining | **confirmed** — dispatcher: inlined 0.43 ns but MISS (`.nbc` 1→2, address in key); `.as_func`/cfunc: HIT but indirect ~1.9 ns (4.4×). stable-cache XOR inlining |
+| **S3** | B's invalidation is correct only with a co_consts-sensitive digest; bare `co_code` gives a stale false-HIT after a literal edit | **confirmed** — `co_code` digest: false HIT, stale result 30≠45; `cloudpickle.dumps` digest: recompiles, correct 45, stable HIT unchanged |
+| **S4** | Mechanism E (shared cached lifecycle calling user step via `@proxy` extern symbol) caches but is indirect per row | **confirmed** — both warm-HIT, but E=3.02 ns vs B=1.21 ns (2.5×); asm shows `callq *%r13` extern vs B's inlined+unrolled body |
+
+**Rejected non-B mechanisms:** **C** (dispatcher-arg) — uncacheable (S2). **D** (CRE
+import-as-module) — same idea as B but heavier for numbox: needs `cloudpickle` (not in
+the venv), a writable cache package on `sys.path`, and `config.CACHE_DIR` mutation;
+numbox's exec-at-anchor avoids all of it. **E** (proxy extern-symbol) — cacheable but
+indirect per row (S4), fatal for a per-row `step`. **F** (`_PreciseCacheLocator`) — a
+clean way to auto-fold dep bytecode into the cache stamp, but it monkey-patches
+numba-internal cache classes (version-fragile against numbox's `numba<0.66` pin) and
+needs cloudpickle; B's manual digest achieves the same using only the public on-disk
+anchor contract.
+
+**Decision: implement B** — uniquely keeps **both** inlining (S1/S2/S4) and stable,
+bounded cross-process caching (S1), buildable with **zero new infrastructure** (reuses
+`preprocessing.py` `_anchor_path`/`_materialize_anchor`, the `highlevel.py`
+`make_structref` exec-at-anchor recipe, and the `meminfo.py` bridge), and corroborated
+as the right approach by CRE and numbduck.
 
 ## Placement
 
@@ -225,13 +284,19 @@ safety.
 4. **No cross-contamination** — two different UDAFs (different `state_type`s) registered
    in one process give correct independent results (guards C's per-overload specialization).
 5. **Cross-process cache** — a subprocess registers + runs a UDAF twice; correct both
-   times, and the numba cache dir is populated on the second run (validates C's caching
-   claim end-to-end).
-6. **flake8 clean** at `--max-line-length=127`; runs in existing `numbox_ci`
+   times, and on the warm run the target `.nbc` is **loaded, not re-saved** (assert via
+   `NUMBA_DEBUG_CACHE` output or a stable `.nbc` count). Validates B's stable-key claim
+   (spike S1) and guards against a regression to the C failure mode (unbounded `.nbc`).
+6. **Invalidation** — register a UDAF, then edit `step` so only a numeric literal changes
+   (`x*2` → `x*3`); a fresh process must **recompile and return the new result**, not a
+   stale cached one. Guards the co_consts-sensitive digest (spike S3 — a `co_code` digest
+   silently fails this).
+7. **flake8 clean** at `--max-line-length=127`; runs in existing `numbox_ci`
    (which already includes `--durations=20`).
 
-Tests 4–5 are the regression guards for B's per-UDAF specialization and stable
-cross-process caching (the spike that selected B is recorded under "Mechanism").
+Tests 4–6 are the regression guards for B's per-UDAF specialization, stable
+cross-process caching, and correct invalidation (the full mechanism re-review and the
+S1–S4 spikes that selected B are recorded under "Mechanism").
 
 ## Dependencies & sequencing
 

--- a/docs/superpowers/specs/2026-05-29-sqlite-udaf-registration-helper-design.md
+++ b/docs/superpowers/specs/2026-05-29-sqlite-udaf-registration-helper-design.md
@@ -1,0 +1,262 @@
+# SQLite UDAF Registration Helper — Design
+
+**Date:** 2026-05-29
+**Status:** Design approved; pending spec review → implementation plan
+**Builds on:** Phase 2 SQLite UDF/UDAF/window bindings (currently on `feat/sqlite-udf`; upstream PR #17 BLOCKED)
+
+## Goal
+
+Provide a thin, lifecycle-only convenience layer that registers structref-backed
+**aggregate** and **window** user-defined functions from `@njit` code, so users
+no longer hand-write the error-prone state lifecycle that phase 2 requires today.
+
+The helper eliminates the per-callback boilerplate — `sqlite3_aggregate_context`
+allocation + NULL/OOM guard, the single-`intp` slot, init-on-first-step,
+`borrow_structref`, and the **release-in-`xFinal`-but-not-`xValue`** rule — and the
+`cfunc` wrapping + keep-alive + registration call. Users write only their own
+state logic (`init` / `step` / `finalize`, plus `inverse` / `value` for windows).
+
+### Non-goals (out of scope for this work item)
+
+- **Scalar UDFs** — stateless, so there is no lifecycle to manage.
+- **Typed argument/result marshalling** — the user still reads SQL values
+  (`sqlite3_value_*`) and writes results (`sqlite3_result_*`) themselves. A typed
+  layer that generates extraction/result-setting from declared types is a possible
+  future enhancement layered on top, explicitly deferred.
+- **`set_auxdata`/`get_auxdata`** and **`Connection`/`Statement` wrappers** — the
+  other two sibling work items, each their own spec/PR.
+
+## Key decisions
+
+| Decision | Choice |
+|----------|--------|
+| Abstraction level | **Thin (lifecycle-only)** — user does their own value reads / result writes |
+| Scope | **Aggregate + window** (window's release-in-`xFinal`-only rule is the highest-value case) |
+| Entry-point shape | **Two functions** returning a **keep-alive handle** |
+| Wrapper mechanism | **C-primary** (shared cached lifecycle + thin trampolines); **B fallback** (anchored codegen), gated by a spike |
+| Caching | **Yes** — consistent with every phase-1/phase-2 binding |
+| Empty groups | Helper finalizes a fresh `init()` state; user's `finalize`/`value` always receives a valid state |
+
+## Public API
+
+Two Python-level setup functions (run at registration time, before queries), each
+returning a keep-alive handle:
+
+```python
+register_aggregate(db, name, n_arg, state_type, init, step, finalize,
+                   *, deterministic=False) -> handle
+register_window(db, name, n_arg, state_type, init, step, inverse, value, finalize,
+                *, deterministic=False) -> handle
+```
+
+- `db` — connection pointer (`intp`), as returned by `sqlite3_open`.
+- `name` — Python `str`; the helper owns the C-string (`c_string`) lifetime.
+- `n_arg` — argument count; `-1` for variadic.
+- `state_type` — the numba structref **instance** type
+  (e.g. `sum_state_type = SumStateType([("total", int64)])`).
+- `deterministic` — OR-in `SQLITE_DETERMINISTIC`; text encoding fixed to `SQLITE_UTF8`.
+- **Returns** a handle the caller **must retain**. The handle owns the generated
+  `cfunc`s and references to the user functions; dropping it frees the callback
+  pointers SQLite holds → segfault. On a non-`SQLITE_OK` rc, the helper **raises**
+  (this is the ergonomic layer; the low-level bindings still return rc directly for
+  callers who want it).
+
+## User contract (thin / lifecycle-only)
+
+The user supplies `@njit` functions that touch only SQL values/results and their
+own state — never `aggregate_context`, `export_meminfo`, `borrow_structref`, or
+`release_meminfo`:
+
+```python
+def init():                                 # fresh state for a new group
+    return SumState(0)
+
+def step(state, ctx, argc, argv_pp):        # mutate state from the row's args
+    args = carray(_cast_int_to_void_p(argv_pp), (argc,), dtype=np.intp)
+    state.total += sqlite3_value_int64(args[0])
+
+def finalize(state, ctx):                    # read state, set the result
+    sqlite3_result_int64(ctx, state.total)
+```
+
+Window adds two more of the same shape:
+
+- `inverse(state, ctx, argc, argv_pp)` — un-applies a row. The helper guarantees the
+  state already exists (no init-on-first-step here).
+- `value(state, ctx)` — emit the running result **without** finalizing or releasing.
+
+`ctx` is passed to `step`/`inverse` as well (for `sqlite3_user_data` etc.), even
+though aggregates usually ignore it — uniform and flexible.
+
+### What the helper owns
+
+For each callback SQLite invokes, the helper generates the lifecycle (generalized
+verbatim from the phase-2 hand-written test code). Every callback guards the NULL
+`aggregate_context` **before** indexing the slot — `carray` on a NULL pointer
+segfaults, and for an empty group `aggregate_context(ctx, 0)` returns NULL (no prior
+allocation), so the NULL check *is* the empty-group signal:
+
+- **`xStep`**: `agg = aggregate_context(ctx, 8)`; if `agg == 0` return (OOM);
+  `slot = carray(agg, (1,), intp)`; if `slot[0] == 0`: `slot[0] = export_meminfo(init())`;
+  `state = borrow_structref(state_type, slot[0])`; `step(state, ctx, argc, argv_pp)`.
+- **`xInverse`** (window): `agg = aggregate_context(ctx, 0)`; if `agg == 0` return;
+  `slot = carray(agg, (1,), intp)`; if `slot[0] == 0` return;
+  `inverse(borrow_structref(state_type, slot[0]), ctx, argc, argv_pp)`.
+- **`xValue`** (window): `agg = aggregate_context(ctx, 0)`; if `agg == 0` ⇒
+  `value(init(), ctx)`, return; `slot = carray(agg, (1,), intp)`; if `slot[0] == 0` ⇒
+  `value(init(), ctx)`, return; else `value(borrow_structref(state_type, slot[0]), ctx)`
+  — **no release**.
+- **`xFinal`**: `agg = aggregate_context(ctx, 0)`; if `agg == 0` ⇒ `finalize(init(), ctx)`,
+  return; `slot = carray(agg, (1,), intp)`; if `slot[0] == 0` ⇒ `finalize(init(), ctx)`,
+  return; else `finalize(borrow_structref(state_type, slot[0]), ctx)`;
+  `release_meminfo(slot[0])`.
+
+**Empty groups.** SQLite calls `xFinal` (and may call `xValue`) even when `xStep`
+never ran — `aggregate_context(ctx, 0)` then returns NULL (or, in the OOM-after-alloc
+edge case, a zeroed `slot[0] == 0`). In either case the helper finalizes a fresh
+`init()` state — no release, because nothing was exported — so the user's
+`finalize`/`value` always receives a valid `state` and never needs a "no rows" branch.
+
+**Lifecycle correctness.** `export_meminfo`'s +1 incref (on first step) is balanced
+by exactly one `release_meminfo` in `xFinal`. `borrow_structref`'s incref is balanced
+by the local's decref on scope exit (net zero per callback). `xValue` borrows but
+never releases, so window state survives across the many `xValue` calls until the
+single `xFinal`. This is the exact balance the phase-2 `test_udaf_no_meminfo_leak`
+regression guards.
+
+## Mechanism
+
+### C-primary: shared cached lifecycle + thin trampolines
+
+Four **static** `@njit(cache=True)` functions live in the helper module — the
+lifecycle, parameterized by `state_type` (a `TypeRef` argument, exactly as
+`borrow_structref` already takes it) and the user functions (passed as values):
+
+```python
+_agg_step(state_type, init, step,      ctx, argc, argv_pp)
+_agg_inverse(state_type, inverse,      ctx, argc, argv_pp)
+_agg_value(state_type, init, value,    ctx)
+_agg_final(state_type, init, finalize, ctx)
+```
+
+Because `state_type`/`init`/`step` are **arguments**, numba specializes each UDAF
+into a **distinct overload** (distinct `TypeRef`, distinct function types) under the
+module's own filename, so numba's **normal per-overload cache** handles it — no
+content-addressing, no anchor files. Invalidation is **automatic**: the user
+functions are genuine compile dependencies, so editing `step` restamps and recompiles.
+The expensive compilation (lifecycle + the user's `@njit(cache=True)` logic) is cached
+across cold starts.
+
+Per registration, the helper builds the trivial `cfunc`s SQLite needs — each binds
+this UDAF's `state_type` + user fns and forwards into the cached lifecycle:
+
+```python
+_step_cb = cfunc(types.void(types.intp, types.int32, types.intp))(
+    lambda ctx, argc, argv: _agg_step(state_type, init, step, ctx, argc, argv))
+```
+
+These trampolines share an identical C signature across UDAFs, so they cannot be
+cache-shared — they are **`cache=False`**. That is acceptable: each body is a single
+forwarding call and the callee loads from cache, so per-process recompile cost is
+negligible. Registration then calls `sqlite3_create_function_v2` (aggregate) or
+`sqlite3_create_window_function` (window) with
+`flags = SQLITE_UTF8 | (SQLITE_DETERMINISTIC if deterministic)`, `p_app=0`,
+`xDestroy=0`; the handle keeps the `cfunc`s and user-fn references alive.
+
+### Why this resolves the caching hazard
+
+Dynamically generated numba callbacks collide in the cache because numba keys an
+overload on `(filename, firstlineno, bytecode, signature)`, and **all four callbacks
+share the identical C signature** `void(intp, int32, intp)` (or `void(intp)`). A naive
+closure makes it worse — the wrapper's *code object is byte-identical* across every
+UDAF, only the captured freevars differ — so numba would serve the wrong cached
+machine code. C **dissolves** this by lifting the per-UDAF variation into
+signature-differentiating arguments. (The alternative, B, *works around* the symptom
+with content-addressed filenames.)
+
+### B fallback: anchored codegen
+
+If the spike rules C out, fall back to generating each callback's source as text per
+UDAF, injecting `state_type`/user fns into the exec namespace, writing to a
+content-addressed anchor file via `numbox/utils/preprocessing.py`'s
+`_anchor_path`/`_materialize_anchor` (new subdir `numbox-sqlite-udaf`), and
+`cfunc(cache=True)`. **Correctness requirement:** the digest must fold in a hash of
+the user functions' bytecode + the `state_type` repr, both so two byte-identical
+generated blocks don't collide and so editing `step` invalidates — numba will not see
+the user fns as dependencies of generated text on its own.
+
+The **public API and user contract are identical** under C or B; the choice is purely
+internal.
+
+### Spike (first implementation task) and decision rule
+
+C rests on numba behavior to be **verified, not assumed**. Build the C skeleton for a
+`sum` aggregate and measure:
+
+1. **Composition + caching** — a `cfunc` trampoline calling a cached `@njit` lifecycle
+   with `TypeRef` + function-value args composes, runs correctly, and the lifecycle
+   *loads from cache* on a second process.
+2. **Per-row cost** — whether the user-fn call inlines or is indirect. Passing the user
+   fns as **njit dispatchers** (each its own compile-time `Dispatcher` type) may yield
+   both clean caching *and* an inlinable direct call; passing them as `.as_func`
+   function-values is definitely indirect. Measure the per-row delta on a realistic
+   aggregate.
+
+**Decision rule:** ship **C** unless the spike shows it cannot compose, or the
+indirect-call cost is material on a realistic aggregate — in which case fall back to **B**.
+
+## Placement
+
+- New module **`numbox/core/bindings/_sqlite_udf_helpers.py`**, alongside the
+  `_sqlite_*` family (all sqlite code lives under `core/bindings/`; no new top-level
+  subpackage).
+- Public `register_aggregate` / `register_window` in `__all__`, star-imported via
+  `numbox/core/bindings/__init__.py` (same pattern as `_sqlite_udf`). The keep-alive
+  handle class is returned but **not** in `__all__` — users hold it, never construct it.
+- **Docs (mandatory):** a new `_*.py` module requires an `automodule` section in
+  `docs/numbox.core.bindings.rst` plus the "Bindings module conventions" family entry,
+  then `sphinx-build` exit 0 — per the CLAUDE.md "Adding a New Binding" doc rule.
+
+## Error handling
+
+- **Registration failure:** non-`SQLITE_OK` rc ⇒ raise `RuntimeError` with the rc and
+  `sqlite3_errmsg(db)` decoded immediately (phase-2 errmsg-lifetime gotcha).
+- **Input validation (raised at registration, clear messages):** `state_type` is a
+  structref instance type; `register_window` received all five callbacks; the user
+  functions are passable into the lifecycle (if the spike selects the dispatcher path
+  and a function lacks the required form, say so explicitly rather than emit a cryptic
+  numba typing error).
+- **Runtime (inside callbacks):** NULL `aggregate_context` (OOM) ⇒ early return, matching
+  the phase-2 tests. Empty group is **not** an error — it is the `init()`-fresh-state path.
+- **Keep-alive:** the handle docstring states loudly that dropping it frees the callback
+  pointers (segfault). This is the one contract the user must honor.
+
+## Testing & success criteria
+
+The bar is: the helper reproduces the phase-2 hand-written results with the same memory
+safety.
+
+1. **Behavioral parity** — port `test_udaf_sum_structref` (→ 15),
+   `test_udaf_empty_group` (→ 0), and `test_window_running_sum` (→ `[1,3,5,7,9]`) to the
+   helper; assert identical results.
+2. **Leak regression** — the helper version of `test_udaf_no_meminfo_leak`: many
+   iterations ⇒ `mi_alloc == mi_free`. Proof the helper preserves the `export`/`release`
+   balance and the release-in-`xFinal`-only rule.
+3. **`deterministic=True`** registers cleanly and computes correctly.
+4. **No cross-contamination** — two different UDAFs (different `state_type`s) registered
+   in one process give correct independent results (guards C's per-overload specialization).
+5. **Cross-process cache** — a subprocess registers + runs a UDAF twice; correct both
+   times, and the numba cache dir is populated on the second run (validates C's caching
+   claim end-to-end).
+6. **flake8 clean** at `--max-line-length=127`; runs in existing `numbox_ci`
+   (which already includes `--durations=20`).
+
+Tests 4–5 plus the spike are the C-vs-B decision evidence.
+
+## Dependencies & sequencing
+
+This work sits on phase-2 modules that currently exist **only on `feat/sqlite-udf`**
+(upstream PR #17 BLOCKED). Implementation therefore branches off `feat/sqlite-udf`, not
+`origin/main`. The **wait-for-#17-merge vs. develop-now-and-rebase** call, and the
+upstream-PR-branch strategy, are made at the writing-plans → execute boundary per the
+standing numbox workflow rules. The spec itself is independent of phase-2's merge status.

--- a/numbox/core/bindings/__init__.py
+++ b/numbox/core/bindings/__init__.py
@@ -11,6 +11,7 @@ from numbox.core.bindings._sqlite_hooks import *  # noqa: F401, F403
 from numbox.core.bindings._sqlite_value import *  # noqa: F401, F403
 from numbox.core.bindings._sqlite_result import *  # noqa: F401, F403
 from numbox.core.bindings._sqlite_udf import *  # noqa: F401, F403
+from numbox.core.bindings._sqlite_udf_helpers import *  # noqa: F401, F403
 from numbox.core.bindings._stdio import *  # noqa: F401, F403
 from numbox.core.bindings._errno import *  # noqa: F401, F403
 from numbox.core.bindings._strerror import *  # noqa: F401, F403

--- a/numbox/core/bindings/_sqlite_exec.py
+++ b/numbox/core/bindings/_sqlite_exec.py
@@ -17,6 +17,14 @@ Produce the callback address from Python via:
     @cfunc(int32(voidptr, int32, intp, intp))
     def my_row_cb(ctx, n, values_pp, names_pp): ...
     sqlite3_exec(db, sql, my_row_cb.address, ctx_p, errmsg_pp)
+
+Exception handling: a numba @cfunc swallows any exception raised by its body (it
+prints "Exception ignored" and returns the zero default = 0 = "continue"), so an
+intended abort is silently suppressed and iteration proceeds. The row callback
+has no sqlite3_context, so the return code is the only channel: wrap the body in
+a bare try/except (never try/finally) and return NONZERO from the except to force
+SQLITE_ABORT. The same guard also prevents an NRT meminfo leak when the body
+holds an array / list / structref live across a call that raises.
 """
 from numbox.core.bindings.call import _call_lib_func
 from numbox.core.bindings.signatures import signatures

--- a/numbox/core/bindings/_sqlite_hooks.py
+++ b/numbox/core/bindings/_sqlite_hooks.py
@@ -12,6 +12,22 @@ Callback shapes (informational; signatures are caller's responsibility):
 - commit_hook:       int(void*) -- nonzero vetoes commit
 - rollback_hook:     void(void*)
 - trace_v2:          int(unsigned, void*, void*, void*)
+
+Exception handling: a numba @cfunc swallows any exception raised by its body (it
+prints "Exception ignored" and returns the zero default -- 0 for the int hooks,
+nothing for the void hooks) without unwinding into SQLite. None of these hooks
+receive an sqlite3_context, so sqlite3_result_error is NOT available -- the only
+channel is the return code (or nothing, for the void hooks). Guard the body with
+a bare try/except (never try/finally) and choose the except's return per hook:
+
+- commit_hook: return NONZERO to veto (else a raising veto silently COMMITS).
+- progress_handler: return NONZERO to interrupt (else a raising cancel is lost).
+- busy_handler: return 0 to give up (SQLITE_BUSY) or nonzero to retry.
+- trace_v2: return 0 (SQLite currently ignores the return value).
+- update_hook / rollback_hook: void, so no error can be signalled to SQLite -- catch internally to avoid the leak below.
+
+The try/except also prevents an NRT meminfo leak when the body holds an
+array / list / structref live across a call that raises.
 """
 from numbox.core.bindings.call import _call_lib_func
 from numbox.core.bindings.signatures import signatures

--- a/numbox/core/bindings/_sqlite_udf.py
+++ b/numbox/core/bindings/_sqlite_udf.py
@@ -8,6 +8,17 @@ sqlite3_context_db_handle -- retrieve db pointer from context.
 
 Callback function pointers are passed as intp obtained from @cfunc(...).address.
 Pass 0 for NULL (no callback / no pApp / no xDestroy).
+
+Exception handling: a numba @cfunc swallows any exception raised by its body (it
+prints "Exception ignored" and returns the zero default without unwinding into
+SQLite), so a raising scalar xFunc reports success to SQLite -- a silent
+wrong/NULL result. xFunc receives an sqlite3_context, so guard the body with a
+bare try/except (never try/finally -- numba rejects re-raising through finally)
+and call sqlite3_result_error / sqlite3_result_error_code in the except to fail
+the query loudly. The same guard also prevents an NRT meminfo leak when the body
+holds an array / list / structref live across a call that raises. The
+structref-backed register_aggregate / register_window helpers already do this
+for the aggregate and window callbacks.
 """
 from numbox.core.bindings.call import _call_lib_func
 from numbox.core.bindings.signatures import signatures

--- a/numbox/core/bindings/_sqlite_udf_helpers.py
+++ b/numbox/core/bindings/_sqlite_udf_helpers.py
@@ -21,17 +21,19 @@ per-group meminfo leak. Only ``xFinal`` releases the slot.
 Mechanism: per-UDAF callback source is generated with the state type and the user functions
 baked in as module globals (so the calls inline), written to a content-addressed
 anchor file under numba's cache dir (reusing numbox.utils.preprocessing), and the
-``@njit(cache=True)`` impls cache across processes. The anchor's content hash
+impls (``@njit(**jit_options)`` -- the numbox-wide config, default ``cache=True``)
+cache across processes. The anchor's content hash
 folds a cloudpickle of the user functions' code objects so editing a body --
 including a numeric literal -- invalidates correctly.
 
 **Caller requirements.** Callbacks may be plain Python functions or already-jitted
 callables (``@njit``/``@proxy``); plain ones are compiled with ``njit`` (see
-``_prepare_callbacks``). The generated ``@njit(cache=True)`` impls cache and
-invalidate correctly even when the state-type class and the callbacks
-are defined in ``__main__`` -- the anchor key is content-addressed on a
-``cloudpickle`` of each callback's ``__code__`` (plus ``repr(state_type)`` and
-the numba/numbox versions), never on ``__module__`` (see ``_digest``); the
+``_prepare_callbacks``). The generated impls (``@njit(**jit_options)``, default
+``cache=True``) cache and invalidate correctly even when the state-type class and
+the callbacks are defined in ``__main__`` -- the anchor key is content-addressed
+on a ``cloudpickle`` of each callback's ``__code__`` (plus ``repr(state_type)``,
+the resolved ``jit_options``, and the numba/numbox versions), never on
+``__module__`` (see ``_digest``); the
 subprocess tests ``test_xprocess_cache_no_growth`` /
 ``test_invalidation_on_literal_edit`` exercise this ``__main__`` path. The one
 case that does require a stable ``__module__`` is a *caller-side*
@@ -49,6 +51,7 @@ from numba.core.types import StructRef
 from numba.extending import is_jitted
 
 import numbox
+from numbox.core.configurations import jit_options
 from numbox.core.bindings._sqlite_conn import sqlite3_errmsg
 from numbox.core.bindings._sqlite_constants import (
     SQLITE_DETERMINISTIC,
@@ -86,10 +89,11 @@ _orphan_anchor_sweep(_ANCHOR_SUBDIR)
 
 
 # Generated-source templates. Baked global names: _state_type, _init, _step,
-# _finalize, _inverse, _value. Each impl is @njit(cache=True) so it caches
-# cross-process; the user fns inline because they are module globals here.
+# _finalize, _inverse, _value, jit_options. Each impl is @njit(**jit_options)
+# (numbox-wide config, default cache=True) so it caches cross-process; the user
+# fns inline because they are module globals here.
 _XSTEP_SRC = '''
-@njit(cache=True)
+@njit(**jit_options)
 def _xstep_impl(ctx, argc, argv_pp):
     agg = sqlite3_aggregate_context(ctx, 8)
     if agg == 0:
@@ -108,7 +112,7 @@ def _xstep_impl(ctx, argc, argv_pp):
 '''
 
 _XFINAL_SRC = '''
-@njit(cache=True)
+@njit(**jit_options)
 def _xfinal_impl(ctx):
     agg = sqlite3_aggregate_context(ctx, 0)
     if agg == 0:
@@ -142,7 +146,7 @@ def _xfinal_impl(ctx):
 '''
 
 _XINVERSE_SRC = '''
-@njit(cache=True)
+@njit(**jit_options)
 def _xinverse_impl(ctx, argc, argv_pp):
     agg = sqlite3_aggregate_context(ctx, 0)
     if agg == 0:
@@ -157,7 +161,7 @@ def _xinverse_impl(ctx, argc, argv_pp):
 '''
 
 _XVALUE_SRC = '''
-@njit(cache=True)
+@njit(**jit_options)
 def _xvalue_impl(ctx):
     agg = sqlite3_aggregate_context(ctx, 0)
     if agg == 0:
@@ -231,7 +235,7 @@ def _prepare_callbacks(**fns):
 def _digest(state_type, fns):
     """Content hash that invalidates when the state type, the user functions
     (co_consts-sensitive, via cloudpickle of the code object -- NOT bare
-    co_code), or the numba/numbox versions change."""
+    co_code), the resolved ``jit_options``, or the numba/numbox versions change."""
     h = hashlib.sha256()
     h.update(repr(state_type).encode("utf-8"))
     h.update(numba.__version__.encode("utf-8"))
@@ -241,6 +245,9 @@ def _digest(state_type, fns):
     # numba version above and the code-object hash below do the real
     # invalidating work (proven by test_invalidation_on_literal_edit).
     h.update((numbox.__version__ or "").encode("utf-8"))
+    # fold the resolved numbox-wide jit_options so flipping NUMBOX_JIT_OPTIONS
+    # (e.g. cache off) re-keys the anchor; numba's own cache also keys on flags.
+    h.update(repr(sorted(jit_options.items())).encode("utf-8"))
     for fn in fns:
         py = getattr(fn, "py_func", fn)
         h.update(cloudpickle.dumps(py.__code__))

--- a/numbox/core/bindings/_sqlite_udf_helpers.py
+++ b/numbox/core/bindings/_sqlite_udf_helpers.py
@@ -5,8 +5,8 @@ functions (xStep/xInverse/xValue/xFinal) that perform the per-group state
 lifecycle -- ``sqlite3_aggregate_context`` allocation + NULL guard, the single
 intp slot, init-on-first-step via ``export_meminfo``, ``borrow_structref``, and
 the release-in-xFinal-but-NOT-xValue rule -- so callers write only their
-``@njit`` ``init``/``step``/``finalize`` (and ``inverse``/``value`` for windows)
-state logic.
+``init``/``step``/``finalize`` (and ``inverse``/``value`` for windows) state
+logic, as plain Python or already-jitted (``@njit``/``@proxy``) functions.
 
 **Exception handling.** Each generated callback wraps the user
 step/inverse/value/finalize call in a ``try``/``except`` that reports a
@@ -26,8 +26,10 @@ anchor file under numba's cache dir (reusing numbox.utils.preprocessing), and th
 folds a cloudpickle of the user functions' code objects so editing a body --
 including a numeric literal -- invalidates correctly.
 
-**Caller requirements.** The generated ``@njit(cache=True)`` impls cache and
-invalidate correctly even when the state-type class and the ``@njit`` callbacks
+**Caller requirements.** Callbacks may be plain Python functions or already-jitted
+callables (``@njit``/``@proxy``); plain ones are compiled with ``njit`` (see
+``_prepare_callbacks``). The generated ``@njit(cache=True)`` impls cache and
+invalidate correctly even when the state-type class and the callbacks
 are defined in ``__main__`` -- the anchor key is content-addressed on a
 ``cloudpickle`` of each callback's ``__code__`` (plus ``repr(state_type)`` and
 the numba/numbox versions), never on ``__module__`` (see ``_digest``); the
@@ -207,14 +209,24 @@ def _validate_state_type(state_type):
             "(e.g. MyStateType([('x', int64)])), got %r" % (state_type,))
 
 
-def _validate_callbacks(**fns):
-    """Reject non-``@njit`` callbacks up front with a clear message; otherwise a
-    plain Python callable surfaces as a cryptic numba ``TypingError`` when it
-    fails to bake into the generated source."""
+def _prepare_callbacks(**fns):
+    """Return ``fns`` with each callback ensured numba-compiled: an already
+    jitted callable (``@njit``, ``@proxy``, ...) passes through; a plain Python
+    function is wrapped with ``njit``. The callbacks are inlined into the
+    generated ``@njit(cache=True)`` impls, so a lazy ``njit`` (no explicit
+    signature) suffices -- the impl drives specialization -- and the
+    content-addressed anchor (keyed on ``py_func.__code__``) provides the
+    cross-process caching, so callbacks need no ``cache=True`` of their own."""
+    prepared = {}
     for role, fn in fns.items():
-        if not is_jitted(fn):
+        if is_jitted(fn):
+            prepared[role] = fn
+        elif callable(fn):
+            prepared[role] = njit(fn)
+        else:
             raise TypeError(
-                "%s must be an @njit-compiled function, got %r" % (role, fn))
+                "%s must be a callable (plain Python or @njit), got %r" % (role, fn))
+    return prepared
 
 
 def _digest(state_type, fns):
@@ -271,21 +283,24 @@ def register_aggregate(db, name, n_arg, state_type, init, step, finalize,
                        *, deterministic=False):
     """Register a structref-backed aggregate UDAF.
 
+    Callbacks may be plain Python or already-jitted (``@njit``/``@proxy``); plain
+    functions are compiled with ``njit``.
+
     :param db: connection pointer (intp), as returned by ``sqlite3_open``.
     :param name: SQL function name (str); the C-string lifetime is handled here.
     :param n_arg: argument count, or -1 for variadic.
     :param state_type: the numba structref *instance* type for per-group state.
-    :param init: ``@njit`` ``() -> state`` returning a fresh state.
-    :param step: ``@njit`` ``(state, ctx, argc, argv_pp)`` updating state.
-    :param finalize: ``@njit`` ``(state, ctx)`` writing the result.
+    :param init: ``() -> state`` returning a fresh state.
+    :param step: ``(state, ctx, argc, argv_pp)`` updating state.
+    :param finalize: ``(state, ctx)`` writing the result.
     :param deterministic: OR-in ``SQLITE_DETERMINISTIC``.
     :returns: a keep-alive handle the caller MUST retain (see ``_UDAFHandle``).
     """
     _validate_state_type(state_type)
-    _validate_callbacks(init=init, step=step, finalize=finalize)
+    fns = _prepare_callbacks(init=init, step=step, finalize=finalize)
     ns = _compile_callbacks(
         _stem("udaf_", name), [_XSTEP_SRC, _XFINAL_SRC], state_type,
-        {"_init": init, "_step": step, "_finalize": finalize})
+        {"_init": fns["init"], "_step": fns["step"], "_finalize": fns["finalize"]})
     xstep_impl = ns["_xstep_impl"]
     xfinal_impl = ns["_xfinal_impl"]
 
@@ -305,7 +320,7 @@ def register_aggregate(db, name, n_arg, state_type, init, step, finalize,
     if rc != SQLITE_OK:
         _raise_rc(db, name, rc)
     return _UDAFHandle(step_cb, final_cb, xstep_impl, xfinal_impl,
-                       init, step, finalize)
+                       fns["init"], fns["step"], fns["finalize"])
 
 
 def register_window(db, name, n_arg, state_type, init, step, inverse, value,
@@ -318,13 +333,13 @@ def register_window(db, name, n_arg, state_type, init, step, inverse, value,
     releases the meminfo.
     """
     _validate_state_type(state_type)
-    _validate_callbacks(init=init, step=step, inverse=inverse, value=value,
-                        finalize=finalize)
+    fns = _prepare_callbacks(init=init, step=step, inverse=inverse, value=value,
+                             finalize=finalize)
     ns = _compile_callbacks(
         _stem("wudaf_", name),
         [_XSTEP_SRC, _XINVERSE_SRC, _XVALUE_SRC, _XFINAL_SRC], state_type,
-        {"_init": init, "_step": step, "_inverse": inverse,
-         "_value": value, "_finalize": finalize})
+        {"_init": fns["init"], "_step": fns["step"], "_inverse": fns["inverse"],
+         "_value": fns["value"], "_finalize": fns["finalize"]})
     xstep_impl = ns["_xstep_impl"]
     xinverse_impl = ns["_xinverse_impl"]
     xvalue_impl = ns["_xvalue_impl"]
@@ -356,4 +371,5 @@ def register_window(db, name, n_arg, state_type, init, step, inverse, value,
         _raise_rc(db, name, rc)
     return _UDAFHandle(step_cb, inverse_cb, value_cb, final_cb,
                        xstep_impl, xinverse_impl, xvalue_impl, xfinal_impl,
-                       init, step, inverse, value, finalize)
+                       fns["init"], fns["step"], fns["inverse"],
+                       fns["value"], fns["finalize"])

--- a/numbox/core/bindings/_sqlite_udf_helpers.py
+++ b/numbox/core/bindings/_sqlite_udf_helpers.py
@@ -18,8 +18,7 @@ be a silent wrong result; the in-body catch also lets numba run the borrowed
 state's reference-count decrement, which the unwind would otherwise skip -- a
 per-group meminfo leak. Only ``xFinal`` releases the slot.
 
-Mechanism (see docs/superpowers/specs/2026-05-29-sqlite-udaf-registration-helper-design.md):
-per-UDAF callback source is generated with the state type and the user functions
+Mechanism: per-UDAF callback source is generated with the state type and the user functions
 baked in as module globals (so the calls inline), written to a content-addressed
 anchor file under numba's cache dir (reusing numbox.utils.preprocessing), and the
 ``@njit(cache=True)`` impls cache across processes. The anchor's content hash

--- a/numbox/core/bindings/_sqlite_udf_helpers.py
+++ b/numbox/core/bindings/_sqlite_udf_helpers.py
@@ -194,17 +194,6 @@ def _xvalue_impl(ctx):
 '''
 
 
-class _UDAFHandle:
-    """Keeps the generated ``cfunc`` callbacks (and the user functions they bake
-    in) alive. SQLite holds raw pointers to the cfuncs; if this handle is
-    garbage-collected the pointers dangle and the next call segfaults. **The
-    caller MUST retain the returned handle for as long as the UDAF is used.**"""
-    __slots__ = ("_keep",)
-
-    def __init__(self, *objs):
-        self._keep = objs
-
-
 def _validate_state_type(state_type):
     if not isinstance(state_type, StructRef):
         raise TypeError(
@@ -300,7 +289,9 @@ def register_aggregate(db, name, n_arg, state_type, init, step, finalize,
     :param step: ``(state, ctx, argc, argv_pp)`` updating state.
     :param finalize: ``(state, ctx)`` writing the result.
     :param deterministic: OR-in ``SQLITE_DETERMINISTIC``.
-    :returns: a keep-alive handle the caller MUST retain (see ``_UDAFHandle``).
+
+    Returns ``None``; the generated callbacks need not be retained -- numba keeps
+    the compiled cfunc code and dispatchers resident for the process lifetime.
     """
     _validate_state_type(state_type)
     fns = _prepare_callbacks(init=init, step=step, finalize=finalize)
@@ -325,8 +316,6 @@ def register_aggregate(db, name, n_arg, state_type, init, step, finalize,
             step_cb.address, final_cb.address, 0)
     if rc != SQLITE_OK:
         _raise_rc(db, name, rc)
-    return _UDAFHandle(step_cb, final_cb, xstep_impl, xfinal_impl,
-                       fns["init"], fns["step"], fns["finalize"])
 
 
 def register_window(db, name, n_arg, state_type, init, step, inverse, value,
@@ -375,7 +364,3 @@ def register_window(db, name, n_arg, state_type, init, step, inverse, value,
             value_cb.address, inverse_cb.address, 0)
     if rc != SQLITE_OK:
         _raise_rc(db, name, rc)
-    return _UDAFHandle(step_cb, inverse_cb, value_cb, final_cb,
-                       xstep_impl, xinverse_impl, xvalue_impl, xfinal_impl,
-                       fns["init"], fns["step"], fns["inverse"],
-                       fns["value"], fns["finalize"])

--- a/numbox/core/bindings/_sqlite_udf_helpers.py
+++ b/numbox/core/bindings/_sqlite_udf_helpers.py
@@ -16,13 +16,20 @@ anchor file under numba's cache dir (reusing numbox.utils.preprocessing), and th
 folds a cloudpickle of the user functions' code objects so editing a body --
 including a numeric literal -- invalidates correctly.
 
-**Caller requirements.** The state-type class and the ``@njit`` functions MUST
-live in an importable module (stable ``__module__``, not ``__main__``); this is a
-precondition for numba caching of any generated code that references them.
+**Caller requirements.** The generated ``@njit(cache=True)`` impls cache and
+invalidate correctly even when the state-type class and the ``@njit`` callbacks
+are defined in ``__main__`` -- the anchor key is content-addressed on a
+``cloudpickle`` of each callback's ``__code__`` (plus ``repr(state_type)`` and
+the numba/numbox versions), never on ``__module__`` (see ``_digest``); the
+subprocess tests ``test_xprocess_cache_no_growth`` /
+``test_invalidation_on_literal_edit`` exercise this ``__main__`` path. The one
+case that does require a stable ``__module__`` is a *caller-side*
+``@njit(cache=True)`` callback -- numba refuses to cache functions defined in
+``__main__`` -- so for deployments where callbacks are themselves cached, define
+the state-type class and callbacks in an importable module.
 """
 import ctypes
 import hashlib
-from inspect import getmodule
 
 import numba
 from numba import cfunc, types
@@ -52,6 +59,8 @@ from numbox.utils.preprocessing import (
 # puts them in this module's __dict__, which seeds the exec namespace below.
 import numpy as np  # noqa: F401
 from numba import carray, njit  # noqa: F401
+from numbox.core.bindings._sqlite_constants import SQLITE_ERROR  # noqa: F401
+from numbox.core.bindings._sqlite_result import sqlite3_result_error_code  # noqa: F401
 from numbox.core.bindings._sqlite_udf import sqlite3_aggregate_context  # noqa: F401
 from numbox.utils.lowlevel import _cast_int_to_void_p  # noqa: F401
 from numbox.utils.meminfo import (  # noqa: F401
@@ -64,14 +73,6 @@ __all__ = ["register_aggregate", "register_window"]
 
 _ANCHOR_SUBDIR = "numbox-sqlite-udaf"
 _orphan_anchor_sweep(_ANCHOR_SUBDIR)
-
-
-def _file_anchor():
-    """Identity handle whose module __dict__ (this module's globals, incl.
-    ``__name__``) seeds the generated code's exec namespace. Mirrors
-    ``numbox.utils.highlevel.make_structref``; the ``__name__`` is required or
-    the warm cache reload aborts in numba's Environment rebuild."""
-    raise NotImplementedError
 
 
 # Generated-source templates. Baked global names: _state_type, _init, _step,
@@ -100,7 +101,10 @@ def _xfinal_impl(ctx):
     if slot[0] == 0:
         _finalize(_init(), ctx)
         return
-    _finalize(borrow_structref(_state_type, slot[0]), ctx)
+    try:
+        _finalize(borrow_structref(_state_type, slot[0]), ctx)
+    except Exception:
+        sqlite3_result_error_code(ctx, SQLITE_ERROR)  # fail the query, never leak the slot
     release_meminfo(slot[0])
 '''
 
@@ -185,7 +189,9 @@ def _compile_callbacks(stem, srcs, state_type, fns):
     callables. Returns the exec namespace (contains ``_xstep_impl`` etc.)."""
     digest = _digest(state_type, list(fns.values()))
     code_txt = "# udaf-digest: %s\n%s" % (digest, "".join(srcs))
-    ns = {**getmodule(_file_anchor).__dict__, "_state_type": state_type, **fns}
+    # globals() is this module's __dict__; it carries __name__, which numba's
+    # warm-cache Environment rebuild requires when reloading the cached impls.
+    ns = {**globals(), "_state_type": state_type, **fns}
     anchor = _anchor_path(_ANCHOR_SUBDIR, stem, code_txt)
     _materialize_anchor(anchor, code_txt)
     code = compile(code_txt, str(anchor), mode="exec")

--- a/numbox/core/bindings/_sqlite_udf_helpers.py
+++ b/numbox/core/bindings/_sqlite_udf_helpers.py
@@ -103,6 +103,32 @@ def _xfinal_impl(ctx):
     release_meminfo(slot[0])
 '''
 
+_XINVERSE_SRC = '''
+@njit(cache=True)
+def _xinverse_impl(ctx, argc, argv_pp):
+    agg = sqlite3_aggregate_context(ctx, 0)
+    if agg == 0:
+        return
+    slot = carray(_cast_int_to_void_p(agg), (1,), dtype=np.intp)
+    if slot[0] == 0:
+        return
+    _inverse(borrow_structref(_state_type, slot[0]), ctx, argc, argv_pp)
+'''
+
+_XVALUE_SRC = '''
+@njit(cache=True)
+def _xvalue_impl(ctx):
+    agg = sqlite3_aggregate_context(ctx, 0)
+    if agg == 0:
+        _value(_init(), ctx)
+        return
+    slot = carray(_cast_int_to_void_p(agg), (1,), dtype=np.intp)
+    if slot[0] == 0:
+        _value(_init(), ctx)
+        return
+    _value(borrow_structref(_state_type, slot[0]), ctx)
+'''
+
 
 class _UDAFHandle:
     """Keeps the generated ``cfunc`` callbacks (and the user functions they bake
@@ -203,3 +229,52 @@ def register_aggregate(db, name, n_arg, state_type, init, step, finalize,
         _raise_rc(db, name, rc)
     return _UDAFHandle(step_cb, final_cb, xstep_impl, xfinal_impl,
                        init, step, finalize)
+
+
+def register_window(db, name, n_arg, state_type, init, step, inverse, value,
+                    finalize, *, deterministic=False):
+    """Register a structref-backed window UDAF.
+
+    Same as :func:`register_aggregate` plus ``inverse(state, ctx, argc,
+    argv_pp)`` (un-applies a row; state already exists) and ``value(state,
+    ctx)`` (emits the running result WITHOUT releasing). Only ``xFinal``
+    releases the meminfo.
+    """
+    _validate_state_type(state_type)
+    ns = _compile_callbacks(
+        _stem("wudaf_", name),
+        [_XSTEP_SRC, _XINVERSE_SRC, _XVALUE_SRC, _XFINAL_SRC], state_type,
+        {"_init": init, "_step": step, "_inverse": inverse,
+         "_value": value, "_finalize": finalize})
+    xstep_impl = ns["_xstep_impl"]
+    xinverse_impl = ns["_xinverse_impl"]
+    xvalue_impl = ns["_xvalue_impl"]
+    xfinal_impl = ns["_xfinal_impl"]
+
+    @cfunc(types.void(types.intp, types.int32, types.intp))
+    def step_cb(ctx, argc, argv):
+        xstep_impl(ctx, argc, argv)
+
+    @cfunc(types.void(types.intp, types.int32, types.intp))
+    def inverse_cb(ctx, argc, argv):
+        xinverse_impl(ctx, argc, argv)
+
+    @cfunc(types.void(types.intp))
+    def value_cb(ctx):
+        xvalue_impl(ctx)
+
+    @cfunc(types.void(types.intp))
+    def final_cb(ctx):
+        xfinal_impl(ctx)
+
+    flags = SQLITE_UTF8 | (SQLITE_DETERMINISTIC if deterministic else 0)
+    with c_string(name) as name_p:
+        rc = sqlite3_create_window_function(
+            db, name_p, n_arg, flags, 0,
+            step_cb.address, final_cb.address,
+            value_cb.address, inverse_cb.address, 0)
+    if rc != SQLITE_OK:
+        _raise_rc(db, name, rc)
+    return _UDAFHandle(step_cb, inverse_cb, value_cb, final_cb,
+                       xstep_impl, xinverse_impl, xvalue_impl, xfinal_impl,
+                       init, step, inverse, value, finalize)

--- a/numbox/core/bindings/_sqlite_udf_helpers.py
+++ b/numbox/core/bindings/_sqlite_udf_helpers.py
@@ -1,0 +1,205 @@
+"""Higher-level registration helpers for structref-backed SQLite UDAFs.
+
+``register_aggregate`` / ``register_window`` generate the SQLite callback
+functions (xStep/xInverse/xValue/xFinal) that perform the per-group state
+lifecycle -- ``sqlite3_aggregate_context`` allocation + NULL guard, the single
+intp slot, init-on-first-step via ``export_meminfo``, ``borrow_structref``, and
+the release-in-xFinal-but-NOT-xValue rule -- so callers write only their
+``@njit`` ``init``/``step``/``finalize`` (and ``inverse``/``value`` for windows)
+state logic.
+
+Mechanism (see docs/superpowers/specs/2026-05-29-sqlite-udaf-registration-helper-design.md):
+per-UDAF callback source is generated with the state type and the user functions
+baked in as module globals (so the calls inline), written to a content-addressed
+anchor file under numba's cache dir (reusing numbox.utils.preprocessing), and the
+``@njit(cache=True)`` impls cache across processes. The anchor's content hash
+folds a cloudpickle of the user functions' code objects so editing a body --
+including a numeric literal -- invalidates correctly.
+
+**Caller requirements.** The state-type class and the ``@njit`` functions MUST
+live in an importable module (stable ``__module__``, not ``__main__``); this is a
+precondition for numba caching of any generated code that references them.
+"""
+import ctypes
+import hashlib
+from inspect import getmodule
+
+import numba
+from numba import cfunc, types
+from numba.core.serialize import cloudpickle
+from numba.core.types import StructRef
+
+import numbox
+from numbox.core.bindings._sqlite_conn import sqlite3_errmsg
+from numbox.core.bindings._sqlite_constants import (
+    SQLITE_DETERMINISTIC,
+    SQLITE_OK,
+    SQLITE_UTF8,
+)
+from numbox.core.bindings._sqlite_udf import (
+    sqlite3_create_function_v2,
+    sqlite3_create_window_function,
+)
+from numbox.utils.cstrings import c_string
+from numbox.utils.preprocessing import (
+    _anchor_path,
+    _materialize_anchor,
+    _orphan_anchor_sweep,
+)
+
+# These names are referenced by the GENERATED anchor source; importing them here
+# puts them in this module's __dict__, which seeds the exec namespace below.
+import numpy as np  # noqa: F401
+from numba import carray, njit  # noqa: F401
+from numbox.core.bindings._sqlite_udf import sqlite3_aggregate_context  # noqa: F401
+from numbox.utils.lowlevel import _cast_int_to_void_p  # noqa: F401
+from numbox.utils.meminfo import (  # noqa: F401
+    borrow_structref,
+    export_meminfo,
+    release_meminfo,
+)
+
+__all__ = ["register_aggregate", "register_window"]
+
+_ANCHOR_SUBDIR = "numbox-sqlite-udaf"
+_orphan_anchor_sweep(_ANCHOR_SUBDIR)
+
+
+def _file_anchor():
+    """Identity handle whose module __dict__ (this module's globals, incl.
+    ``__name__``) seeds the generated code's exec namespace. Mirrors
+    ``numbox.utils.highlevel.make_structref``; the ``__name__`` is required or
+    the warm cache reload aborts in numba's Environment rebuild."""
+    raise NotImplementedError
+
+
+# Generated-source templates. Baked global names: _state_type, _init, _step,
+# _finalize, _inverse, _value. Each impl is @njit(cache=True) so it caches
+# cross-process; the user fns inline because they are module globals here.
+_XSTEP_SRC = '''
+@njit(cache=True)
+def _xstep_impl(ctx, argc, argv_pp):
+    agg = sqlite3_aggregate_context(ctx, 8)
+    if agg == 0:
+        return
+    slot = carray(_cast_int_to_void_p(agg), (1,), dtype=np.intp)
+    if slot[0] == 0:
+        slot[0] = export_meminfo(_init())
+    _step(borrow_structref(_state_type, slot[0]), ctx, argc, argv_pp)
+'''
+
+_XFINAL_SRC = '''
+@njit(cache=True)
+def _xfinal_impl(ctx):
+    agg = sqlite3_aggregate_context(ctx, 0)
+    if agg == 0:
+        _finalize(_init(), ctx)
+        return
+    slot = carray(_cast_int_to_void_p(agg), (1,), dtype=np.intp)
+    if slot[0] == 0:
+        _finalize(_init(), ctx)
+        return
+    _finalize(borrow_structref(_state_type, slot[0]), ctx)
+    release_meminfo(slot[0])
+'''
+
+
+class _UDAFHandle:
+    """Keeps the generated ``cfunc`` callbacks (and the user functions they bake
+    in) alive. SQLite holds raw pointers to the cfuncs; if this handle is
+    garbage-collected the pointers dangle and the next call segfaults. **The
+    caller MUST retain the returned handle for as long as the UDAF is used.**"""
+    __slots__ = ("_keep",)
+
+    def __init__(self, *objs):
+        self._keep = objs
+
+
+def _validate_state_type(state_type):
+    if not isinstance(state_type, StructRef):
+        raise TypeError(
+            "state_type must be a numba StructRef instance "
+            "(e.g. MyStateType([('x', int64)])), got %r" % (state_type,))
+
+
+def _digest(state_type, fns):
+    """Content hash that invalidates when the state type, the user functions
+    (co_consts-sensitive, via cloudpickle of the code object -- NOT bare
+    co_code), or the numba/numbox versions change."""
+    h = hashlib.sha256()
+    h.update(repr(state_type).encode("utf-8"))
+    h.update(numba.__version__.encode("utf-8"))
+    h.update((numbox.__version__ or "").encode("utf-8"))
+    for fn in fns:
+        py = getattr(fn, "py_func", fn)
+        h.update(cloudpickle.dumps(py.__code__))
+    return h.hexdigest()[:16]
+
+
+def _compile_callbacks(stem, srcs, state_type, fns):
+    """Generate + content-address-anchor + exec the @njit(cache=True) impls.
+
+    ``fns`` maps generated global names (``_init``, ``_step``, ...) to user
+    callables. Returns the exec namespace (contains ``_xstep_impl`` etc.)."""
+    digest = _digest(state_type, list(fns.values()))
+    code_txt = "# udaf-digest: %s\n%s" % (digest, "".join(srcs))
+    ns = {**getmodule(_file_anchor).__dict__, "_state_type": state_type, **fns}
+    anchor = _anchor_path(_ANCHOR_SUBDIR, stem, code_txt)
+    _materialize_anchor(anchor, code_txt)
+    code = compile(code_txt, str(anchor), mode="exec")
+    exec(code, ns)  # nosec B102 - JIT codegen of internal source
+    return ns
+
+
+def _raise_rc(db, name, rc):
+    msg_p = sqlite3_errmsg(db)
+    detail = ""
+    if msg_p:
+        detail = ": " + ctypes.cast(
+            msg_p, ctypes.c_char_p).value.decode("utf-8", "replace")
+    raise RuntimeError(
+        "sqlite3 UDAF registration failed for %r (rc=%d)%s" % (name, rc, detail))
+
+
+def _stem(prefix, name):
+    return prefix + "".join(c if c.isalnum() else "_" for c in name)
+
+
+def register_aggregate(db, name, n_arg, state_type, init, step, finalize,
+                       *, deterministic=False):
+    """Register a structref-backed aggregate UDAF.
+
+    :param db: connection pointer (intp), as returned by ``sqlite3_open``.
+    :param name: SQL function name (str); the C-string lifetime is handled here.
+    :param n_arg: argument count, or -1 for variadic.
+    :param state_type: the numba structref *instance* type for per-group state.
+    :param init: ``@njit`` ``() -> state`` returning a fresh state.
+    :param step: ``@njit`` ``(state, ctx, argc, argv_pp)`` updating state.
+    :param finalize: ``@njit`` ``(state, ctx)`` writing the result.
+    :param deterministic: OR-in ``SQLITE_DETERMINISTIC``.
+    :returns: a keep-alive handle the caller MUST retain (see ``_UDAFHandle``).
+    """
+    _validate_state_type(state_type)
+    ns = _compile_callbacks(
+        _stem("udaf_", name), [_XSTEP_SRC, _XFINAL_SRC], state_type,
+        {"_init": init, "_step": step, "_finalize": finalize})
+    xstep_impl = ns["_xstep_impl"]
+    xfinal_impl = ns["_xfinal_impl"]
+
+    @cfunc(types.void(types.intp, types.int32, types.intp))
+    def step_cb(ctx, argc, argv):
+        xstep_impl(ctx, argc, argv)
+
+    @cfunc(types.void(types.intp))
+    def final_cb(ctx):
+        xfinal_impl(ctx)
+
+    flags = SQLITE_UTF8 | (SQLITE_DETERMINISTIC if deterministic else 0)
+    with c_string(name) as name_p:
+        rc = sqlite3_create_function_v2(
+            db, name_p, n_arg, flags, 0, 0,
+            step_cb.address, final_cb.address, 0)
+    if rc != SQLITE_OK:
+        _raise_rc(db, name, rc)
+    return _UDAFHandle(step_cb, final_cb, xstep_impl, xfinal_impl,
+                       init, step, finalize)

--- a/numbox/core/bindings/_sqlite_udf_helpers.py
+++ b/numbox/core/bindings/_sqlite_udf_helpers.py
@@ -8,6 +8,15 @@ the release-in-xFinal-but-NOT-xValue rule -- so callers write only their
 ``@njit`` ``init``/``step``/``finalize`` (and ``inverse``/``value`` for windows)
 state logic.
 
+**Exception handling.** Each generated callback wraps the user
+step/inverse/value/finalize call in a ``try``/``except`` that reports
+``SQLITE_ERROR`` via ``sqlite3_result_error_code`` when the user callback raises.
+A numba ``@cfunc`` otherwise SWALLOWS the exception (it prints "Exception
+ignored" and returns the zero default without unwinding into SQLite), which would
+be a silent wrong result; the in-body catch also lets numba run the borrowed
+state's reference-count decrement, which the unwind would otherwise skip -- a
+per-group meminfo leak. Only ``xFinal`` releases the slot.
+
 Mechanism (see docs/superpowers/specs/2026-05-29-sqlite-udaf-registration-helper-design.md):
 per-UDAF callback source is generated with the state type and the user functions
 baked in as module globals (so the calls inline), written to a content-addressed
@@ -87,7 +96,10 @@ def _xstep_impl(ctx, argc, argv_pp):
     slot = carray(_cast_int_to_void_p(agg), (1,), dtype=np.intp)
     if slot[0] == 0:
         slot[0] = export_meminfo(_init())
-    _step(borrow_structref(_state_type, slot[0]), ctx, argc, argv_pp)
+    try:
+        _step(borrow_structref(_state_type, slot[0]), ctx, argc, argv_pp)
+    except Exception:
+        sqlite3_result_error_code(ctx, SQLITE_ERROR)  # fail the query; the catch prevents the borrow leak
 '''
 
 _XFINAL_SRC = '''
@@ -117,7 +129,10 @@ def _xinverse_impl(ctx, argc, argv_pp):
     slot = carray(_cast_int_to_void_p(agg), (1,), dtype=np.intp)
     if slot[0] == 0:
         return
-    _inverse(borrow_structref(_state_type, slot[0]), ctx, argc, argv_pp)
+    try:
+        _inverse(borrow_structref(_state_type, slot[0]), ctx, argc, argv_pp)
+    except Exception:
+        sqlite3_result_error_code(ctx, SQLITE_ERROR)  # fail the query; the catch prevents the borrow leak
 '''
 
 _XVALUE_SRC = '''
@@ -131,7 +146,10 @@ def _xvalue_impl(ctx):
     if slot[0] == 0:
         _value(_init(), ctx)
         return
-    _value(borrow_structref(_state_type, slot[0]), ctx)
+    try:
+        _value(borrow_structref(_state_type, slot[0]), ctx)
+    except Exception:
+        sqlite3_result_error_code(ctx, SQLITE_ERROR)  # fail the query; the catch prevents the borrow leak
 '''
 
 

--- a/numbox/core/bindings/_sqlite_udf_helpers.py
+++ b/numbox/core/bindings/_sqlite_udf_helpers.py
@@ -9,8 +9,9 @@ the release-in-xFinal-but-NOT-xValue rule -- so callers write only their
 state logic.
 
 **Exception handling.** Each generated callback wraps the user
-step/inverse/value/finalize call in a ``try``/``except`` that reports
-``SQLITE_ERROR`` via ``sqlite3_result_error_code`` when the user callback raises.
+step/inverse/value/finalize call in a ``try``/``except`` that reports a
+descriptive error via ``sqlite3_result_error`` (e.g. "error in user step
+callback", with code ``SQLITE_ERROR``) when the user callback raises.
 A numba ``@cfunc`` otherwise SWALLOWS the exception (it prints "Exception
 ignored" and returns the zero default without unwinding into SQLite), which would
 be a silent wrong result; the in-body catch also lets numba run the borrowed
@@ -68,10 +69,9 @@ from numbox.utils.preprocessing import (
 # puts them in this module's __dict__, which seeds the exec namespace below.
 import numpy as np  # noqa: F401
 from numba import carray, njit  # noqa: F401
-from numbox.core.bindings._sqlite_constants import SQLITE_ERROR  # noqa: F401
-from numbox.core.bindings._sqlite_result import sqlite3_result_error_code  # noqa: F401
+from numbox.core.bindings._sqlite_result import sqlite3_result_error  # noqa: F401
 from numbox.core.bindings._sqlite_udf import sqlite3_aggregate_context  # noqa: F401
-from numbox.utils.lowlevel import _cast_int_to_void_p  # noqa: F401
+from numbox.utils.lowlevel import _cast_int_to_void_p, get_unicode_data_p  # noqa: F401
 from numbox.utils.meminfo import (  # noqa: F401
     borrow_structref,
     export_meminfo,
@@ -99,7 +99,7 @@ def _xstep_impl(ctx, argc, argv_pp):
     try:
         _step(borrow_structref(_state_type, slot[0]), ctx, argc, argv_pp)
     except Exception:
-        sqlite3_result_error_code(ctx, SQLITE_ERROR)  # fail the query; the catch prevents the borrow leak
+        sqlite3_result_error(ctx, get_unicode_data_p("error in user step callback"), -1)
 '''
 
 _XFINAL_SRC = '''
@@ -110,19 +110,19 @@ def _xfinal_impl(ctx):
         try:
             _finalize(_init(), ctx)
         except Exception:
-            sqlite3_result_error_code(ctx, SQLITE_ERROR)
+            sqlite3_result_error(ctx, get_unicode_data_p("error in user finalize callback"), -1)
         return
     slot = carray(_cast_int_to_void_p(agg), (1,), dtype=np.intp)
     if slot[0] == 0:
         try:
             _finalize(_init(), ctx)
         except Exception:
-            sqlite3_result_error_code(ctx, SQLITE_ERROR)
+            sqlite3_result_error(ctx, get_unicode_data_p("error in user finalize callback"), -1)
         return
     try:
         _finalize(borrow_structref(_state_type, slot[0]), ctx)
     except Exception:
-        sqlite3_result_error_code(ctx, SQLITE_ERROR)  # fail the query, never leak the slot
+        sqlite3_result_error(ctx, get_unicode_data_p("error in user finalize callback"), -1)
     release_meminfo(slot[0])
 '''
 
@@ -138,7 +138,7 @@ def _xinverse_impl(ctx, argc, argv_pp):
     try:
         _inverse(borrow_structref(_state_type, slot[0]), ctx, argc, argv_pp)
     except Exception:
-        sqlite3_result_error_code(ctx, SQLITE_ERROR)  # fail the query; the catch prevents the borrow leak
+        sqlite3_result_error(ctx, get_unicode_data_p("error in user inverse callback"), -1)
 '''
 
 _XVALUE_SRC = '''
@@ -149,19 +149,19 @@ def _xvalue_impl(ctx):
         try:
             _value(_init(), ctx)
         except Exception:
-            sqlite3_result_error_code(ctx, SQLITE_ERROR)
+            sqlite3_result_error(ctx, get_unicode_data_p("error in user value callback"), -1)
         return
     slot = carray(_cast_int_to_void_p(agg), (1,), dtype=np.intp)
     if slot[0] == 0:
         try:
             _value(_init(), ctx)
         except Exception:
-            sqlite3_result_error_code(ctx, SQLITE_ERROR)
+            sqlite3_result_error(ctx, get_unicode_data_p("error in user value callback"), -1)
         return
     try:
         _value(borrow_structref(_state_type, slot[0]), ctx)
     except Exception:
-        sqlite3_result_error_code(ctx, SQLITE_ERROR)  # fail the query; the catch prevents the borrow leak
+        sqlite3_result_error(ctx, get_unicode_data_p("error in user value callback"), -1)
 '''
 
 

--- a/numbox/core/bindings/_sqlite_udf_helpers.py
+++ b/numbox/core/bindings/_sqlite_udf_helpers.py
@@ -107,11 +107,17 @@ _XFINAL_SRC = '''
 def _xfinal_impl(ctx):
     agg = sqlite3_aggregate_context(ctx, 0)
     if agg == 0:
-        _finalize(_init(), ctx)
+        try:
+            _finalize(_init(), ctx)
+        except Exception:
+            sqlite3_result_error_code(ctx, SQLITE_ERROR)
         return
     slot = carray(_cast_int_to_void_p(agg), (1,), dtype=np.intp)
     if slot[0] == 0:
-        _finalize(_init(), ctx)
+        try:
+            _finalize(_init(), ctx)
+        except Exception:
+            sqlite3_result_error_code(ctx, SQLITE_ERROR)
         return
     try:
         _finalize(borrow_structref(_state_type, slot[0]), ctx)
@@ -140,11 +146,17 @@ _XVALUE_SRC = '''
 def _xvalue_impl(ctx):
     agg = sqlite3_aggregate_context(ctx, 0)
     if agg == 0:
-        _value(_init(), ctx)
+        try:
+            _value(_init(), ctx)
+        except Exception:
+            sqlite3_result_error_code(ctx, SQLITE_ERROR)
         return
     slot = carray(_cast_int_to_void_p(agg), (1,), dtype=np.intp)
     if slot[0] == 0:
-        _value(_init(), ctx)
+        try:
+            _value(_init(), ctx)
+        except Exception:
+            sqlite3_result_error_code(ctx, SQLITE_ERROR)
         return
     try:
         _value(borrow_structref(_state_type, slot[0]), ctx)

--- a/numbox/core/bindings/_sqlite_udf_helpers.py
+++ b/numbox/core/bindings/_sqlite_udf_helpers.py
@@ -28,6 +28,7 @@ import numba
 from numba import cfunc, types
 from numba.core.serialize import cloudpickle
 from numba.core.types import StructRef
+from numba.extending import is_jitted
 
 import numbox
 from numbox.core.bindings._sqlite_conn import sqlite3_errmsg
@@ -148,6 +149,16 @@ def _validate_state_type(state_type):
             "(e.g. MyStateType([('x', int64)])), got %r" % (state_type,))
 
 
+def _validate_callbacks(**fns):
+    """Reject non-``@njit`` callbacks up front with a clear message; otherwise a
+    plain Python callable surfaces as a cryptic numba ``TypingError`` when it
+    fails to bake into the generated source."""
+    for role, fn in fns.items():
+        if not is_jitted(fn):
+            raise TypeError(
+                "%s must be an @njit-compiled function, got %r" % (role, fn))
+
+
 def _digest(state_type, fns):
     """Content hash that invalidates when the state type, the user functions
     (co_consts-sensitive, via cloudpickle of the code object -- NOT bare
@@ -211,6 +222,7 @@ def register_aggregate(db, name, n_arg, state_type, init, step, finalize,
     :returns: a keep-alive handle the caller MUST retain (see ``_UDAFHandle``).
     """
     _validate_state_type(state_type)
+    _validate_callbacks(init=init, step=step, finalize=finalize)
     ns = _compile_callbacks(
         _stem("udaf_", name), [_XSTEP_SRC, _XFINAL_SRC], state_type,
         {"_init": init, "_step": step, "_finalize": finalize})
@@ -246,6 +258,8 @@ def register_window(db, name, n_arg, state_type, init, step, inverse, value,
     releases the meminfo.
     """
     _validate_state_type(state_type)
+    _validate_callbacks(init=init, step=step, inverse=inverse, value=value,
+                        finalize=finalize)
     ns = _compile_callbacks(
         _stem("wudaf_", name),
         [_XSTEP_SRC, _XINVERSE_SRC, _XVALUE_SRC, _XFINAL_SRC], state_type,

--- a/numbox/core/bindings/_sqlite_udf_helpers.py
+++ b/numbox/core/bindings/_sqlite_udf_helpers.py
@@ -95,7 +95,11 @@ def _xstep_impl(ctx, argc, argv_pp):
         return
     slot = carray(_cast_int_to_void_p(agg), (1,), dtype=np.intp)
     if slot[0] == 0:
-        slot[0] = export_meminfo(_init())
+        try:
+            slot[0] = export_meminfo(_init())
+        except Exception:
+            sqlite3_result_error(ctx, get_unicode_data_p("error in user init callback"), -1)
+            return
     try:
         _step(borrow_structref(_state_type, slot[0]), ctx, argc, argv_pp)
     except Exception:
@@ -108,14 +112,24 @@ def _xfinal_impl(ctx):
     agg = sqlite3_aggregate_context(ctx, 0)
     if agg == 0:
         try:
-            _finalize(_init(), ctx)
+            _state = _init()
+        except Exception:
+            sqlite3_result_error(ctx, get_unicode_data_p("error in user init callback"), -1)
+            return
+        try:
+            _finalize(_state, ctx)
         except Exception:
             sqlite3_result_error(ctx, get_unicode_data_p("error in user finalize callback"), -1)
         return
     slot = carray(_cast_int_to_void_p(agg), (1,), dtype=np.intp)
     if slot[0] == 0:
         try:
-            _finalize(_init(), ctx)
+            _state = _init()
+        except Exception:
+            sqlite3_result_error(ctx, get_unicode_data_p("error in user init callback"), -1)
+            return
+        try:
+            _finalize(_state, ctx)
         except Exception:
             sqlite3_result_error(ctx, get_unicode_data_p("error in user finalize callback"), -1)
         return
@@ -147,14 +161,24 @@ def _xvalue_impl(ctx):
     agg = sqlite3_aggregate_context(ctx, 0)
     if agg == 0:
         try:
-            _value(_init(), ctx)
+            _state = _init()
+        except Exception:
+            sqlite3_result_error(ctx, get_unicode_data_p("error in user init callback"), -1)
+            return
+        try:
+            _value(_state, ctx)
         except Exception:
             sqlite3_result_error(ctx, get_unicode_data_p("error in user value callback"), -1)
         return
     slot = carray(_cast_int_to_void_p(agg), (1,), dtype=np.intp)
     if slot[0] == 0:
         try:
-            _value(_init(), ctx)
+            _state = _init()
+        except Exception:
+            sqlite3_result_error(ctx, get_unicode_data_p("error in user init callback"), -1)
+            return
+        try:
+            _value(_state, ctx)
         except Exception:
             sqlite3_result_error(ctx, get_unicode_data_p("error in user value callback"), -1)
         return

--- a/numbox/core/bindings/_sqlite_udf_helpers.py
+++ b/numbox/core/bindings/_sqlite_udf_helpers.py
@@ -155,6 +155,11 @@ def _digest(state_type, fns):
     h = hashlib.sha256()
     h.update(repr(state_type).encode("utf-8"))
     h.update(numba.__version__.encode("utf-8"))
+    # numbox.__version__ is "" upstream (the package version derives from it via
+    # pyproject's dynamic attr), so this fold is currently inert; it is kept so
+    # digests auto-invalidate should numbox ever set a real __version__. The
+    # numba version above and the code-object hash below do the real
+    # invalidating work (proven by test_invalidation_on_literal_edit).
     h.update((numbox.__version__ or "").encode("utf-8"))
     for fn in fns:
         py = getattr(fn, "py_func", fn)

--- a/numbox/core/work/builder.py
+++ b/numbox/core/work/builder.py
@@ -167,11 +167,6 @@ def make_graph(
     for derived_ in all_derived_:
         line_ = _derived_line(derived_, ns, initializers, derive_hashes, _make_args, jit_options)
         code_txt.write(f"\n\t{line_}")
-    # No node types in the key: numba dispatches the generated _make by argument
-    # signature, so identical-structure graphs with different init types share the
-    # _make name and compile/load separate overloads correctly (pinned by
-    # test_make_graph_distinct_types_dispatch). The init *value* is deliberately
-    # absent too -- a non-deterministic repr (numpy.empty) would churn the cache.
     hash_str = f"code_block = {code_txt.getvalue()} derive_hashes = {derive_hashes}"
     hash_ = code_block_hash(hash_str)
     access_nodes_names = [n.name for n in access_nodes]

--- a/numbox/core/work/builder.py
+++ b/numbox/core/work/builder.py
@@ -167,7 +167,8 @@ def make_graph(
     for derived_ in all_derived_:
         line_ = _derived_line(derived_, ns, initializers, derive_hashes, _make_args, jit_options)
         code_txt.write(f"\n\t{line_}")
-    hash_str = f"code_block = {code_txt.getvalue()} initializers = {list(initializers.values())} derive_hashes = {derive_hashes}"  # noqa: E501
+    init_types = [str(get_ty(s)) for s in (*all_inputs_, *all_derived_)]
+    hash_str = f"code_block = {code_txt.getvalue()} init_types = {init_types} derive_hashes = {derive_hashes}"  # noqa: E501
     hash_ = code_block_hash(hash_str)
     access_nodes_names = [n.name for n in access_nodes]
     tup_ = ", ".join(access_nodes_names) + ","

--- a/numbox/core/work/builder.py
+++ b/numbox/core/work/builder.py
@@ -167,8 +167,12 @@ def make_graph(
     for derived_ in all_derived_:
         line_ = _derived_line(derived_, ns, initializers, derive_hashes, _make_args, jit_options)
         code_txt.write(f"\n\t{line_}")
-    init_types = [str(get_ty(s)) for s in (*all_inputs_, *all_derived_)]
-    hash_str = f"code_block = {code_txt.getvalue()} init_types = {init_types} derive_hashes = {derive_hashes}"  # noqa: E501
+    # No node types in the key: numba dispatches the generated _make by argument
+    # signature, so identical-structure graphs with different init types share the
+    # _make name and compile/load separate overloads correctly (pinned by
+    # test_make_graph_distinct_types_dispatch). The init *value* is deliberately
+    # absent too -- a non-deterministic repr (numpy.empty) would churn the cache.
+    hash_str = f"code_block = {code_txt.getvalue()} derive_hashes = {derive_hashes}"
     hash_ = code_block_hash(hash_str)
     access_nodes_names = [n.name for n in access_nodes]
     tup_ = ", ".join(access_nodes_names) + ","

--- a/test/core/test_builder.py
+++ b/test/core/test_builder.py
@@ -468,20 +468,26 @@ def test_9():
 
 
 # Regression guard: make_graph's cached _make function must be keyed on node
-# TYPES, not init-value contents. A numpy.empty init (uninitialized memory,
-# non-deterministic repr) must not write a fresh .nbc on every process.
+# TYPES, not init-value contents -- else a non-deterministic init repr (e.g.
+# numpy.empty's uninitialized bytes) mints a fresh .nbc every process, growing
+# the cache without bound. The value is injected per run (PROBE_VAL) so it
+# DIFFERS between the two processes while the TYPE stays identical; this catches
+# the regression deterministically on every platform rather than relying on
+# np.empty happening to return distinct garbage across processes.
 _GRAPH_DRIVER = textwrap.dedent('''
+    import os
     import numpy as np
     from numbox.core.work.builder import End, make_graph
-    make_graph(End(name="probe_a", init_value=np.empty((4,), np.float64)))
+    v = np.full((4,), float(os.environ["PROBE_VAL"]), np.float64)
+    make_graph(End(name="probe_a", init_value=v))
     print("OK")
 ''')
 
 
-def _run_graph_driver(tmp_path, cache):
+def _run_graph_driver(tmp_path, cache, probe_val):
     script = tmp_path / "graph_drv.py"
     script.write_text(_GRAPH_DRIVER)
-    env = dict(os.environ, NUMBA_CACHE_DIR=str(cache))
+    env = dict(os.environ, NUMBA_CACHE_DIR=str(cache), PROBE_VAL=probe_val)
     out = subprocess.run([sys.executable, str(script)], env=env,
                          capture_output=True, text=True, timeout=600)
     assert out.returncode == 0, out.stderr
@@ -490,14 +496,14 @@ def _run_graph_driver(tmp_path, cache):
 def test_make_graph_cache_key_content_independent(tmp_path):
     cache = tmp_path / "nbcache"
     cache.mkdir()
-    _run_graph_driver(tmp_path, cache)               # cold: compiles + caches
+    _run_graph_driver(tmp_path, cache, "1.0")        # cold: compiles + caches
     n_cold = sum(1 for _ in cache.rglob("builder._make*.nbc"))
     assert n_cold > 0
-    _run_graph_driver(tmp_path, cache)               # warm: np.empty garbage differs
+    _run_graph_driver(tmp_path, cache, "2.0")        # warm: same TYPE, different value
     n_warm = sum(1 for _ in cache.rglob("builder._make*.nbc"))
     assert n_warm == n_cold, (
-        "make_graph wrote a new _make .nbc in a second process "
-        "(cache key depends on init contents)")
+        "make_graph wrote a new _make .nbc for a same-typed init with different "
+        "contents (cache key depends on init values, not just types)")
 
 
 if __name__ == "__main__":

--- a/test/core/test_builder.py
+++ b/test/core/test_builder.py
@@ -506,5 +506,44 @@ def test_make_graph_cache_key_content_independent(tmp_path):
         "contents (cache key depends on init values, not just types)")
 
 
+# With node types out of the hash, identical-structure graphs with different init
+# TYPES collide on one _make name; numba dispatches the generated _make by argument
+# signature, so each loads its own overload correctly across a shared cache dir.
+_TYPED_GRAPH_DRIVER = textwrap.dedent('''
+    import sys
+    from numbox.core.work.builder import End, Derived, make_graph
+
+    def inc(x):
+        return x + 1
+
+    t = sys.argv[1]
+    iv_e, iv_d = (2.0, 0.0) if t == "f" else (2, 0)
+    e = End(name="e", init_value=iv_e)
+    d = Derived(name="d", init_value=iv_d, sources=(e,), derive=inc)
+    acc = make_graph(d)
+    acc.d.calculate()
+    print("RESULT", t, acc.d.data, type(acc.d.data).__name__)
+''')
+
+
+def _run_typed_driver(tmp_path, cache, t):
+    script = tmp_path / ("typed_drv_%s.py" % t)
+    script.write_text(_TYPED_GRAPH_DRIVER)
+    env = dict(os.environ, NUMBA_CACHE_DIR=str(cache))
+    out = subprocess.run([sys.executable, str(script), t], env=env,
+                         capture_output=True, text=True, timeout=600)
+    assert out.returncode == 0, out.stderr
+    return [ln for ln in out.stdout.splitlines() if ln.startswith("RESULT")][0].split()
+
+
+def test_make_graph_distinct_types_dispatch(tmp_path):
+    cache = tmp_path / "nbcache_types"
+    cache.mkdir()
+    rf = _run_typed_driver(tmp_path, cache, "f")     # cold: float overload
+    ri = _run_typed_driver(tmp_path, cache, "i")     # warm dir: int overload, same _make name
+    assert rf == ["RESULT", "f", "3.0", "float"]
+    assert ri == ["RESULT", "i", "3", "int"]
+
+
 if __name__ == "__main__":
     collect_and_run_tests(__name__)

--- a/test/core/test_builder.py
+++ b/test/core/test_builder.py
@@ -1,3 +1,8 @@
+import os
+import subprocess
+import sys
+import textwrap
+
 import numpy
 import pytest
 
@@ -460,6 +465,39 @@ def test_9():
     assert d1.data == 0.0
     d1.calculate()
     assert isclose(d1.data, 3.14)
+
+
+# Regression guard: make_graph's cached _make function must be keyed on node
+# TYPES, not init-value contents. A numpy.empty init (uninitialized memory,
+# non-deterministic repr) must not write a fresh .nbc on every process.
+_GRAPH_DRIVER = textwrap.dedent('''
+    import numpy as np
+    from numbox.core.work.builder import End, make_graph
+    make_graph(End(name="probe_a", init_value=np.empty((4,), np.float64)))
+    print("OK")
+''')
+
+
+def _run_graph_driver(tmp_path, cache):
+    script = tmp_path / "graph_drv.py"
+    script.write_text(_GRAPH_DRIVER)
+    env = dict(os.environ, NUMBA_CACHE_DIR=str(cache))
+    out = subprocess.run([sys.executable, str(script)], env=env,
+                         capture_output=True, text=True, timeout=600)
+    assert out.returncode == 0, out.stderr
+
+
+def test_make_graph_cache_key_content_independent(tmp_path):
+    cache = tmp_path / "nbcache"
+    cache.mkdir()
+    _run_graph_driver(tmp_path, cache)               # cold: compiles + caches
+    n_cold = sum(1 for _ in cache.rglob("builder._make*.nbc"))
+    assert n_cold > 0
+    _run_graph_driver(tmp_path, cache)               # warm: np.empty garbage differs
+    n_warm = sum(1 for _ in cache.rglob("builder._make*.nbc"))
+    assert n_warm == n_cold, (
+        "make_graph wrote a new _make .nbc in a second process "
+        "(cache key depends on init contents)")
 
 
 if __name__ == "__main__":

--- a/test/core/test_sqlite_udf_helpers.py
+++ b/test/core/test_sqlite_udf_helpers.py
@@ -396,18 +396,38 @@ def test_registration_error_raises(monkeypatch):
     sqlite3_close(db)
 
 
-def test_non_njit_callback_rejected():
-    """A plain (non-@njit) callback is rejected up front with a clear TypeError
-    rather than a cryptic numba TypingError at bake time."""
-    import pytest
+def test_plain_python_callbacks_accepted():
+    """Plain (undecorated) Python callbacks are njit-wrapped by the helper and
+    work end-to-end -- callers need not pre-``@njit`` them."""
     db = _open_memory()
+    _make_table(db, [1, 2, 3, 4, 5])
+
+    def plain_init():
+        return SumState(nb_types.int64(0))
 
     def plain_step(state, ctx, argc, argv_pp):
-        pass
+        args = carray(_cast_int_to_void_p(argv_pp), (argc,), dtype=np.intp)
+        state.total += sqlite3_value_int64(args[0])
 
-    with pytest.raises(TypeError, match="step must be an @njit"):
+    def plain_finalize(state, ctx):
+        sqlite3_result_int64(ctx, state.total)
+
+    h = register_aggregate(db, "plain_sum", 1, sum_state_type,
+                           plain_init, plain_step, plain_finalize)
+    gc.collect()  # handle must keep callbacks alive
+    val, _cap = _read1_int64(db, "SELECT __cap(plain_sum(v)) FROM t")
+    sqlite3_close(db)
+    assert val == 15
+    assert h is not None
+
+
+def test_non_callable_callback_rejected():
+    """A non-callable callback is rejected up front with a clear TypeError."""
+    import pytest
+    db = _open_memory()
+    with pytest.raises(TypeError, match="step must be a callable"):
         register_aggregate(db, "bad_cb", 1, sum_state_type,
-                           sum_init, plain_step, sum_finalize)
+                           sum_init, 42, sum_finalize)
     sqlite3_close(db)
 
 

--- a/test/core/test_sqlite_udf_helpers.py
+++ b/test/core/test_sqlite_udf_helpers.py
@@ -104,24 +104,20 @@ def _read1_int64(db, select_sql):
 def test_aggregate_sum():
     db = _open_memory()
     _make_table(db, [1, 2, 3, 4, 5])
-    h = register_aggregate(db, "my_sum", 1, sum_state_type,
-                           sum_init, sum_step, sum_finalize)
-    gc.collect()  # handle must keep callbacks alive
+    register_aggregate(db, "my_sum", 1, sum_state_type, sum_init, sum_step, sum_finalize)
+    gc.collect()  # no handle retained; callbacks survive GC (numba keeps the JIT code alive)
     val, _cap = _read1_int64(db, "SELECT __cap(my_sum(v)) FROM t")
     sqlite3_close(db)
     assert val == 15
-    assert h is not None
 
 
 def test_aggregate_empty_group():
     db = _open_memory()
     _make_table(db, [])
-    h = register_aggregate(db, "my_sum", 1, sum_state_type,
-                           sum_init, sum_step, sum_finalize)
+    register_aggregate(db, "my_sum", 1, sum_state_type, sum_init, sum_step, sum_finalize)
     val, _cap = _read1_int64(db, "SELECT __cap(my_sum(v)) FROM t")
     sqlite3_close(db)
     assert val == 0
-    assert h is not None
 
 
 def test_aggregate_bad_state_type():
@@ -185,7 +181,7 @@ _DRIVER = textwrap.dedent('''
     for v in (1, 2, 3, 4, 5):
         with c_string("INSERT INTO t VALUES (%d)" % v) as p:
             sqlite3_exec(db, p, 0, 0, 0)
-    h = register_aggregate(db, "f", 1, st, s_init, s_step, s_fin)
+    register_aggregate(db, "f", 1, st, s_init, s_step, s_fin)
     buf = np.zeros(1, dtype=np.int64)
     @cfunc(types.void(types.intp, types.int32, types.intp))
     def cap(ctx, argc, argv):
@@ -288,15 +284,13 @@ def _read_window(db, select_sql, nrows):
 def test_window_running_sum():
     db = _open_memory()
     _make_table(db, [1, 2, 3, 4, 5])
-    h = register_window(db, "my_wsum", 1, sum_state_type,
-                        sum_init, sum_step, w_inverse, w_value, sum_finalize)
+    register_window(db, "my_wsum", 1, sum_state_type, sum_init, sum_step, w_inverse, w_value, sum_finalize)
     sql = ("SELECT __wcap(my_wsum(v) OVER "
            "(ORDER BY v ROWS BETWEEN 1 PRECEDING AND CURRENT ROW)) "
            "FROM t ORDER BY v")
     vals, _cap = _read_window(db, sql, 5)
     sqlite3_close(db)
     assert vals == [1, 3, 5, 7, 9]
-    assert h is not None
 
 
 @njit
@@ -308,26 +302,21 @@ def sum2_step(state, ctx, argc, argv_pp):  # distinct body => independent compil
 def test_two_distinct_aggregates_no_collision():
     db = _open_memory()
     _make_table(db, [1, 2, 3, 4, 5])
-    h1 = register_aggregate(db, "my_sum", 1, sum_state_type,
-                            sum_init, sum_step, sum_finalize)
-    h2 = register_aggregate(db, "my_sum2", 1, sum_state_type,
-                            sum_init, sum2_step, sum_finalize)
+    register_aggregate(db, "my_sum", 1, sum_state_type, sum_init, sum_step, sum_finalize)
+    register_aggregate(db, "my_sum2", 1, sum_state_type, sum_init, sum2_step, sum_finalize)
     v1, _c1 = _read1_int64(db, "SELECT __cap(my_sum(v)) FROM t")
     v2, _c2 = _read1_int64(db, "SELECT __cap(my_sum2(v)) FROM t")
     sqlite3_close(db)
     assert (v1, v2) == (15, 30)
-    assert h1 is not None and h2 is not None
 
 
 def test_deterministic_flag():
     db = _open_memory()
     _make_table(db, [1, 2, 3, 4, 5])
-    h = register_aggregate(db, "my_sum_det", 1, sum_state_type,
-                           sum_init, sum_step, sum_finalize, deterministic=True)
+    register_aggregate(db, "my_sum_det", 1, sum_state_type, sum_init, sum_step, sum_finalize, deterministic=True)
     val, _cap = _read1_int64(db, "SELECT __cap(my_sum_det(v)) FROM t")
     sqlite3_close(db)
     assert val == 15
-    assert h is not None
 
 
 def test_deterministic_flag_ors_bit(monkeypatch):
@@ -345,10 +334,8 @@ def test_deterministic_flag_ors_bit(monkeypatch):
 
     monkeypatch.setattr(helpers, "sqlite3_create_function_v2", spy)
     db = _open_memory()
-    register_aggregate(db, "det_on", 1, sum_state_type,
-                       sum_init, sum_step, sum_finalize, deterministic=True)
-    register_aggregate(db, "det_off", 1, sum_state_type,
-                       sum_init, sum_step, sum_finalize)
+    register_aggregate(db, "det_on", 1, sum_state_type, sum_init, sum_step, sum_finalize, deterministic=True)
+    register_aggregate(db, "det_off", 1, sum_state_type, sum_init, sum_step, sum_finalize)
     sqlite3_close(db)
     assert seen[0] & helpers.SQLITE_DETERMINISTIC
     assert not (seen[1] & helpers.SQLITE_DETERMINISTIC)
@@ -387,10 +374,8 @@ def test_window_deterministic_flag_ors_bit(monkeypatch):
 
     monkeypatch.setattr(helpers, "sqlite3_create_window_function", spy)
     db = _open_memory()
-    register_window(db, "wdet_on", 1, sum_state_type, sum_init, sum_step,
-                    w_inverse, w_value, sum_finalize, deterministic=True)
-    register_window(db, "wdet_off", 1, sum_state_type, sum_init, sum_step,
-                    w_inverse, w_value, sum_finalize)
+    register_window(db, "wdet_on", 1, sum_state_type, sum_init, sum_step, w_inverse, w_value, sum_finalize, deterministic=True)
+    register_window(db, "wdet_off", 1, sum_state_type, sum_init, sum_step, w_inverse, w_value, sum_finalize)
     sqlite3_close(db)
     assert seen[0] & helpers.SQLITE_DETERMINISTIC
     assert not (seen[1] & helpers.SQLITE_DETERMINISTIC)
@@ -408,8 +393,7 @@ def test_registration_error_raises(monkeypatch):
                         lambda *a, **k: 1)  # non-OK rc (SQLITE_ERROR)
     db = _open_memory()
     with pytest.raises(RuntimeError, match="registration failed"):
-        register_aggregate(db, "err", 1, sum_state_type,
-                           sum_init, sum_step, sum_finalize)
+        register_aggregate(db, "err", 1, sum_state_type, sum_init, sum_step, sum_finalize)
     sqlite3_close(db)
 
 
@@ -429,13 +413,11 @@ def test_plain_python_callbacks_accepted():
     def plain_finalize(state, ctx):
         sqlite3_result_int64(ctx, state.total)
 
-    h = register_aggregate(db, "plain_sum", 1, sum_state_type,
-                           plain_init, plain_step, plain_finalize)
-    gc.collect()  # handle must keep callbacks alive
+    register_aggregate(db, "plain_sum", 1, sum_state_type, plain_init, plain_step, plain_finalize)
+    gc.collect()  # no handle retained; plain callbacks njit-wrapped, survive GC too
     val, _cap = _read1_int64(db, "SELECT __cap(plain_sum(v)) FROM t")
     sqlite3_close(db)
     assert val == 15
-    assert h is not None
 
 
 def test_non_callable_callback_rejected():
@@ -443,8 +425,7 @@ def test_non_callable_callback_rejected():
     import pytest
     db = _open_memory()
     with pytest.raises(TypeError, match="step must be a callable"):
-        register_aggregate(db, "bad_cb", 1, sum_state_type,
-                           sum_init, 42, sum_finalize)
+        register_aggregate(db, "bad_cb", 1, sum_state_type, sum_init, 42, sum_finalize)
     sqlite3_close(db)
 
 
@@ -488,12 +469,10 @@ def test_multiarg_multifield_state():
     for a, b in [(1, 4), (2, 5), (3, 6)]:
         with c_string("INSERT INTO t2 VALUES (%d, %d)" % (a, b)) as p:
             assert sqlite3_exec(db, p, 0, 0, 0) == SQLITE_OK
-    h = register_aggregate(db, "pairsum", 2, pair_state_type,
-                           pair_init, pair_step, pair_finalize)
+    register_aggregate(db, "pairsum", 2, pair_state_type, pair_init, pair_step, pair_finalize)
     val, _cap = _read1_int64(db, "SELECT __cap(pairsum(a, b)) FROM t2")
     sqlite3_close(db)
     assert val == 156  # sa=1+2+3=6, sb=4+5+6=15 => 6 + 10*15
-    assert h is not None
 
 
 @njit
@@ -512,8 +491,7 @@ def test_finalize_exception_surfaces_error_and_no_leak():
 
     db = _open_memory()
     _make_table(db, [1, 2, 3, 4, 5])
-    h = register_aggregate(db, "raise_fin", 1, sum_state_type,
-                           sum_init, sum_step, raising_finalize)
+    register_aggregate(db, "raise_fin", 1, sum_state_type, sum_init, sum_step, raising_finalize)
     with c_string("SELECT raise_fin(v) FROM t") as sp:
         rc = sqlite3_exec(db, sp, 0, 0, 0)
     assert rc != SQLITE_OK  # error surfaced to sqlite, not a silent wrong result
@@ -531,7 +509,6 @@ def test_finalize_exception_surfaces_error_and_no_leak():
     allocated = after.mi_alloc - before.mi_alloc
     freed = after.mi_free - before.mi_free
     assert allocated == freed, "leak on raising finalize: %d alloc, %d free" % (allocated, freed)
-    assert h is not None
 
 
 @njit
@@ -550,8 +527,7 @@ def test_step_exception_surfaces_error_and_no_leak():
 
     db = _open_memory()
     _make_table(db, [1, 2, 3, 4, 5])
-    h = register_aggregate(db, "raise_step", 1, sum_state_type,
-                           sum_init, raising_step, sum_finalize)
+    register_aggregate(db, "raise_step", 1, sum_state_type, sum_init, raising_step, sum_finalize)
     with c_string("SELECT raise_step(v) FROM t") as sp:
         rc = sqlite3_exec(db, sp, 0, 0, 0)
     assert rc != SQLITE_OK  # raising step fails the query, not a silent wrong result
@@ -569,7 +545,6 @@ def test_step_exception_surfaces_error_and_no_leak():
     allocated = after.mi_alloc - before.mi_alloc
     freed = after.mi_free - before.mi_free
     assert allocated == freed, "leak on raising step: %d alloc, %d free" % (allocated, freed)
-    assert h is not None
 
 
 _WIN_SQL = ("SELECT %s(v) OVER (ORDER BY v ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) "
@@ -592,8 +567,7 @@ def test_value_exception_surfaces_error_and_no_leak():
 
     db = _open_memory()
     _make_table(db, [1, 2, 3, 4, 5])
-    h = register_window(db, "raise_wval", 1, sum_state_type, sum_init, sum_step,
-                        w_inverse, raising_value, sum_finalize)
+    register_window(db, "raise_wval", 1, sum_state_type, sum_init, sum_step, w_inverse, raising_value, sum_finalize)
     with c_string(_WIN_SQL % "raise_wval") as sp:
         rc = sqlite3_exec(db, sp, 0, 0, 0)
     assert rc != SQLITE_OK
@@ -611,7 +585,6 @@ def test_value_exception_surfaces_error_and_no_leak():
     allocated = after.mi_alloc - before.mi_alloc
     freed = after.mi_free - before.mi_free
     assert allocated == freed, "leak on raising value: %d alloc, %d free" % (allocated, freed)
-    assert h is not None
 
 
 @njit
@@ -631,8 +604,7 @@ def test_inverse_exception_surfaces_error_and_no_leak():
 
     db = _open_memory()
     _make_table(db, [1, 2, 3, 4, 5])
-    h = register_window(db, "raise_winv", 1, sum_state_type, sum_init, sum_step,
-                        raising_inverse, w_value, sum_finalize)
+    register_window(db, "raise_winv", 1, sum_state_type, sum_init, sum_step, raising_inverse, w_value, sum_finalize)
     with c_string(_WIN_SQL % "raise_winv") as sp:
         rc = sqlite3_exec(db, sp, 0, 0, 0)
     assert rc != SQLITE_OK
@@ -649,7 +621,6 @@ def test_inverse_exception_surfaces_error_and_no_leak():
     allocated = after.mi_alloc - before.mi_alloc
     freed = after.mi_free - before.mi_free
     assert allocated == freed, "leak on raising inverse: %d alloc, %d free" % (allocated, freed)
-    assert h is not None
 
 
 def test_finalize_exception_empty_group_surfaces_error():
@@ -658,15 +629,13 @@ def test_finalize_exception_empty_group_surfaces_error():
     silently swallowed -- the empty-group branch is guarded like the borrow path."""
     db = _open_memory()
     _make_table(db, [])  # empty: xStep never runs -> xFinal hits the no-state branch
-    h = register_aggregate(db, "raise_fin_empty", 1, sum_state_type,
-                           sum_init, sum_step, raising_finalize)
+    register_aggregate(db, "raise_fin_empty", 1, sum_state_type, sum_init, sum_step, raising_finalize)
     with c_string("SELECT raise_fin_empty(v) FROM t") as sp:
         rc = sqlite3_exec(db, sp, 0, 0, 0)
     msg = _errmsg(db)
     sqlite3_close(db)
     assert rc != SQLITE_OK  # raising finalize on an empty group must fail loudly
     assert "finalize callback" in msg  # descriptive message even on the empty-group path
-    assert h is not None
 
 
 @njit
@@ -683,8 +652,7 @@ def test_init_exception_surfaces_error_no_unraisable():
     boundary as an 'Exception ignored' unraisable."""
     db = _open_memory()
     _make_table(db, [1, 2, 3])
-    h = register_aggregate(db, "raise_init", 1, sum_state_type,
-                           init_raise, sum_step, sum_finalize)
+    register_aggregate(db, "raise_init", 1, sum_state_type, init_raise, sum_step, sum_finalize)
     captured = []
     old_hook = sys.unraisablehook
     sys.unraisablehook = lambda a: captured.append(a)
@@ -698,7 +666,6 @@ def test_init_exception_surfaces_error_no_unraisable():
     assert not captured, "raising init leaked an unraisable (swallowed): %r" % (captured,)
     assert rc != SQLITE_OK
     assert "init callback" in msg  # accurate role, not a mislabeled finalize error
-    assert h is not None
 
 
 def test_init_exception_empty_group_surfaces_error():
@@ -706,12 +673,10 @@ def test_init_exception_empty_group_surfaces_error():
     'error in user init callback', not the mislabeled 'finalize callback'."""
     db = _open_memory()
     _make_table(db, [])
-    h = register_aggregate(db, "raise_init_empty", 1, sum_state_type,
-                           init_raise, sum_step, sum_finalize)
+    register_aggregate(db, "raise_init_empty", 1, sum_state_type, init_raise, sum_step, sum_finalize)
     with c_string("SELECT raise_init_empty(v) FROM t") as sp:
         rc = sqlite3_exec(db, sp, 0, 0, 0)
     msg = _errmsg(db)
     sqlite3_close(db)
     assert rc != SQLITE_OK
     assert "init callback" in msg
-    assert h is not None

--- a/test/core/test_sqlite_udf_helpers.py
+++ b/test/core/test_sqlite_udf_helpers.py
@@ -236,6 +236,23 @@ def test_invalidation_on_literal_edit(tmp_path):
     assert _run_driver(tmp_path, cache, 3) == 45       # step: += 3*v  => 45 (not stale 15)
 
 
+def test_jit_options_cache_disabled_honored(tmp_path):
+    """Generated impls honor the numbox-wide jit_options: with NUMBOX_JIT_OPTIONS
+    cache off, the UDAF still computes correctly and writes no impl .nbc."""
+    cache = tmp_path / "nbcache_nocache"
+    cache.mkdir()
+    script = tmp_path / "drv_nocache.py"
+    script.write_text(_DRIVER.replace("{MULT}", "1"))
+    env = dict(os.environ, NUMBA_CACHE_DIR=str(cache),
+               NUMBOX_JIT_OPTIONS='{"cache": false}')
+    out = subprocess.run([sys.executable, str(script)], env=env,
+                         capture_output=True, text=True, timeout=600)
+    assert out.returncode == 0, out.stderr
+    result = [ln for ln in out.stdout.splitlines() if ln.startswith("RESULT")][0]
+    assert int(result.split()[1]) == 15                # correct with cache disabled
+    assert _count_nbc(cache) == 0, "cache disabled but a udaf impl .nbc was written"
+
+
 @njit
 def w_inverse(state, ctx, argc, argv_pp):
     args = carray(_cast_int_to_void_p(argv_pp), (argc,), dtype=np.intp)

--- a/test/core/test_sqlite_udf_helpers.py
+++ b/test/core/test_sqlite_udf_helpers.py
@@ -630,3 +630,51 @@ def test_finalize_exception_empty_group_surfaces_error():
     assert rc != SQLITE_OK  # raising finalize on an empty group must fail loudly
     assert "finalize callback" in msg  # descriptive message even on the empty-group path
     assert h is not None
+
+
+@njit
+def init_raise():
+    s = SumState(nb_types.int64(0))
+    if s.total >= 0:  # always true at runtime; keeps the St return type for typing
+        raise ValueError("boom from init")
+    return s
+
+
+def test_init_exception_surfaces_error_no_unraisable():
+    """A raising init (called at xStep's first-row export) must be caught and
+    reported as 'error in user init callback', NOT swallowed by the @cfunc
+    boundary as an 'Exception ignored' unraisable."""
+    db = _open_memory()
+    _make_table(db, [1, 2, 3])
+    h = register_aggregate(db, "raise_init", 1, sum_state_type,
+                           init_raise, sum_step, sum_finalize)
+    captured = []
+    old_hook = sys.unraisablehook
+    sys.unraisablehook = lambda a: captured.append(a)
+    try:
+        with c_string("SELECT raise_init(v) FROM t") as sp:
+            rc = sqlite3_exec(db, sp, 0, 0, 0)
+        msg = _errmsg(db)
+    finally:
+        sys.unraisablehook = old_hook
+    sqlite3_close(db)
+    assert not captured, "raising init leaked an unraisable (swallowed): %r" % (captured,)
+    assert rc != SQLITE_OK
+    assert "init callback" in msg  # accurate role, not a mislabeled finalize error
+    assert h is not None
+
+
+def test_init_exception_empty_group_surfaces_error():
+    """A raising init on an empty group (xFinal's no-state branch) must report
+    'error in user init callback', not the mislabeled 'finalize callback'."""
+    db = _open_memory()
+    _make_table(db, [])
+    h = register_aggregate(db, "raise_init_empty", 1, sum_state_type,
+                           init_raise, sum_step, sum_finalize)
+    with c_string("SELECT raise_init_empty(v) FROM t") as sp:
+        rc = sqlite3_exec(db, sp, 0, 0, 0)
+    msg = _errmsg(db)
+    sqlite3_close(db)
+    assert rc != SQLITE_OK
+    assert "init callback" in msg
+    assert h is not None

--- a/test/core/test_sqlite_udf_helpers.py
+++ b/test/core/test_sqlite_udf_helpers.py
@@ -350,3 +350,99 @@ def test_no_meminfo_leak():
     allocated = after.mi_alloc - before.mi_alloc
     freed = after.mi_free - before.mi_free
     assert allocated == freed, "meminfo imbalance: %d alloc, %d free" % (allocated, freed)
+
+
+def test_window_deterministic_flag_ors_bit(monkeypatch):
+    """register_window must OR SQLITE_DETERMINISTIC into the flags passed to
+    sqlite3_create_window_function when deterministic=True, and not otherwise."""
+    import numbox.core.bindings._sqlite_udf_helpers as helpers
+    real = helpers.sqlite3_create_window_function
+    seen = []
+
+    def spy(db, name_p, n_arg, flags, *rest):
+        seen.append(flags)
+        return real(db, name_p, n_arg, flags, *rest)
+
+    monkeypatch.setattr(helpers, "sqlite3_create_window_function", spy)
+    db = _open_memory()
+    register_window(db, "wdet_on", 1, sum_state_type, sum_init, sum_step,
+                    w_inverse, w_value, sum_finalize, deterministic=True)
+    register_window(db, "wdet_off", 1, sum_state_type, sum_init, sum_step,
+                    w_inverse, w_value, sum_finalize)
+    sqlite3_close(db)
+    assert seen[0] & helpers.SQLITE_DETERMINISTIC
+    assert not (seen[1] & helpers.SQLITE_DETERMINISTIC)
+
+
+def test_registration_error_raises():
+    """A failed sqlite registration (here an out-of-range n_arg) surfaces as a
+    RuntimeError via _raise_rc, not a silent success."""
+    import pytest
+    db = _open_memory()
+    with pytest.raises(RuntimeError, match="registration failed"):
+        register_aggregate(db, "too_many_args", 200, sum_state_type,
+                           sum_init, sum_step, sum_finalize)
+    sqlite3_close(db)
+
+
+def test_non_njit_callback_rejected():
+    """A plain (non-@njit) callback is rejected up front with a clear TypeError
+    rather than a cryptic numba TypingError at bake time."""
+    import pytest
+    db = _open_memory()
+
+    def plain_step(state, ctx, argc, argv_pp):
+        pass
+
+    with pytest.raises(TypeError, match="step must be an @njit"):
+        register_aggregate(db, "bad_cb", 1, sum_state_type,
+                           sum_init, plain_step, sum_finalize)
+    sqlite3_close(db)
+
+
+# --- multi-field state + multi-arg UDAF parity ---
+@structref.register
+class PairStateType(nb_types.StructRef):
+    def preprocess_fields(self, fields):
+        return tuple((n, nb_types.unliteral(t)) for n, t in fields)
+
+
+class PairState(structref.StructRefProxy):
+    def __new__(cls, sa, sb):
+        return structref.StructRefProxy.__new__(cls, sa, sb)
+
+
+structref.define_proxy(PairState, PairStateType, ["sa", "sb"])
+pair_state_type = PairStateType([("sa", nb_types.int64), ("sb", nb_types.int64)])
+
+
+@njit
+def pair_init():
+    return PairState(nb_types.int64(0), nb_types.int64(0))
+
+
+@njit
+def pair_step(state, ctx, argc, argv_pp):
+    args = carray(_cast_int_to_void_p(argv_pp), (argc,), dtype=np.intp)
+    state.sa += sqlite3_value_int64(args[0])
+    state.sb += sqlite3_value_int64(args[1])
+
+
+@njit
+def pair_finalize(state, ctx):
+    sqlite3_result_int64(ctx, state.sa + 10 * state.sb)
+
+
+def test_multiarg_multifield_state():
+    db = _open_memory()
+    with c_string("CREATE TABLE t2(a INTEGER, b INTEGER)") as p:
+        assert sqlite3_exec(db, p, 0, 0, 0) == SQLITE_OK
+    for a, b in [(1, 4), (2, 5), (3, 6)]:
+        with c_string("INSERT INTO t2 VALUES (%d, %d)" % (a, b)) as p:
+            assert sqlite3_exec(db, p, 0, 0, 0) == SQLITE_OK
+    h = register_aggregate(db, "pairsum", 2, pair_state_type,
+                           pair_init, pair_step, pair_finalize)
+    val, _cap = _read1_int64(db, "SELECT __cap(pairsum(a, b)) FROM t2")
+    sqlite3_close(db)
+    assert val == 156  # sa=1+2+3=6, sb=4+5+6=15 => 6 + 10*15
+    assert h is not None

--- a/test/core/test_sqlite_udf_helpers.py
+++ b/test/core/test_sqlite_udf_helpers.py
@@ -1,6 +1,6 @@
 """Tests for the structref-backed SQLite UDAF/window registration helpers."""
 import gc
-from ctypes import addressof, c_int64
+from ctypes import addressof, c_char_p, c_int64
 
 import numpy as np
 from numba import carray, cfunc, njit, types
@@ -14,6 +14,7 @@ from numbox.core.bindings import (
     register_window,
     sqlite3_close,
     sqlite3_create_function_v2,
+    sqlite3_errmsg,
     sqlite3_exec,
     sqlite3_open,
     sqlite3_result_int,
@@ -71,6 +72,12 @@ def _make_table(db, values):
     for v in values:
         with c_string("INSERT INTO t VALUES (%d)" % v) as p:
             assert sqlite3_exec(db, p, 0, 0, 0) == SQLITE_OK
+
+
+def _errmsg(db):
+    """Decode sqlite3_errmsg(db) (the most recent error string) to a str."""
+    p = sqlite3_errmsg(db)
+    return c_char_p(p).value.decode("utf-8", "replace") if p else ""
 
 
 def _read1_int64(db, select_sql):
@@ -473,6 +480,7 @@ def test_finalize_exception_surfaces_error_and_no_leak():
     with c_string("SELECT raise_fin(v) FROM t") as sp:
         rc = sqlite3_exec(db, sp, 0, 0, 0)
     assert rc != SQLITE_OK  # error surfaced to sqlite, not a silent wrong result
+    assert "finalize callback" in _errmsg(db)  # descriptive message, not the generic code
 
     _nrt.memsys_enable_stats()
     with c_string("SELECT raise_fin(v) FROM t") as sp:  # warm
@@ -510,6 +518,7 @@ def test_step_exception_surfaces_error_and_no_leak():
     with c_string("SELECT raise_step(v) FROM t") as sp:
         rc = sqlite3_exec(db, sp, 0, 0, 0)
     assert rc != SQLITE_OK  # raising step fails the query, not a silent wrong result
+    assert "step callback" in _errmsg(db)  # descriptive message, not the generic code
 
     _nrt.memsys_enable_stats()
     with c_string("SELECT raise_step(v) FROM t") as sp:  # warm
@@ -551,6 +560,7 @@ def test_value_exception_surfaces_error_and_no_leak():
     with c_string(_WIN_SQL % "raise_wval") as sp:
         rc = sqlite3_exec(db, sp, 0, 0, 0)
     assert rc != SQLITE_OK
+    assert "value callback" in _errmsg(db)  # descriptive message, not the generic code
 
     _nrt.memsys_enable_stats()
     with c_string(_WIN_SQL % "raise_wval") as sp:  # warm
@@ -615,6 +625,8 @@ def test_finalize_exception_empty_group_surfaces_error():
                            sum_init, sum_step, raising_finalize)
     with c_string("SELECT raise_fin_empty(v) FROM t") as sp:
         rc = sqlite3_exec(db, sp, 0, 0, 0)
+    msg = _errmsg(db)
     sqlite3_close(db)
     assert rc != SQLITE_OK  # raising finalize on an empty group must fail loudly
+    assert "finalize callback" in msg  # descriptive message even on the empty-group path
     assert h is not None

--- a/test/core/test_sqlite_udf_helpers.py
+++ b/test/core/test_sqlite_udf_helpers.py
@@ -275,3 +275,54 @@ def test_window_running_sum():
     sqlite3_close(db)
     assert vals == [1, 3, 5, 7, 9]
     assert h is not None
+
+
+@njit
+def sum2_step(state, ctx, argc, argv_pp):  # distinct body => distinct anchor
+    args = carray(_cast_int_to_void_p(argv_pp), (argc,), dtype=np.intp)
+    state.total += 2 * sqlite3_value_int64(args[0])
+
+
+def test_two_distinct_aggregates_no_collision():
+    db = _open_memory()
+    _make_table(db, [1, 2, 3, 4, 5])
+    h1 = register_aggregate(db, "my_sum", 1, sum_state_type,
+                            sum_init, sum_step, sum_finalize)
+    h2 = register_aggregate(db, "my_sum2", 1, sum_state_type,
+                            sum_init, sum2_step, sum_finalize)
+    v1, _c1 = _read1_int64(db, "SELECT __cap(my_sum(v)) FROM t")
+    v2, _c2 = _read1_int64(db, "SELECT __cap(my_sum2(v)) FROM t")
+    sqlite3_close(db)
+    assert (v1, v2) == (15, 30)
+    assert h1 is not None and h2 is not None
+
+
+def test_deterministic_flag():
+    db = _open_memory()
+    _make_table(db, [1, 2, 3, 4, 5])
+    h = register_aggregate(db, "my_sum_det", 1, sum_state_type,
+                           sum_init, sum_step, sum_finalize, deterministic=True)
+    val, _cap = _read1_int64(db, "SELECT __cap(my_sum_det(v)) FROM t")
+    sqlite3_close(db)
+    assert val == 15
+    assert h is not None
+
+
+def test_no_meminfo_leak():
+    """The helper-generated lifecycle must preserve export/release balance."""
+    from numba.core.runtime import nrt
+    _nrt = nrt._nrt
+    if not hasattr(_nrt, "memsys_enable_stats"):
+        import pytest
+        pytest.skip("NRT allocation stats unavailable")
+    _nrt.memsys_enable_stats()
+    test_aggregate_sum()          # warm up JIT / one-time allocs
+    test_window_running_sum()
+    before = nrt.rtsys.get_allocation_stats()
+    for _ in range(10):
+        test_aggregate_sum()
+        test_window_running_sum()
+    after = nrt.rtsys.get_allocation_stats()
+    allocated = after.mi_alloc - before.mi_alloc
+    freed = after.mi_free - before.mi_free
+    assert allocated == freed, "meminfo imbalance: %d alloc, %d free" % (allocated, freed)

--- a/test/core/test_sqlite_udf_helpers.py
+++ b/test/core/test_sqlite_udf_helpers.py
@@ -1,0 +1,124 @@
+"""Tests for the structref-backed SQLite UDAF/window registration helpers."""
+import gc
+from ctypes import addressof, c_int64
+
+import numpy as np
+from numba import carray, cfunc, njit, types
+from numba.core import types as nb_types
+from numba.experimental import structref
+
+from numbox.core.bindings import (
+    SQLITE_OK,
+    SQLITE_UTF8,
+    sqlite3_close,
+    sqlite3_create_function_v2,
+    sqlite3_exec,
+    sqlite3_open,
+    sqlite3_result_int,
+    sqlite3_result_int64,
+    sqlite3_user_data,
+    sqlite3_value_int64,
+)
+from numbox.core.bindings._sqlite_udf_helpers import register_aggregate
+from numbox.utils.cstrings import c_string
+from numbox.utils.lowlevel import _cast_int_to_void_p
+
+
+# --- state type (module-level => importable, stable __module__) ---
+@structref.register
+class SumStateType(nb_types.StructRef):
+    def preprocess_fields(self, fields):
+        return tuple((n, nb_types.unliteral(t)) for n, t in fields)
+
+
+class SumState(structref.StructRefProxy):
+    def __new__(cls, total):
+        return structref.StructRefProxy.__new__(cls, total)
+
+
+structref.define_proxy(SumState, SumStateType, ["total"])
+sum_state_type = SumStateType([("total", nb_types.int64)])
+
+
+@njit
+def sum_init():
+    return SumState(nb_types.int64(0))
+
+
+@njit
+def sum_step(state, ctx, argc, argv_pp):
+    args = carray(_cast_int_to_void_p(argv_pp), (argc,), dtype=np.intp)
+    state.total += sqlite3_value_int64(args[0])
+
+
+@njit
+def sum_finalize(state, ctx):
+    sqlite3_result_int64(ctx, state.total)
+
+
+# --- test plumbing ---
+def _open_memory():
+    db_p = c_int64(0)
+    with c_string(":memory:") as name_p:
+        assert sqlite3_open(name_p, addressof(db_p)) == SQLITE_OK
+    return db_p.value
+
+
+def _make_table(db, values):
+    with c_string("CREATE TABLE t(v INTEGER)") as p:
+        assert sqlite3_exec(db, p, 0, 0, 0) == SQLITE_OK
+    for v in values:
+        with c_string("INSERT INTO t VALUES (%d)" % v) as p:
+            assert sqlite3_exec(db, p, 0, 0, 0) == SQLITE_OK
+
+
+def _read1_int64(db, select_sql):
+    """Route a scalar SELECT through a capture UDF that stores arg0 into a
+    numpy buffer; returns (value, keepalive)."""
+    buf = np.zeros(1, dtype=np.int64)
+
+    @cfunc(types.void(types.intp, types.int32, types.intp))
+    def cap_cb(ctx, argc, argv):
+        ud = sqlite3_user_data(ctx)
+        args = carray(_cast_int_to_void_p(argv), (argc,), dtype=np.intp)
+        o = carray(_cast_int_to_void_p(ud), (1,), dtype=np.int64)
+        o[0] = sqlite3_value_int64(args[0])
+        sqlite3_result_int(ctx, 0)
+
+    with c_string("__cap") as cp:
+        assert sqlite3_create_function_v2(
+            db, cp, 1, SQLITE_UTF8, buf.ctypes.data, cap_cb.address, 0, 0, 0) == SQLITE_OK
+    with c_string(select_sql) as sp:
+        assert sqlite3_exec(db, sp, 0, 0, 0) == SQLITE_OK
+    return int(buf[0]), cap_cb
+
+
+def test_aggregate_sum():
+    db = _open_memory()
+    _make_table(db, [1, 2, 3, 4, 5])
+    h = register_aggregate(db, "my_sum", 1, sum_state_type,
+                           sum_init, sum_step, sum_finalize)
+    gc.collect()  # handle must keep callbacks alive
+    val, _cap = _read1_int64(db, "SELECT __cap(my_sum(v)) FROM t")
+    sqlite3_close(db)
+    assert val == 15
+    assert h is not None
+
+
+def test_aggregate_empty_group():
+    db = _open_memory()
+    _make_table(db, [])
+    h = register_aggregate(db, "my_sum", 1, sum_state_type,
+                           sum_init, sum_step, sum_finalize)
+    val, _cap = _read1_int64(db, "SELECT __cap(my_sum(v)) FROM t")
+    sqlite3_close(db)
+    assert val == 0
+    assert h is not None
+
+
+def test_aggregate_bad_state_type():
+    import pytest
+    db = _open_memory()
+    with pytest.raises(TypeError):
+        register_aggregate(db, "bad", 1, object(), sum_init, sum_step, sum_finalize)
+    sqlite3_close(db)

--- a/test/core/test_sqlite_udf_helpers.py
+++ b/test/core/test_sqlite_udf_helpers.py
@@ -226,3 +226,52 @@ def test_invalidation_on_literal_edit(tmp_path):
     cache.mkdir()
     assert _run_driver(tmp_path, cache, 1) == 15       # step: += 1*v  => 15
     assert _run_driver(tmp_path, cache, 3) == 45       # step: += 3*v  => 45 (not stale 15)
+
+
+from numbox.core.bindings._sqlite_udf_helpers import register_window  # noqa: E402
+
+
+@njit
+def w_inverse(state, ctx, argc, argv_pp):
+    args = carray(_cast_int_to_void_p(argv_pp), (argc,), dtype=np.intp)
+    state.total -= sqlite3_value_int64(args[0])
+
+
+@njit
+def w_value(state, ctx):
+    sqlite3_result_int64(ctx, state.total)
+
+
+def _read_window(db, select_sql, nrows):
+    meta = np.zeros(nrows + 1, dtype=np.int64)  # meta[0]=count, meta[1:]=values
+
+    @cfunc(types.void(types.intp, types.int32, types.intp))
+    def wcap_cb(ctx, argc, argv):
+        ud = sqlite3_user_data(ctx)
+        m = carray(_cast_int_to_void_p(ud), (nrows + 1,), dtype=np.int64)
+        i = m[0]
+        args = carray(_cast_int_to_void_p(argv), (argc,), dtype=np.intp)
+        m[1 + i] = sqlite3_value_int64(args[0])
+        m[0] = i + 1
+        sqlite3_result_int(ctx, 0)
+
+    with c_string("__wcap") as cp:
+        assert sqlite3_create_function_v2(
+            db, cp, 1, SQLITE_UTF8, meta.ctypes.data, wcap_cb.address, 0, 0, 0) == SQLITE_OK
+    with c_string(select_sql) as sp:
+        assert sqlite3_exec(db, sp, 0, 0, 0) == SQLITE_OK
+    return [int(meta[1 + i]) for i in range(int(meta[0]))], wcap_cb
+
+
+def test_window_running_sum():
+    db = _open_memory()
+    _make_table(db, [1, 2, 3, 4, 5])
+    h = register_window(db, "my_wsum", 1, sum_state_type,
+                        sum_init, sum_step, w_inverse, w_value, sum_finalize)
+    sql = ("SELECT __wcap(my_wsum(v) OVER "
+           "(ORDER BY v ROWS BETWEEN 1 PRECEDING AND CURRENT ROW)) "
+           "FROM t ORDER BY v")
+    vals, _cap = _read_window(db, sql, 5)
+    sqlite3_close(db)
+    assert vals == [1, 3, 5, 7, 9]
+    assert h is not None

--- a/test/core/test_sqlite_udf_helpers.py
+++ b/test/core/test_sqlite_udf_helpers.py
@@ -10,6 +10,8 @@ from numba.experimental import structref
 from numbox.core.bindings import (
     SQLITE_OK,
     SQLITE_UTF8,
+    register_aggregate,
+    register_window,
     sqlite3_close,
     sqlite3_create_function_v2,
     sqlite3_exec,
@@ -19,7 +21,6 @@ from numbox.core.bindings import (
     sqlite3_user_data,
     sqlite3_value_int64,
 )
-from numbox.core.bindings._sqlite_udf_helpers import register_aggregate
 from numbox.utils.cstrings import c_string
 from numbox.utils.lowlevel import _cast_int_to_void_p
 
@@ -226,9 +227,6 @@ def test_invalidation_on_literal_edit(tmp_path):
     cache.mkdir()
     assert _run_driver(tmp_path, cache, 1) == 15       # step: += 1*v  => 15
     assert _run_driver(tmp_path, cache, 3) == 45       # step: += 3*v  => 45 (not stale 15)
-
-
-from numbox.core.bindings._sqlite_udf_helpers import register_window  # noqa: E402
 
 
 @njit
@@ -451,4 +449,41 @@ def test_multiarg_multifield_state():
     val, _cap = _read1_int64(db, "SELECT __cap(pairsum(a, b)) FROM t2")
     sqlite3_close(db)
     assert val == 156  # sa=1+2+3=6, sb=4+5+6=15 => 6 + 10*15
+    assert h is not None
+
+
+@njit
+def raising_finalize(state, ctx):
+    raise ValueError("boom from finalize")
+
+
+def test_finalize_exception_surfaces_error_and_no_leak():
+    """A raising finalize must fail the query (xFinal reports SQLITE_ERROR) and
+    must not leak the exported meminfo slot -- xFinal releases in a try/except."""
+    from numba.core.runtime import nrt
+    _nrt = nrt._nrt
+    if not hasattr(_nrt, "memsys_enable_stats"):
+        import pytest
+        pytest.skip("NRT allocation stats unavailable")
+
+    db = _open_memory()
+    _make_table(db, [1, 2, 3, 4, 5])
+    h = register_aggregate(db, "raise_fin", 1, sum_state_type,
+                           sum_init, sum_step, raising_finalize)
+    with c_string("SELECT raise_fin(v) FROM t") as sp:
+        rc = sqlite3_exec(db, sp, 0, 0, 0)
+    assert rc != SQLITE_OK  # error surfaced to sqlite, not a silent wrong result
+
+    _nrt.memsys_enable_stats()
+    with c_string("SELECT raise_fin(v) FROM t") as sp:  # warm
+        sqlite3_exec(db, sp, 0, 0, 0)
+    before = nrt.rtsys.get_allocation_stats()
+    for _ in range(10):
+        with c_string("SELECT raise_fin(v) FROM t") as sp:
+            sqlite3_exec(db, sp, 0, 0, 0)
+    after = nrt.rtsys.get_allocation_stats()
+    sqlite3_close(db)
+    allocated = after.mi_alloc - before.mi_alloc
+    freed = after.mi_free - before.mi_free
+    assert allocated == freed, "leak on raising finalize: %d alloc, %d free" % (allocated, freed)
     assert h is not None

--- a/test/core/test_sqlite_udf_helpers.py
+++ b/test/core/test_sqlite_udf_helpers.py
@@ -122,3 +122,107 @@ def test_aggregate_bad_state_type():
     with pytest.raises(TypeError):
         register_aggregate(db, "bad", 1, object(), sum_init, sum_step, sum_finalize)
     sqlite3_close(db)
+
+
+import os                                            # noqa: E402
+import subprocess                                    # noqa: E402
+import sys                                           # noqa: E402
+import textwrap                                      # noqa: E402
+
+
+# A self-contained driver: defines a state type + sum UDAF in an importable
+# module, registers it, runs SELECT sum(v), prints the result. {MULT} is the
+# step multiplier (1 normally; flipped to prove invalidation).
+_DRIVER = textwrap.dedent('''
+    from ctypes import addressof, c_int64
+    import numpy as np
+    from numba import carray, cfunc, njit, types
+    from numba.core import types as nb_types
+    from numba.experimental import structref
+    from numbox.core.bindings import (
+        SQLITE_OK, SQLITE_UTF8, sqlite3_close, sqlite3_create_function_v2,
+        sqlite3_exec, sqlite3_open, sqlite3_result_int, sqlite3_result_int64,
+        sqlite3_user_data, sqlite3_value_int64)
+    from numbox.core.bindings._sqlite_udf_helpers import register_aggregate
+    from numbox.utils.cstrings import c_string
+    from numbox.utils.lowlevel import _cast_int_to_void_p
+
+    @structref.register
+    class StT(nb_types.StructRef):
+        def preprocess_fields(self, fields):
+            return tuple((n, nb_types.unliteral(t)) for n, t in fields)
+    class St(structref.StructRefProxy):
+        def __new__(cls, total):
+            return structref.StructRefProxy.__new__(cls, total)
+    structref.define_proxy(St, StT, ["total"])
+    st = StT([("total", nb_types.int64)])
+
+    @njit
+    def s_init():
+        return St(nb_types.int64(0))
+    @njit
+    def s_step(state, ctx, argc, argv_pp):
+        a = carray(_cast_int_to_void_p(argv_pp), (argc,), dtype=np.intp)
+        state.total += {MULT} * sqlite3_value_int64(a[0])
+    @njit
+    def s_fin(state, ctx):
+        sqlite3_result_int64(ctx, state.total)
+
+    db_p = c_int64(0)
+    with c_string(":memory:") as n:
+        sqlite3_open(n, addressof(db_p))
+    db = db_p.value
+    with c_string("CREATE TABLE t(v INTEGER)") as p:
+        sqlite3_exec(db, p, 0, 0, 0)
+    for v in (1, 2, 3, 4, 5):
+        with c_string("INSERT INTO t VALUES (%d)" % v) as p:
+            sqlite3_exec(db, p, 0, 0, 0)
+    h = register_aggregate(db, "f", 1, st, s_init, s_step, s_fin)
+    buf = np.zeros(1, dtype=np.int64)
+    @cfunc(types.void(types.intp, types.int32, types.intp))
+    def cap(ctx, argc, argv):
+        ud = sqlite3_user_data(ctx)
+        a = carray(_cast_int_to_void_p(argv), (argc,), dtype=np.intp)
+        o = carray(_cast_int_to_void_p(ud), (1,), dtype=np.int64)
+        o[0] = sqlite3_value_int64(a[0]); sqlite3_result_int(ctx, 0)
+    with c_string("cap") as cp:
+        sqlite3_create_function_v2(db, cp, 1, SQLITE_UTF8, buf.ctypes.data, cap.address, 0, 0, 0)
+    with c_string("SELECT cap(f(v)) FROM t") as sp:
+        sqlite3_exec(db, sp, 0, 0, 0)
+    print("RESULT", int(buf[0]))
+''')
+
+
+def _run_driver(tmp_path, cache_dir, mult):
+    script = tmp_path / ("drv_%d.py" % mult)
+    script.write_text(_DRIVER.replace("{MULT}", str(mult)))
+    env = dict(os.environ, NUMBA_CACHE_DIR=str(cache_dir))
+    out = subprocess.run([sys.executable, str(script)], env=env,
+                         capture_output=True, text=True, timeout=600)
+    assert out.returncode == 0, out.stderr
+    line = [ln for ln in out.stdout.splitlines() if ln.startswith("RESULT")][0]
+    return int(line.split()[1])
+
+
+def _count_nbc(cache_dir):
+    # Count only the generated UDAF impl caches (anchor stem "udaf_"/"wudaf_"),
+    # not the whole cache: scoping keeps the no-growth assertion immune to
+    # unrelated bindings whose compile timing could differ across the matrix.
+    return sum(1 for _ in cache_dir.rglob("*udaf*.nbc"))
+
+
+def test_xprocess_cache_no_growth(tmp_path):
+    cache = tmp_path / "nbcache"
+    cache.mkdir()
+    assert _run_driver(tmp_path, cache, 1) == 15      # cold: compiles + writes cache
+    n_cold = _count_nbc(cache)
+    assert n_cold > 0
+    assert _run_driver(tmp_path, cache, 1) == 15      # warm: must reuse, not append
+    assert _count_nbc(cache) == n_cold, "warm run grew the cache (C failure mode)"
+
+
+def test_invalidation_on_literal_edit(tmp_path):
+    cache = tmp_path / "nbcache"
+    cache.mkdir()
+    assert _run_driver(tmp_path, cache, 1) == 15       # step: += 1*v  => 15
+    assert _run_driver(tmp_path, cache, 3) == 45       # step: += 3*v  => 45 (not stale 15)

--- a/test/core/test_sqlite_udf_helpers.py
+++ b/test/core/test_sqlite_udf_helpers.py
@@ -603,3 +603,18 @@ def test_inverse_exception_surfaces_error_and_no_leak():
     freed = after.mi_free - before.mi_free
     assert allocated == freed, "leak on raising inverse: %d alloc, %d free" % (allocated, freed)
     assert h is not None
+
+
+def test_finalize_exception_empty_group_surfaces_error():
+    """A raising finalize on an EMPTY group (xFinal's no-state branch, where no
+    xStep ran so the aggregate context is NULL) must also fail the query, not be
+    silently swallowed -- the empty-group branch is guarded like the borrow path."""
+    db = _open_memory()
+    _make_table(db, [])  # empty: xStep never runs -> xFinal hits the no-state branch
+    h = register_aggregate(db, "raise_fin_empty", 1, sum_state_type,
+                           sum_init, sum_step, raising_finalize)
+    with c_string("SELECT raise_fin_empty(v) FROM t") as sp:
+        rc = sqlite3_exec(db, sp, 0, 0, 0)
+    sqlite3_close(db)
+    assert rc != SQLITE_OK  # raising finalize on an empty group must fail loudly
+    assert h is not None

--- a/test/core/test_sqlite_udf_helpers.py
+++ b/test/core/test_sqlite_udf_helpers.py
@@ -374,13 +374,19 @@ def test_window_deterministic_flag_ors_bit(monkeypatch):
     assert not (seen[1] & helpers.SQLITE_DETERMINISTIC)
 
 
-def test_registration_error_raises():
-    """A failed sqlite registration (here an out-of-range n_arg) surfaces as a
-    RuntimeError via _raise_rc, not a silent success."""
+def test_registration_error_raises(monkeypatch):
+    """A non-OK return from sqlite registration surfaces as a RuntimeError via
+    _raise_rc, not a silent success. The non-OK code is injected (rather than
+    relying on an out-of-range n_arg or an over-long name, whose rejection is
+    build-dependent -- SQLITE_MAX_FUNCTION_ARG and name limits vary), so the
+    test is portable across sqlite builds."""
     import pytest
+    import numbox.core.bindings._sqlite_udf_helpers as helpers
+    monkeypatch.setattr(helpers, "sqlite3_create_function_v2",
+                        lambda *a, **k: 1)  # non-OK rc (SQLITE_ERROR)
     db = _open_memory()
     with pytest.raises(RuntimeError, match="registration failed"):
-        register_aggregate(db, "too_many_args", 200, sum_state_type,
+        register_aggregate(db, "err", 1, sum_state_type,
                            sum_init, sum_step, sum_finalize)
     sqlite3_close(db)
 

--- a/test/core/test_sqlite_udf_helpers.py
+++ b/test/core/test_sqlite_udf_helpers.py
@@ -278,7 +278,7 @@ def test_window_running_sum():
 
 
 @njit
-def sum2_step(state, ctx, argc, argv_pp):  # distinct body => distinct anchor
+def sum2_step(state, ctx, argc, argv_pp):  # distinct body => independent compiled callbacks
     args = carray(_cast_int_to_void_p(argv_pp), (argc,), dtype=np.intp)
     state.total += 2 * sqlite3_value_int64(args[0])
 
@@ -306,6 +306,30 @@ def test_deterministic_flag():
     sqlite3_close(db)
     assert val == 15
     assert h is not None
+
+
+def test_deterministic_flag_ors_bit(monkeypatch):
+    """deterministic=True must OR SQLITE_DETERMINISTIC into the flags passed to
+    sqlite3_create_function_v2, and the default must not. The flag is a
+    query-planner hint with no effect on an aggregate's value, so a result
+    assertion alone cannot guard this contract -- spy on the flags instead."""
+    import numbox.core.bindings._sqlite_udf_helpers as helpers
+    real = helpers.sqlite3_create_function_v2
+    seen = []
+
+    def spy(db, name_p, n_arg, flags, *rest):
+        seen.append(flags)
+        return real(db, name_p, n_arg, flags, *rest)
+
+    monkeypatch.setattr(helpers, "sqlite3_create_function_v2", spy)
+    db = _open_memory()
+    register_aggregate(db, "det_on", 1, sum_state_type,
+                       sum_init, sum_step, sum_finalize, deterministic=True)
+    register_aggregate(db, "det_off", 1, sum_state_type,
+                       sum_init, sum_step, sum_finalize)
+    sqlite3_close(db)
+    assert seen[0] & helpers.SQLITE_DETERMINISTIC
+    assert not (seen[1] & helpers.SQLITE_DETERMINISTIC)
 
 
 def test_no_meminfo_leak():

--- a/test/core/test_sqlite_udf_helpers.py
+++ b/test/core/test_sqlite_udf_helpers.py
@@ -487,3 +487,119 @@ def test_finalize_exception_surfaces_error_and_no_leak():
     freed = after.mi_free - before.mi_free
     assert allocated == freed, "leak on raising finalize: %d alloc, %d free" % (allocated, freed)
     assert h is not None
+
+
+@njit
+def raising_step(state, ctx, argc, argv_pp):
+    raise ValueError("boom from step")
+
+
+def test_step_exception_surfaces_error_and_no_leak():
+    """A raising step must fail the query (xStep reports SQLITE_ERROR) instead of
+    silently dropping rows, and must not leak the borrowed state meminfo."""
+    from numba.core.runtime import nrt
+    _nrt = nrt._nrt
+    if not hasattr(_nrt, "memsys_enable_stats"):
+        import pytest
+        pytest.skip("NRT allocation stats unavailable")
+
+    db = _open_memory()
+    _make_table(db, [1, 2, 3, 4, 5])
+    h = register_aggregate(db, "raise_step", 1, sum_state_type,
+                           sum_init, raising_step, sum_finalize)
+    with c_string("SELECT raise_step(v) FROM t") as sp:
+        rc = sqlite3_exec(db, sp, 0, 0, 0)
+    assert rc != SQLITE_OK  # raising step fails the query, not a silent wrong result
+
+    _nrt.memsys_enable_stats()
+    with c_string("SELECT raise_step(v) FROM t") as sp:  # warm
+        sqlite3_exec(db, sp, 0, 0, 0)
+    before = nrt.rtsys.get_allocation_stats()
+    for _ in range(10):
+        with c_string("SELECT raise_step(v) FROM t") as sp:
+            sqlite3_exec(db, sp, 0, 0, 0)
+    after = nrt.rtsys.get_allocation_stats()
+    sqlite3_close(db)
+    allocated = after.mi_alloc - before.mi_alloc
+    freed = after.mi_free - before.mi_free
+    assert allocated == freed, "leak on raising step: %d alloc, %d free" % (allocated, freed)
+    assert h is not None
+
+
+_WIN_SQL = ("SELECT %s(v) OVER (ORDER BY v ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) "
+            "FROM t ORDER BY v")
+
+
+@njit
+def raising_value(state, ctx):
+    raise ValueError("boom from value")
+
+
+def test_value_exception_surfaces_error_and_no_leak():
+    """A raising window value must fail the query (xValue reports SQLITE_ERROR)
+    instead of emitting a stale value, and must not leak the borrowed meminfo."""
+    from numba.core.runtime import nrt
+    _nrt = nrt._nrt
+    if not hasattr(_nrt, "memsys_enable_stats"):
+        import pytest
+        pytest.skip("NRT allocation stats unavailable")
+
+    db = _open_memory()
+    _make_table(db, [1, 2, 3, 4, 5])
+    h = register_window(db, "raise_wval", 1, sum_state_type, sum_init, sum_step,
+                        w_inverse, raising_value, sum_finalize)
+    with c_string(_WIN_SQL % "raise_wval") as sp:
+        rc = sqlite3_exec(db, sp, 0, 0, 0)
+    assert rc != SQLITE_OK
+
+    _nrt.memsys_enable_stats()
+    with c_string(_WIN_SQL % "raise_wval") as sp:  # warm
+        sqlite3_exec(db, sp, 0, 0, 0)
+    before = nrt.rtsys.get_allocation_stats()
+    for _ in range(10):
+        with c_string(_WIN_SQL % "raise_wval") as sp:
+            sqlite3_exec(db, sp, 0, 0, 0)
+    after = nrt.rtsys.get_allocation_stats()
+    sqlite3_close(db)
+    allocated = after.mi_alloc - before.mi_alloc
+    freed = after.mi_free - before.mi_free
+    assert allocated == freed, "leak on raising value: %d alloc, %d free" % (allocated, freed)
+    assert h is not None
+
+
+@njit
+def raising_inverse(state, ctx, argc, argv_pp):
+    raise ValueError("boom from inverse")
+
+
+def test_inverse_exception_surfaces_error_and_no_leak():
+    """A raising window inverse must fail the query and must not leak the borrowed
+    meminfo. (SQLite does not document xInverse error propagation, but it is
+    observed on the system sqlite; the load-bearing guarantee is no-leak.)"""
+    from numba.core.runtime import nrt
+    _nrt = nrt._nrt
+    if not hasattr(_nrt, "memsys_enable_stats"):
+        import pytest
+        pytest.skip("NRT allocation stats unavailable")
+
+    db = _open_memory()
+    _make_table(db, [1, 2, 3, 4, 5])
+    h = register_window(db, "raise_winv", 1, sum_state_type, sum_init, sum_step,
+                        raising_inverse, w_value, sum_finalize)
+    with c_string(_WIN_SQL % "raise_winv") as sp:
+        rc = sqlite3_exec(db, sp, 0, 0, 0)
+    assert rc != SQLITE_OK
+
+    _nrt.memsys_enable_stats()
+    with c_string(_WIN_SQL % "raise_winv") as sp:  # warm
+        sqlite3_exec(db, sp, 0, 0, 0)
+    before = nrt.rtsys.get_allocation_stats()
+    for _ in range(10):
+        with c_string(_WIN_SQL % "raise_winv") as sp:
+            sqlite3_exec(db, sp, 0, 0, 0)
+    after = nrt.rtsys.get_allocation_stats()
+    sqlite3_close(db)
+    allocated = after.mi_alloc - before.mi_alloc
+    freed = after.mi_free - before.mi_free
+    assert allocated == freed, "leak on raising inverse: %d alloc, %d free" % (allocated, freed)
+    assert h is not None


### PR DESCRIPTION
Adds thin, lifecycle-only helpers — `register_aggregate` and `register_window` — that generate the SQLite UDAF/window callbacks (`xStep` / `xInverse` / `xValue` / `xFinal`) so callers write only their `@njit` `init` / `step` / `finalize` (+ `inverse` / `value`) state logic. Built on the phase-2 sqlite bindings and the [`meminfo`](https://github.com/nelson2005/numbox/blob/feat/sqlite-udaf-helper/numbox/utils/meminfo.py) bridge.

### Usage
```python
from numbox.core.bindings import register_aggregate

handle = register_aggregate(db, "my_sum", 1, sum_state_type,
                            sum_init, sum_step, sum_finalize)
# caller retains `handle` — SQLite holds raw pointers to the generated cfuncs
```

The helper owns the error-prone boilerplate: `sqlite3_aggregate_context` allocation + NULL guard, the single `intp` meminfo slot, init-on-first-step via `export_meminfo`, `borrow_structref` per call, and the release-in-`xFinal`-but-not-`xValue` rule for windows.

### Mechanism
Per-UDAF callback source is generated with the state type and user functions baked in as module globals (so calls inline), written to a content-addressed anchor under numba's cache dir (reusing [`preprocessing.py`](https://github.com/nelson2005/numbox/blob/feat/sqlite-udaf-helper/numbox/utils/preprocessing.py)), and the `@njit(cache=True)` impls cache across processes. The content hash folds a `cloudpickle` of each user function's `__code__`, so editing a body — even one numeric literal — invalidates correctly. Distinct stems (`udaf_` / `wudaf_`) + the digest prevent collisions when an aggregate and a window share a name or state type.

### Public API & docs
Exported from [`numbox.core.bindings`](https://github.com/nelson2005/numbox/blob/feat/sqlite-udaf-helper/numbox/core/bindings/__init__.py); new `automodule` section in [`docs/numbox.core.bindings.rst`](https://github.com/nelson2005/numbox/blob/feat/sqlite-udaf-helper/docs/numbox.core.bindings.rst).

### Also bundled — `make_graph` cache-key fix
[`8ef1b81`](https://github.com/nelson2005/numbox/commit/8ef1b81) + [`7243cac`](https://github.com/nelson2005/numbox/commit/7243cac) fix an unrelated unbounded `.nbc` growth in [`make_graph`](https://github.com/nelson2005/numbox/blob/feat/sqlite-udaf-helper/numbox/core/work/builder.py): it hashed `repr(init_value)` into the cached name, so a `numpy.empty` init (nondeterministic repr) wrote a fresh cache entry every process. Now keyed off node types. Present upstream too.
