### PR TITLE
Sync main with upstream/main (phase-3 UDAF helper #19)

### DIFF
--- a/docs/numbox.core.bindings.rst
+++ b/docs/numbox.core.bindings.rst
@@ -584,6 +584,14 @@ numbox.core.bindings._sqlite_udf
    :show-inheritance:
    :undoc-members:
 
+numbox.core.bindings._sqlite_udf_helpers
+----------------------------------------
+
+.. automodule:: numbox.core.bindings._sqlite_udf_helpers
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
 numbox.core.bindings.call
 -------------------------
 

--- a/numbox/core/bindings/__init__.py
+++ b/numbox/core/bindings/__init__.py
@@ -11,6 +11,7 @@ from numbox.core.bindings._sqlite_hooks import *  # noqa: F401, F403
 from numbox.core.bindings._sqlite_value import *  # noqa: F401, F403
 from numbox.core.bindings._sqlite_result import *  # noqa: F401, F403
 from numbox.core.bindings._sqlite_udf import *  # noqa: F401, F403
+from numbox.core.bindings._sqlite_udf_helpers import *  # noqa: F401, F403
 from numbox.core.bindings._stdio import *  # noqa: F401, F403
 from numbox.core.bindings._errno import *  # noqa: F401, F403
 from numbox.core.bindings._strerror import *  # noqa: F401, F403

--- a/numbox/core/bindings/_c.py
+++ b/numbox/core/bindings/_c.py
@@ -8,6 +8,8 @@ from numbox.core.proxy.proxy import proxy
 from numbox.core.bindings.call import _call_lib_func
 from numbox.core.bindings.signatures import signatures
 from numbox.core.bindings.utils import load_lib
+from numbox.core.configurations import jit_options
+
 
 __all__ = [
     "rand", "srand",
@@ -23,21 +25,21 @@ __all__ = [
 load_lib("c")
 
 
-@proxy(signatures.get("rand"), jit_options={"cache": True})
+@proxy(signatures.get("rand"), jit_options=jit_options)
 def rand():
     """POSIX `rand() <https://man7.org/linux/man-pages/man3/rand.3.html>`_:
     pseudo-random int in [0, RAND_MAX]. Not thread-safe."""
     return _call_lib_func("rand", ())
 
 
-@proxy(signatures.get("srand"), jit_options={"cache": True})
+@proxy(signatures.get("srand"), jit_options=jit_options)
 def srand(s):
     """POSIX `srand(seed) <https://man7.org/linux/man-pages/man3/rand.3.html>`_:
     seed the rand() generator."""
     return _call_lib_func("srand", (s,))
 
 
-@proxy(signatures.get("strlen"), jit_options={"cache": True})
+@proxy(signatures.get("strlen"), jit_options=jit_options)
 def strlen(s):
     """POSIX `strlen(s) <https://man7.org/linux/man-pages/man3/strlen.3.html>`_:
     number of bytes in the C string at `s` up to (but excluding) the trailing NUL.
@@ -45,7 +47,7 @@ def strlen(s):
     return _call_lib_func("strlen", (s,))
 
 
-@proxy(signatures.get("puts"), jit_options={"cache": True})
+@proxy(signatures.get("puts"), jit_options=jit_options)
 def puts(s):
     """POSIX `puts(s) <https://man7.org/linux/man-pages/man3/puts.3.html>`_:
     write the NUL-terminated string at `s` to stdout followed by a newline.
@@ -53,7 +55,7 @@ def puts(s):
     return _call_lib_func("puts", (s,))
 
 
-@proxy(signatures.get("fputs"), jit_options={"cache": True})
+@proxy(signatures.get("fputs"), jit_options=jit_options)
 def fputs(s, fp):
     """POSIX `fputs(s, fp) <https://man7.org/linux/man-pages/man3/fputs.3.html>`_:
     write the NUL-terminated string at `s` to FILE* `fp` (no trailing newline).
@@ -61,7 +63,7 @@ def fputs(s, fp):
     return _call_lib_func("fputs", (s, fp))
 
 
-@proxy(signatures.get("fputc"), jit_options={"cache": True})
+@proxy(signatures.get("fputc"), jit_options=jit_options)
 def fputc(c, fp):
     """POSIX `fputc(c, fp) <https://man7.org/linux/man-pages/man3/fputc.3.html>`_:
     write byte `c` (as unsigned char) to FILE* `fp`. Returns the byte on success,
@@ -69,14 +71,14 @@ def fputc(c, fp):
     return _call_lib_func("fputc", (c, fp))
 
 
-@proxy(signatures.get("putchar"), jit_options={"cache": True})
+@proxy(signatures.get("putchar"), jit_options=jit_options)
 def putchar(c):
     """POSIX `putchar(c) <https://man7.org/linux/man-pages/man3/putchar.3.html>`_:
     write byte `c` (as unsigned char) to stdout."""
     return _call_lib_func("putchar", (c,))
 
 
-@proxy(signatures.get("fwrite"), jit_options={"cache": True})
+@proxy(signatures.get("fwrite"), jit_options=jit_options)
 def fwrite(ptr, size, nmemb, fp):
     """POSIX `fwrite(ptr, size, nmemb, fp)
     <https://man7.org/linux/man-pages/man3/fwrite.3.html>`_: write `nmemb`
@@ -85,7 +87,7 @@ def fwrite(ptr, size, nmemb, fp):
     return _call_lib_func("fwrite", (ptr, size, nmemb, fp))
 
 
-@proxy(signatures.get("fread"), jit_options={"cache": True})
+@proxy(signatures.get("fread"), jit_options=jit_options)
 def fread(ptr, size, nmemb, fp):
     """POSIX `fread(ptr, size, nmemb, fp)
     <https://man7.org/linux/man-pages/man3/fread.3.html>`_: read up to `nmemb`
@@ -94,7 +96,7 @@ def fread(ptr, size, nmemb, fp):
     return _call_lib_func("fread", (ptr, size, nmemb, fp))
 
 
-@proxy(signatures.get("fflush"), jit_options={"cache": True})
+@proxy(signatures.get("fflush"), jit_options=jit_options)
 def fflush(fp):
     """POSIX `fflush(fp) <https://man7.org/linux/man-pages/man3/fflush.3.html>`_:
     flush the C stdio buffer for FILE* `fp` (pass NULL/0 to flush all streams).
@@ -102,7 +104,7 @@ def fflush(fp):
     return _call_lib_func("fflush", (fp,))
 
 
-@proxy(signatures.get("fopen"), jit_options={"cache": True})
+@proxy(signatures.get("fopen"), jit_options=jit_options)
 def fopen(path, mode):
     """POSIX `fopen(path, mode) <https://man7.org/linux/man-pages/man3/fopen.3.html>`_:
     open the file at `path` (NUL-terminated) with mode string `mode` (e.g.
@@ -111,7 +113,7 @@ def fopen(path, mode):
     return _call_lib_func("fopen", (path, mode))
 
 
-@proxy(signatures.get("fclose"), jit_options={"cache": True})
+@proxy(signatures.get("fclose"), jit_options=jit_options)
 def fclose(fp):
     """POSIX `fclose(fp) <https://man7.org/linux/man-pages/man3/fclose.3.html>`_:
     close FILE* `fp` and flush any buffered output. Returns 0 on success, EOF
@@ -119,7 +121,7 @@ def fclose(fp):
     return _call_lib_func("fclose", (fp,))
 
 
-@proxy(signatures.get("feof"), jit_options={"cache": True})
+@proxy(signatures.get("feof"), jit_options=jit_options)
 def feof(fp):
     """POSIX `feof(fp) <https://man7.org/linux/man-pages/man3/feof.3.html>`_:
     non-zero iff the end-of-file indicator is set on FILE* `fp`. Cleared by
@@ -127,7 +129,7 @@ def feof(fp):
     return _call_lib_func("feof", (fp,))
 
 
-@proxy(signatures.get("ferror"), jit_options={"cache": True})
+@proxy(signatures.get("ferror"), jit_options=jit_options)
 def ferror(fp):
     """POSIX `ferror(fp) <https://man7.org/linux/man-pages/man3/ferror.3.html>`_:
     non-zero iff the error indicator is set on FILE* `fp`. Cleared only by
@@ -135,14 +137,14 @@ def ferror(fp):
     return _call_lib_func("ferror", (fp,))
 
 
-@proxy(signatures.get("clearerr"), jit_options={"cache": True})
+@proxy(signatures.get("clearerr"), jit_options=jit_options)
 def clearerr(fp):
     """POSIX `clearerr(fp) <https://man7.org/linux/man-pages/man3/clearerr.3.html>`_:
     clear the end-of-file and error indicators on FILE* `fp`."""
     return _call_lib_func("clearerr", (fp,))
 
 
-@proxy(signatures.get("strcmp"), jit_options={"cache": True})
+@proxy(signatures.get("strcmp"), jit_options=jit_options)
 def strcmp(a, b):
     """POSIX `strcmp(a, b) <https://man7.org/linux/man-pages/man3/strcmp.3.html>`_:
     lexicographic byte comparison of two NUL-terminated strings. Returns
@@ -150,7 +152,7 @@ def strcmp(a, b):
     return _call_lib_func("strcmp", (a, b))
 
 
-@proxy(signatures.get("strncmp"), jit_options={"cache": True})
+@proxy(signatures.get("strncmp"), jit_options=jit_options)
 def strncmp(a, b, n):
     """POSIX `strncmp(a, b, n) <https://man7.org/linux/man-pages/man3/strncmp.3.html>`_:
     `strcmp` bounded to the first `n` bytes (stops early at a NUL on either side).
@@ -158,7 +160,7 @@ def strncmp(a, b, n):
     return _call_lib_func("strncmp", (a, b, n))
 
 
-@proxy(signatures.get("strchr"), jit_options={"cache": True})
+@proxy(signatures.get("strchr"), jit_options=jit_options)
 def strchr(s, c):
     """POSIX `strchr(s, c) <https://man7.org/linux/man-pages/man3/strchr.3.html>`_:
     pointer to the FIRST occurrence of byte `c` in NUL-terminated string `s`,
@@ -166,7 +168,7 @@ def strchr(s, c):
     return _call_lib_func("strchr", (s, c))
 
 
-@proxy(signatures.get("strrchr"), jit_options={"cache": True})
+@proxy(signatures.get("strrchr"), jit_options=jit_options)
 def strrchr(s, c):
     """POSIX `strrchr(s, c) <https://man7.org/linux/man-pages/man3/strrchr.3.html>`_:
     pointer to the LAST occurrence of byte `c` in NUL-terminated string `s`,
@@ -174,7 +176,7 @@ def strrchr(s, c):
     return _call_lib_func("strrchr", (s, c))
 
 
-@proxy(signatures.get("strstr"), jit_options={"cache": True})
+@proxy(signatures.get("strstr"), jit_options=jit_options)
 def strstr(haystack, needle):
     """POSIX `strstr(haystack, needle) <https://man7.org/linux/man-pages/man3/strstr.3.html>`_:
     pointer to the first occurrence of NUL-terminated `needle` within
@@ -183,7 +185,7 @@ def strstr(haystack, needle):
     return _call_lib_func("strstr", (haystack, needle))
 
 
-@proxy(signatures.get("strncpy"), jit_options={"cache": True})
+@proxy(signatures.get("strncpy"), jit_options=jit_options)
 def strncpy(dst, src, n):
     """POSIX `strncpy(dst, src, n) <https://man7.org/linux/man-pages/man3/strncpy.3.html>`_:
     copy at most n bytes from src to dst.
@@ -196,7 +198,7 @@ def strncpy(dst, src, n):
     return _call_lib_func("strncpy", (dst, src, n))
 
 
-@proxy(signatures.get("strerror"), jit_options={"cache": True})
+@proxy(signatures.get("strerror"), jit_options=jit_options)
 def strerror(errnum):
     """POSIX `strerror(errnum) <https://man7.org/linux/man-pages/man3/strerror.3.html>`_:
     pointer to the static error-message string for errnum.
@@ -208,7 +210,7 @@ def strerror(errnum):
     return _call_lib_func("strerror", (errnum,))
 
 
-@proxy(signatures.get("memcpy"), jit_options={"cache": True})
+@proxy(signatures.get("memcpy"), jit_options=jit_options)
 def memcpy(dst, src, n):
     """POSIX `memcpy(dst, src, n) <https://man7.org/linux/man-pages/man3/memcpy.3.html>`_:
     copy `n` bytes from `src` to `dst`. Source and destination must NOT overlap
@@ -216,7 +218,7 @@ def memcpy(dst, src, n):
     return _call_lib_func("memcpy", (dst, src, n))
 
 
-@proxy(signatures.get("memmove"), jit_options={"cache": True})
+@proxy(signatures.get("memmove"), jit_options=jit_options)
 def memmove(dst, src, n):
     """POSIX `memmove(dst, src, n) <https://man7.org/linux/man-pages/man3/memmove.3.html>`_:
     copy `n` bytes from `src` to `dst`, correctly handling overlapping regions.
@@ -224,7 +226,7 @@ def memmove(dst, src, n):
     return _call_lib_func("memmove", (dst, src, n))
 
 
-@proxy(signatures.get("memset"), jit_options={"cache": True})
+@proxy(signatures.get("memset"), jit_options=jit_options)
 def memset(dst, c, n):
     """POSIX `memset(dst, c, n) <https://man7.org/linux/man-pages/man3/memset.3.html>`_:
     fill the first `n` bytes of `dst` with the byte value `c & 0xff`. Returns `dst`.
@@ -232,7 +234,7 @@ def memset(dst, c, n):
     return _call_lib_func("memset", (dst, c, n))
 
 
-@proxy(signatures.get("memcmp"), jit_options={"cache": True})
+@proxy(signatures.get("memcmp"), jit_options=jit_options)
 def memcmp(a, b, n):
     """POSIX `memcmp(a, b, n) <https://man7.org/linux/man-pages/man3/memcmp.3.html>`_:
     byte-wise compare the first `n` bytes of `a` and `b`. Returns negative, zero,
@@ -241,7 +243,7 @@ def memcmp(a, b, n):
     return _call_lib_func("memcmp", (a, b, n))
 
 
-@proxy(signatures.get("memchr"), jit_options={"cache": True})
+@proxy(signatures.get("memchr"), jit_options=jit_options)
 def memchr(s, c, n):
     """POSIX `memchr(s, c, n) <https://man7.org/linux/man-pages/man3/memchr.3.html>`_:
     pointer to the first byte equal to `c & 0xff` in the first `n` bytes at `s`,
@@ -249,7 +251,7 @@ def memchr(s, c, n):
     return _call_lib_func("memchr", (s, c, n))
 
 
-@proxy(signatures.get("getenv"), jit_options={"cache": True})
+@proxy(signatures.get("getenv"), jit_options=jit_options)
 def getenv(name):
     """POSIX `getenv(name) <https://man7.org/linux/man-pages/man3/getenv.3.html>`_:
     pointer to the value string in the process environ table for variable `name`,

--- a/numbox/core/bindings/_errno.py
+++ b/numbox/core/bindings/_errno.py
@@ -5,6 +5,7 @@ from numba.core.types import int32, int64, intp, void
 from numba.extending import intrinsic
 
 from numbox.core.bindings.utils import platform_, load_lib
+from numbox.core.configurations import jit_options
 from numbox.core.proxy.proxy import proxy
 from numbox.utils.lowlevel import load_at, store_at
 
@@ -46,7 +47,7 @@ def _errno_ptr(typingctx):
     return intp(), codegen
 
 
-@proxy(int32(), jit_options={"cache": True})
+@proxy(int32(), jit_options=jit_options)
 def errno_get():
     """Return the current thread's errno as int32.
 
@@ -59,7 +60,7 @@ def errno_get():
     return load_at(_errno_ptr(), int32)
 
 
-@proxy(void(int64), jit_options={"cache": True})
+@proxy(void(int64), jit_options=jit_options)
 def errno_set(v):
     """Set the current thread's errno to v.
 

--- a/numbox/core/bindings/_math.py
+++ b/numbox/core/bindings/_math.py
@@ -1,7 +1,9 @@
-from numbox.core.proxy.proxy import proxy
 from numbox.core.bindings.call import _call_lib_func
 from numbox.core.bindings.signatures import signatures
 from numbox.core.bindings.utils import load_lib
+from numbox.core.configurations import jit_options
+from numbox.core.proxy.proxy import proxy
+
 
 __all__ = [
     "cos", "sin", "tan",
@@ -22,211 +24,211 @@ __all__ = [
 load_lib("m")
 
 
-@proxy(signatures.get("cos"), jit_options={"cache": True})
+@proxy(signatures.get("cos"), jit_options=jit_options)
 def cos(x):
     return _call_lib_func("cos", (x,))
 
 
-@proxy(signatures.get("sin"), jit_options={"cache": True})
+@proxy(signatures.get("sin"), jit_options=jit_options)
 def sin(x):
     return _call_lib_func("sin", (x,))
 
 
-@proxy(signatures.get("tan"), jit_options={"cache": True})
+@proxy(signatures.get("tan"), jit_options=jit_options)
 def tan(x):
     return _call_lib_func("tan", (x,))
 
 
-@proxy(signatures.get("acos"), jit_options={"cache": True})
+@proxy(signatures.get("acos"), jit_options=jit_options)
 def acos(x):
     return _call_lib_func("acos", (x,))
 
 
-@proxy(signatures.get("asin"), jit_options={"cache": True})
+@proxy(signatures.get("asin"), jit_options=jit_options)
 def asin(x):
     return _call_lib_func("asin", (x,))
 
 
-@proxy(signatures.get("atan"), jit_options={"cache": True})
+@proxy(signatures.get("atan"), jit_options=jit_options)
 def atan(x):
     return _call_lib_func("atan", (x,))
 
 
-@proxy(signatures.get("cosh"), jit_options={"cache": True})
+@proxy(signatures.get("cosh"), jit_options=jit_options)
 def cosh(x):
     return _call_lib_func("cosh", (x,))
 
 
-@proxy(signatures.get("sinh"), jit_options={"cache": True})
+@proxy(signatures.get("sinh"), jit_options=jit_options)
 def sinh(x):
     return _call_lib_func("sinh", (x,))
 
 
-@proxy(signatures.get("tanh"), jit_options={"cache": True})
+@proxy(signatures.get("tanh"), jit_options=jit_options)
 def tanh(x):
     return _call_lib_func("tanh", (x,))
 
 
-@proxy(signatures.get("acosh"), jit_options={"cache": True})
+@proxy(signatures.get("acosh"), jit_options=jit_options)
 def acosh(x):
     return _call_lib_func("acosh", (x,))
 
 
-@proxy(signatures.get("asinh"), jit_options={"cache": True})
+@proxy(signatures.get("asinh"), jit_options=jit_options)
 def asinh(x):
     return _call_lib_func("asinh", (x,))
 
 
-@proxy(signatures.get("atanh"), jit_options={"cache": True})
+@proxy(signatures.get("atanh"), jit_options=jit_options)
 def atanh(x):
     return _call_lib_func("atanh", (x,))
 
 
-@proxy(signatures.get("exp"), jit_options={"cache": True})
+@proxy(signatures.get("exp"), jit_options=jit_options)
 def exp(x):
     return _call_lib_func("exp", (x,))
 
 
-@proxy(signatures.get("exp2"), jit_options={"cache": True})
+@proxy(signatures.get("exp2"), jit_options=jit_options)
 def exp2(x):
     return _call_lib_func("exp2", (x,))
 
 
-@proxy(signatures.get("expm1"), jit_options={"cache": True})
+@proxy(signatures.get("expm1"), jit_options=jit_options)
 def expm1(x):
     return _call_lib_func("expm1", (x,))
 
 
-@proxy(signatures.get("log"), jit_options={"cache": True})
+@proxy(signatures.get("log"), jit_options=jit_options)
 def log(x):
     return _call_lib_func("log", (x,))
 
 
-@proxy(signatures.get("log2"), jit_options={"cache": True})
+@proxy(signatures.get("log2"), jit_options=jit_options)
 def log2(x):
     return _call_lib_func("log2", (x,))
 
 
-@proxy(signatures.get("log10"), jit_options={"cache": True})
+@proxy(signatures.get("log10"), jit_options=jit_options)
 def log10(x):
     return _call_lib_func("log10", (x,))
 
 
-@proxy(signatures.get("log1p"), jit_options={"cache": True})
+@proxy(signatures.get("log1p"), jit_options=jit_options)
 def log1p(x):
     return _call_lib_func("log1p", (x,))
 
 
-@proxy(signatures.get("logb"), jit_options={"cache": True})
+@proxy(signatures.get("logb"), jit_options=jit_options)
 def logb(x):
     return _call_lib_func("logb", (x,))
 
 
-@proxy(signatures.get("sqrt"), jit_options={"cache": True})
+@proxy(signatures.get("sqrt"), jit_options=jit_options)
 def sqrt(x):
     return _call_lib_func("sqrt", (x,))
 
 
-@proxy(signatures.get("cbrt"), jit_options={"cache": True})
+@proxy(signatures.get("cbrt"), jit_options=jit_options)
 def cbrt(x):
     return _call_lib_func("cbrt", (x,))
 
 
-@proxy(signatures.get("ceil"), jit_options={"cache": True})
+@proxy(signatures.get("ceil"), jit_options=jit_options)
 def ceil(x):
     return _call_lib_func("ceil", (x,))
 
 
-@proxy(signatures.get("floor"), jit_options={"cache": True})
+@proxy(signatures.get("floor"), jit_options=jit_options)
 def floor(x):
     return _call_lib_func("floor", (x,))
 
 
-@proxy(signatures.get("trunc"), jit_options={"cache": True})
+@proxy(signatures.get("trunc"), jit_options=jit_options)
 def trunc(x):
     return _call_lib_func("trunc", (x,))
 
 
-@proxy(signatures.get("round"), jit_options={"cache": True})
+@proxy(signatures.get("round"), jit_options=jit_options)
 def round(x):
     return _call_lib_func("round", (x,))
 
 
-@proxy(signatures.get("rint"), jit_options={"cache": True})
+@proxy(signatures.get("rint"), jit_options=jit_options)
 def rint(x):
     return _call_lib_func("rint", (x,))
 
 
-@proxy(signatures.get("nearbyint"), jit_options={"cache": True})
+@proxy(signatures.get("nearbyint"), jit_options=jit_options)
 def nearbyint(x):
     return _call_lib_func("nearbyint", (x,))
 
 
-@proxy(signatures.get("erf"), jit_options={"cache": True})
+@proxy(signatures.get("erf"), jit_options=jit_options)
 def erf(x):
     return _call_lib_func("erf", (x,))
 
 
-@proxy(signatures.get("erfc"), jit_options={"cache": True})
+@proxy(signatures.get("erfc"), jit_options=jit_options)
 def erfc(x):
     return _call_lib_func("erfc", (x,))
 
 
-@proxy(signatures.get("lgamma"), jit_options={"cache": True})
+@proxy(signatures.get("lgamma"), jit_options=jit_options)
 def lgamma(x):
     return _call_lib_func("lgamma", (x,))
 
 
-@proxy(signatures.get("tgamma"), jit_options={"cache": True})
+@proxy(signatures.get("tgamma"), jit_options=jit_options)
 def tgamma(x):
     return _call_lib_func("tgamma", (x,))
 
 
-@proxy(signatures.get("fabs"), jit_options={"cache": True})
+@proxy(signatures.get("fabs"), jit_options=jit_options)
 def fabs(x):
     return _call_lib_func("fabs", (x,))
 
 
-@proxy(signatures.get("atan2"), jit_options={"cache": True})
+@proxy(signatures.get("atan2"), jit_options=jit_options)
 def atan2(y, x):
     return _call_lib_func("atan2", (y, x))
 
 
-@proxy(signatures.get("pow"), jit_options={"cache": True})
+@proxy(signatures.get("pow"), jit_options=jit_options)
 def pow(x, y):
     return _call_lib_func("pow", (x, y))
 
 
-@proxy(signatures.get("fmod"), jit_options={"cache": True})
+@proxy(signatures.get("fmod"), jit_options=jit_options)
 def fmod(x, y):
     return _call_lib_func("fmod", (x, y))
 
 
-@proxy(signatures.get("remainder"), jit_options={"cache": True})
+@proxy(signatures.get("remainder"), jit_options=jit_options)
 def remainder(x, y):
     return _call_lib_func("remainder", (x, y))
 
 
-@proxy(signatures.get("hypot"), jit_options={"cache": True})
+@proxy(signatures.get("hypot"), jit_options=jit_options)
 def hypot(x, y):
     return _call_lib_func("hypot", (x, y))
 
 
-@proxy(signatures.get("fmax"), jit_options={"cache": True})
+@proxy(signatures.get("fmax"), jit_options=jit_options)
 def fmax(x, y):
     return _call_lib_func("fmax", (x, y))
 
 
-@proxy(signatures.get("fmin"), jit_options={"cache": True})
+@proxy(signatures.get("fmin"), jit_options=jit_options)
 def fmin(x, y):
     return _call_lib_func("fmin", (x, y))
 
 
-@proxy(signatures.get("fdim"), jit_options={"cache": True})
+@proxy(signatures.get("fdim"), jit_options=jit_options)
 def fdim(x, y):
     return _call_lib_func("fdim", (x, y))
 
 
-@proxy(signatures.get("copysign"), jit_options={"cache": True})
+@proxy(signatures.get("copysign"), jit_options=jit_options)
 def copysign(x, y):
     return _call_lib_func("copysign", (x, y))

--- a/numbox/core/bindings/_sqlite_bind.py
+++ b/numbox/core/bindings/_sqlite_bind.py
@@ -11,7 +11,9 @@ caller can guarantee the array outlives the prepared statement.
 from numbox.core.bindings.call import _call_lib_func
 from numbox.core.bindings.signatures import signatures
 from numbox.core.bindings.utils import load_lib
+from numbox.core.configurations import jit_options
 from numbox.core.proxy.proxy import proxy
+
 
 __all__ = [
     "sqlite3_bind_int", "sqlite3_bind_int64", "sqlite3_bind_double",
@@ -24,50 +26,50 @@ __all__ = [
 load_lib("sqlite3")
 
 
-@proxy(signatures.get("sqlite3_bind_int"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_bind_int"), jit_options=jit_options)
 def sqlite3_bind_int(stmt_p, idx, val):
     return _call_lib_func("sqlite3_bind_int", (stmt_p, idx, val))
 
 
-@proxy(signatures.get("sqlite3_bind_int64"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_bind_int64"), jit_options=jit_options)
 def sqlite3_bind_int64(stmt_p, idx, val):
     return _call_lib_func("sqlite3_bind_int64", (stmt_p, idx, val))
 
 
-@proxy(signatures.get("sqlite3_bind_double"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_bind_double"), jit_options=jit_options)
 def sqlite3_bind_double(stmt_p, idx, val):
     return _call_lib_func("sqlite3_bind_double", (stmt_p, idx, val))
 
 
-@proxy(signatures.get("sqlite3_bind_text"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_bind_text"), jit_options=jit_options)
 def sqlite3_bind_text(stmt_p, idx, text_p, n, destructor):
     return _call_lib_func(
         "sqlite3_bind_text", (stmt_p, idx, text_p, n, destructor)
     )
 
 
-@proxy(signatures.get("sqlite3_bind_blob"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_bind_blob"), jit_options=jit_options)
 def sqlite3_bind_blob(stmt_p, idx, data_p, n, destructor):
     return _call_lib_func(
         "sqlite3_bind_blob", (stmt_p, idx, data_p, n, destructor)
     )
 
 
-@proxy(signatures.get("sqlite3_bind_null"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_bind_null"), jit_options=jit_options)
 def sqlite3_bind_null(stmt_p, idx):
     return _call_lib_func("sqlite3_bind_null", (stmt_p, idx))
 
 
-@proxy(signatures.get("sqlite3_bind_parameter_count"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_bind_parameter_count"), jit_options=jit_options)
 def sqlite3_bind_parameter_count(stmt_p):
     return _call_lib_func("sqlite3_bind_parameter_count", (stmt_p,))
 
 
-@proxy(signatures.get("sqlite3_bind_parameter_index"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_bind_parameter_index"), jit_options=jit_options)
 def sqlite3_bind_parameter_index(stmt_p, name_p):
     return _call_lib_func("sqlite3_bind_parameter_index", (stmt_p, name_p))
 
 
-@proxy(signatures.get("sqlite3_bind_parameter_name"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_bind_parameter_name"), jit_options=jit_options)
 def sqlite3_bind_parameter_name(stmt_p, idx):
     return _call_lib_func("sqlite3_bind_parameter_name", (stmt_p, idx))

--- a/numbox/core/bindings/_sqlite_blob.py
+++ b/numbox/core/bindings/_sqlite_blob.py
@@ -7,7 +7,9 @@ All functions present in SQLite 3.4.0 (2007) except _reopen which arrived in
 from numbox.core.bindings.call import _call_lib_func
 from numbox.core.bindings.signatures import signatures
 from numbox.core.bindings.utils import load_lib
+from numbox.core.configurations import jit_options
 from numbox.core.proxy.proxy import proxy
+
 
 __all__ = [
     "sqlite3_blob_open", "sqlite3_blob_close", "sqlite3_blob_bytes",
@@ -18,7 +20,7 @@ __all__ = [
 load_lib("sqlite3")
 
 
-@proxy(signatures.get("sqlite3_blob_open"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_blob_open"), jit_options=jit_options)
 def sqlite3_blob_open(db_p, db_name_p, table_p, col_p, rowid, flags, blob_pp):
     return _call_lib_func(
         "sqlite3_blob_open",
@@ -26,26 +28,26 @@ def sqlite3_blob_open(db_p, db_name_p, table_p, col_p, rowid, flags, blob_pp):
     )
 
 
-@proxy(signatures.get("sqlite3_blob_close"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_blob_close"), jit_options=jit_options)
 def sqlite3_blob_close(blob_p):
     return _call_lib_func("sqlite3_blob_close", (blob_p,))
 
 
-@proxy(signatures.get("sqlite3_blob_bytes"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_blob_bytes"), jit_options=jit_options)
 def sqlite3_blob_bytes(blob_p):
     return _call_lib_func("sqlite3_blob_bytes", (blob_p,))
 
 
-@proxy(signatures.get("sqlite3_blob_read"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_blob_read"), jit_options=jit_options)
 def sqlite3_blob_read(blob_p, buf_p, n, offset):
     return _call_lib_func("sqlite3_blob_read", (blob_p, buf_p, n, offset))
 
 
-@proxy(signatures.get("sqlite3_blob_write"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_blob_write"), jit_options=jit_options)
 def sqlite3_blob_write(blob_p, buf_p, n, offset):
     return _call_lib_func("sqlite3_blob_write", (blob_p, buf_p, n, offset))
 
 
-@proxy(signatures.get("sqlite3_blob_reopen"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_blob_reopen"), jit_options=jit_options)
 def sqlite3_blob_reopen(blob_p, new_rowid):
     return _call_lib_func("sqlite3_blob_reopen", (blob_p, new_rowid))

--- a/numbox/core/bindings/_sqlite_column.py
+++ b/numbox/core/bindings/_sqlite_column.py
@@ -14,7 +14,9 @@ All other accessors are universally available across the matrix.
 from numbox.core.bindings.call import _call_lib_func
 from numbox.core.bindings.signatures import signatures
 from numbox.core.bindings.utils import load_lib
+from numbox.core.configurations import jit_options
 from numbox.core.proxy.proxy import proxy, proxy_if_available
+
 
 __all__ = [
     "sqlite3_column_int", "sqlite3_column_int64", "sqlite3_column_double",
@@ -29,67 +31,67 @@ __all__ = [
 _sqlite3_lib = load_lib("sqlite3")
 
 
-@proxy(signatures.get("sqlite3_column_int"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_column_int"), jit_options=jit_options)
 def sqlite3_column_int(stmt_p, idx):
     return _call_lib_func("sqlite3_column_int", (stmt_p, idx))
 
 
-@proxy(signatures.get("sqlite3_column_int64"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_column_int64"), jit_options=jit_options)
 def sqlite3_column_int64(stmt_p, idx):
     return _call_lib_func("sqlite3_column_int64", (stmt_p, idx))
 
 
-@proxy(signatures.get("sqlite3_column_double"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_column_double"), jit_options=jit_options)
 def sqlite3_column_double(stmt_p, idx):
     return _call_lib_func("sqlite3_column_double", (stmt_p, idx))
 
 
-@proxy(signatures.get("sqlite3_column_text"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_column_text"), jit_options=jit_options)
 def sqlite3_column_text(stmt_p, idx):
     return _call_lib_func("sqlite3_column_text", (stmt_p, idx))
 
 
-@proxy(signatures.get("sqlite3_column_blob"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_column_blob"), jit_options=jit_options)
 def sqlite3_column_blob(stmt_p, idx):
     return _call_lib_func("sqlite3_column_blob", (stmt_p, idx))
 
 
-@proxy(signatures.get("sqlite3_column_bytes"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_column_bytes"), jit_options=jit_options)
 def sqlite3_column_bytes(stmt_p, idx):
     return _call_lib_func("sqlite3_column_bytes", (stmt_p, idx))
 
 
-@proxy(signatures.get("sqlite3_column_type"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_column_type"), jit_options=jit_options)
 def sqlite3_column_type(stmt_p, idx):
     return _call_lib_func("sqlite3_column_type", (stmt_p, idx))
 
 
-@proxy(signatures.get("sqlite3_column_count"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_column_count"), jit_options=jit_options)
 def sqlite3_column_count(stmt_p):
     return _call_lib_func("sqlite3_column_count", (stmt_p,))
 
 
-@proxy(signatures.get("sqlite3_column_name"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_column_name"), jit_options=jit_options)
 def sqlite3_column_name(stmt_p, idx):
     return _call_lib_func("sqlite3_column_name", (stmt_p, idx))
 
 
-@proxy(signatures.get("sqlite3_column_decltype"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_column_decltype"), jit_options=jit_options)
 def sqlite3_column_decltype(stmt_p, idx):
     return _call_lib_func("sqlite3_column_decltype", (stmt_p, idx))
 
 
 # Compile-flag-gated (SQLITE_ENABLE_COLUMN_METADATA)
-@proxy_if_available(_sqlite3_lib, signatures.get("sqlite3_column_database_name"), jit_options={"cache": True})
+@proxy_if_available(_sqlite3_lib, signatures.get("sqlite3_column_database_name"), jit_options=jit_options)
 def sqlite3_column_database_name(stmt_p, idx):
     return _call_lib_func("sqlite3_column_database_name", (stmt_p, idx))
 
 
-@proxy_if_available(_sqlite3_lib, signatures.get("sqlite3_column_table_name"), jit_options={"cache": True})
+@proxy_if_available(_sqlite3_lib, signatures.get("sqlite3_column_table_name"), jit_options=jit_options)
 def sqlite3_column_table_name(stmt_p, idx):
     return _call_lib_func("sqlite3_column_table_name", (stmt_p, idx))
 
 
-@proxy_if_available(_sqlite3_lib, signatures.get("sqlite3_column_origin_name"), jit_options={"cache": True})
+@proxy_if_available(_sqlite3_lib, signatures.get("sqlite3_column_origin_name"), jit_options=jit_options)
 def sqlite3_column_origin_name(stmt_p, idx):
     return _call_lib_func("sqlite3_column_origin_name", (stmt_p, idx))

--- a/numbox/core/bindings/_sqlite_conn.py
+++ b/numbox/core/bindings/_sqlite_conn.py
@@ -18,7 +18,9 @@ to the int32 variants.
 from numbox.core.bindings.call import _call_lib_func
 from numbox.core.bindings.signatures import signatures
 from numbox.core.bindings.utils import load_lib
+from numbox.core.configurations import jit_options
 from numbox.core.proxy.proxy import proxy, proxy_if_available
+
 
 __all__ = [
     "sqlite3_open", "sqlite3_open_v2", "sqlite3_close",
@@ -34,87 +36,87 @@ __all__ = [
 _sqlite3_lib = load_lib("sqlite3")
 
 
-@proxy(signatures.get("sqlite3_open"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_open"), jit_options=jit_options)
 def sqlite3_open(filename_p, db_pp):
     return _call_lib_func("sqlite3_open", (filename_p, db_pp))
 
 
-@proxy(signatures.get("sqlite3_open_v2"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_open_v2"), jit_options=jit_options)
 def sqlite3_open_v2(filename_p, db_pp, flags, vfs_p):
     return _call_lib_func("sqlite3_open_v2", (filename_p, db_pp, flags, vfs_p))
 
 
-@proxy(signatures.get("sqlite3_close"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_close"), jit_options=jit_options)
 def sqlite3_close(db_p):
     return _call_lib_func("sqlite3_close", (db_p,))
 
 
-@proxy(signatures.get("sqlite3_libversion"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_libversion"), jit_options=jit_options)
 def sqlite3_libversion():
     return _call_lib_func("sqlite3_libversion")
 
 
-@proxy(signatures.get("sqlite3_libversion_number"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_libversion_number"), jit_options=jit_options)
 def sqlite3_libversion_number():
     return _call_lib_func("sqlite3_libversion_number")
 
 
-@proxy(signatures.get("sqlite3_errmsg"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_errmsg"), jit_options=jit_options)
 def sqlite3_errmsg(db_p):
     return _call_lib_func("sqlite3_errmsg", (db_p,))
 
 
-@proxy(signatures.get("sqlite3_errcode"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_errcode"), jit_options=jit_options)
 def sqlite3_errcode(db_p):
     return _call_lib_func("sqlite3_errcode", (db_p,))
 
 
-@proxy(signatures.get("sqlite3_extended_errcode"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_extended_errcode"), jit_options=jit_options)
 def sqlite3_extended_errcode(db_p):
     return _call_lib_func("sqlite3_extended_errcode", (db_p,))
 
 
-@proxy(signatures.get("sqlite3_threadsafe"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_threadsafe"), jit_options=jit_options)
 def sqlite3_threadsafe():
     return _call_lib_func("sqlite3_threadsafe")
 
 
-@proxy(signatures.get("sqlite3_db_handle"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_db_handle"), jit_options=jit_options)
 def sqlite3_db_handle(stmt_p):
     return _call_lib_func("sqlite3_db_handle", (stmt_p,))
 
 
-@proxy(signatures.get("sqlite3_db_filename"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_db_filename"), jit_options=jit_options)
 def sqlite3_db_filename(db_p, name_p):
     return _call_lib_func("sqlite3_db_filename", (db_p, name_p))
 
 
-@proxy(signatures.get("sqlite3_db_readonly"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_db_readonly"), jit_options=jit_options)
 def sqlite3_db_readonly(db_p, name_p):
     return _call_lib_func("sqlite3_db_readonly", (db_p, name_p))
 
 
-@proxy(signatures.get("sqlite3_changes"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_changes"), jit_options=jit_options)
 def sqlite3_changes(db_p):
     return _call_lib_func("sqlite3_changes", (db_p,))
 
 
-@proxy(signatures.get("sqlite3_last_insert_rowid"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_last_insert_rowid"), jit_options=jit_options)
 def sqlite3_last_insert_rowid(db_p):
     return _call_lib_func("sqlite3_last_insert_rowid", (db_p,))
 
 
-@proxy(signatures.get("sqlite3_total_changes"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_total_changes"), jit_options=jit_options)
 def sqlite3_total_changes(db_p):
     return _call_lib_func("sqlite3_total_changes", (db_p,))
 
 
 # SQLite 3.37+; stubbed via proxy_if_available on older library versions.
-@proxy_if_available(_sqlite3_lib, signatures.get("sqlite3_changes64"), jit_options={"cache": True})
+@proxy_if_available(_sqlite3_lib, signatures.get("sqlite3_changes64"), jit_options=jit_options)
 def sqlite3_changes64(db_p):
     return _call_lib_func("sqlite3_changes64", (db_p,))
 
 
-@proxy_if_available(_sqlite3_lib, signatures.get("sqlite3_total_changes64"), jit_options={"cache": True})
+@proxy_if_available(_sqlite3_lib, signatures.get("sqlite3_total_changes64"), jit_options=jit_options)
 def sqlite3_total_changes64(db_p):
     return _call_lib_func("sqlite3_total_changes64", (db_p,))

--- a/numbox/core/bindings/_sqlite_exec.py
+++ b/numbox/core/bindings/_sqlite_exec.py
@@ -21,7 +21,9 @@ Produce the callback address from Python via:
 from numbox.core.bindings.call import _call_lib_func
 from numbox.core.bindings.signatures import signatures
 from numbox.core.bindings.utils import load_lib
+from numbox.core.configurations import jit_options
 from numbox.core.proxy.proxy import proxy
+
 
 __all__ = [
     "sqlite3_exec", "sqlite3_free",
@@ -31,13 +33,13 @@ __all__ = [
 load_lib("sqlite3")
 
 
-@proxy(signatures.get("sqlite3_exec"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_exec"), jit_options=jit_options)
 def sqlite3_exec(db_p, sql_p, cb_p, ctx_p, errmsg_pp):
     return _call_lib_func(
         "sqlite3_exec", (db_p, sql_p, cb_p, ctx_p, errmsg_pp)
     )
 
 
-@proxy(signatures.get("sqlite3_free"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_free"), jit_options=jit_options)
 def sqlite3_free(mem_p):
     return _call_lib_func("sqlite3_free", (mem_p,))

--- a/numbox/core/bindings/_sqlite_hooks.py
+++ b/numbox/core/bindings/_sqlite_hooks.py
@@ -16,7 +16,9 @@ Callback shapes (informational; signatures are caller's responsibility):
 from numbox.core.bindings.call import _call_lib_func
 from numbox.core.bindings.signatures import signatures
 from numbox.core.bindings.utils import load_lib
+from numbox.core.configurations import jit_options
 from numbox.core.proxy.proxy import proxy
+
 
 __all__ = [
     "sqlite3_update_hook", "sqlite3_progress_handler", "sqlite3_busy_handler",
@@ -27,31 +29,31 @@ __all__ = [
 load_lib("sqlite3")
 
 
-@proxy(signatures.get("sqlite3_update_hook"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_update_hook"), jit_options=jit_options)
 def sqlite3_update_hook(db_p, cb_p, ctx_p):
     return _call_lib_func("sqlite3_update_hook", (db_p, cb_p, ctx_p))
 
 
-@proxy(signatures.get("sqlite3_progress_handler"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_progress_handler"), jit_options=jit_options)
 def sqlite3_progress_handler(db_p, n_ops, cb_p, ctx_p):
     return _call_lib_func("sqlite3_progress_handler", (db_p, n_ops, cb_p, ctx_p))
 
 
-@proxy(signatures.get("sqlite3_busy_handler"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_busy_handler"), jit_options=jit_options)
 def sqlite3_busy_handler(db_p, cb_p, ctx_p):
     return _call_lib_func("sqlite3_busy_handler", (db_p, cb_p, ctx_p))
 
 
-@proxy(signatures.get("sqlite3_commit_hook"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_commit_hook"), jit_options=jit_options)
 def sqlite3_commit_hook(db_p, cb_p, ctx_p):
     return _call_lib_func("sqlite3_commit_hook", (db_p, cb_p, ctx_p))
 
 
-@proxy(signatures.get("sqlite3_rollback_hook"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_rollback_hook"), jit_options=jit_options)
 def sqlite3_rollback_hook(db_p, cb_p, ctx_p):
     return _call_lib_func("sqlite3_rollback_hook", (db_p, cb_p, ctx_p))
 
 
-@proxy(signatures.get("sqlite3_trace_v2"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_trace_v2"), jit_options=jit_options)
 def sqlite3_trace_v2(db_p, mask, cb_p, ctx_p):
     return _call_lib_func("sqlite3_trace_v2", (db_p, mask, cb_p, ctx_p))

--- a/numbox/core/bindings/_sqlite_result.py
+++ b/numbox/core/bindings/_sqlite_result.py
@@ -12,7 +12,9 @@ trailing args) is one of:
 from numbox.core.bindings.call import _call_lib_func
 from numbox.core.bindings.signatures import signatures
 from numbox.core.bindings.utils import load_lib
+from numbox.core.configurations import jit_options
 from numbox.core.proxy.proxy import proxy
+
 
 __all__ = [
     "sqlite3_result_int", "sqlite3_result_int64", "sqlite3_result_double",
@@ -29,81 +31,81 @@ __all__ = [
 load_lib("sqlite3")
 
 
-@proxy(signatures.get("sqlite3_result_int"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_result_int"), jit_options=jit_options)
 def sqlite3_result_int(ctx, val):
     return _call_lib_func("sqlite3_result_int", (ctx, val))
 
 
-@proxy(signatures.get("sqlite3_result_int64"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_result_int64"), jit_options=jit_options)
 def sqlite3_result_int64(ctx, val):
     return _call_lib_func("sqlite3_result_int64", (ctx, val))
 
 
-@proxy(signatures.get("sqlite3_result_double"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_result_double"), jit_options=jit_options)
 def sqlite3_result_double(ctx, val):
     return _call_lib_func("sqlite3_result_double", (ctx, val))
 
 
-@proxy(signatures.get("sqlite3_result_text"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_result_text"), jit_options=jit_options)
 def sqlite3_result_text(ctx, text_p, n_bytes, destructor):
     return _call_lib_func("sqlite3_result_text", (ctx, text_p, n_bytes, destructor))
 
 
-@proxy(signatures.get("sqlite3_result_text64"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_result_text64"), jit_options=jit_options)
 def sqlite3_result_text64(ctx, text_p, n_bytes, destructor, encoding):
     return _call_lib_func("sqlite3_result_text64", (ctx, text_p, n_bytes, destructor, encoding))
 
 
-@proxy(signatures.get("sqlite3_result_blob"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_result_blob"), jit_options=jit_options)
 def sqlite3_result_blob(ctx, data_p, n_bytes, destructor):
     return _call_lib_func("sqlite3_result_blob", (ctx, data_p, n_bytes, destructor))
 
 
-@proxy(signatures.get("sqlite3_result_blob64"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_result_blob64"), jit_options=jit_options)
 def sqlite3_result_blob64(ctx, data_p, n_bytes, destructor):
     return _call_lib_func("sqlite3_result_blob64", (ctx, data_p, n_bytes, destructor))
 
 
-@proxy(signatures.get("sqlite3_result_null"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_result_null"), jit_options=jit_options)
 def sqlite3_result_null(ctx):
     return _call_lib_func("sqlite3_result_null", (ctx,))
 
 
-@proxy(signatures.get("sqlite3_result_error"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_result_error"), jit_options=jit_options)
 def sqlite3_result_error(ctx, msg_p, n_bytes):
     return _call_lib_func("sqlite3_result_error", (ctx, msg_p, n_bytes))
 
 
-@proxy(signatures.get("sqlite3_result_error_nomem"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_result_error_nomem"), jit_options=jit_options)
 def sqlite3_result_error_nomem(ctx):
     return _call_lib_func("sqlite3_result_error_nomem", (ctx,))
 
 
-@proxy(signatures.get("sqlite3_result_error_toobig"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_result_error_toobig"), jit_options=jit_options)
 def sqlite3_result_error_toobig(ctx):
     return _call_lib_func("sqlite3_result_error_toobig", (ctx,))
 
 
-@proxy(signatures.get("sqlite3_result_error_code"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_result_error_code"), jit_options=jit_options)
 def sqlite3_result_error_code(ctx, errcode):
     return _call_lib_func("sqlite3_result_error_code", (ctx, errcode))
 
 
-@proxy(signatures.get("sqlite3_result_subtype"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_result_subtype"), jit_options=jit_options)
 def sqlite3_result_subtype(ctx, subtype):
     return _call_lib_func("sqlite3_result_subtype", (ctx, subtype))
 
 
-@proxy(signatures.get("sqlite3_result_value"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_result_value"), jit_options=jit_options)
 def sqlite3_result_value(ctx, value_p):
     return _call_lib_func("sqlite3_result_value", (ctx, value_p))
 
 
-@proxy(signatures.get("sqlite3_result_zeroblob"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_result_zeroblob"), jit_options=jit_options)
 def sqlite3_result_zeroblob(ctx, n):
     return _call_lib_func("sqlite3_result_zeroblob", (ctx, n))
 
 
-@proxy(signatures.get("sqlite3_result_zeroblob64"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_result_zeroblob64"), jit_options=jit_options)
 def sqlite3_result_zeroblob64(ctx, n):
     return _call_lib_func("sqlite3_result_zeroblob64", (ctx, n))

--- a/numbox/core/bindings/_sqlite_stmt.py
+++ b/numbox/core/bindings/_sqlite_stmt.py
@@ -9,7 +9,9 @@ ownership in a way the rest of the bindings don't.
 from numbox.core.bindings.call import _call_lib_func
 from numbox.core.bindings.signatures import signatures
 from numbox.core.bindings.utils import load_lib
+from numbox.core.configurations import jit_options
 from numbox.core.proxy.proxy import proxy
+
 
 __all__ = [
     "sqlite3_prepare_v2", "sqlite3_finalize", "sqlite3_reset", "sqlite3_step",
@@ -20,36 +22,36 @@ __all__ = [
 load_lib("sqlite3")
 
 
-@proxy(signatures.get("sqlite3_prepare_v2"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_prepare_v2"), jit_options=jit_options)
 def sqlite3_prepare_v2(db_p, sql_p, n_byte, stmt_pp, tail_pp):
     return _call_lib_func("sqlite3_prepare_v2", (db_p, sql_p, n_byte, stmt_pp, tail_pp))
 
 
-@proxy(signatures.get("sqlite3_finalize"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_finalize"), jit_options=jit_options)
 def sqlite3_finalize(stmt_p):
     return _call_lib_func("sqlite3_finalize", (stmt_p,))
 
 
-@proxy(signatures.get("sqlite3_reset"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_reset"), jit_options=jit_options)
 def sqlite3_reset(stmt_p):
     return _call_lib_func("sqlite3_reset", (stmt_p,))
 
 
-@proxy(signatures.get("sqlite3_step"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_step"), jit_options=jit_options)
 def sqlite3_step(stmt_p):
     return _call_lib_func("sqlite3_step", (stmt_p,))
 
 
-@proxy(signatures.get("sqlite3_sql"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_sql"), jit_options=jit_options)
 def sqlite3_sql(stmt_p):
     return _call_lib_func("sqlite3_sql", (stmt_p,))
 
 
-@proxy(signatures.get("sqlite3_expanded_sql"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_expanded_sql"), jit_options=jit_options)
 def sqlite3_expanded_sql(stmt_p):
     return _call_lib_func("sqlite3_expanded_sql", (stmt_p,))
 
 
-@proxy(signatures.get("sqlite3_stmt_busy"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_stmt_busy"), jit_options=jit_options)
 def sqlite3_stmt_busy(stmt_p):
     return _call_lib_func("sqlite3_stmt_busy", (stmt_p,))

--- a/numbox/core/bindings/_sqlite_udf.py
+++ b/numbox/core/bindings/_sqlite_udf.py
@@ -12,7 +12,9 @@ Pass 0 for NULL (no callback / no pApp / no xDestroy).
 from numbox.core.bindings.call import _call_lib_func
 from numbox.core.bindings.signatures import signatures
 from numbox.core.bindings.utils import load_lib
+from numbox.core.configurations import jit_options
 from numbox.core.proxy.proxy import proxy
+
 
 __all__ = [
     "sqlite3_create_function_v2", "sqlite3_create_window_function",
@@ -24,7 +26,7 @@ __all__ = [
 load_lib("sqlite3")
 
 
-@proxy(signatures.get("sqlite3_create_function_v2"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_create_function_v2"), jit_options=jit_options)
 def sqlite3_create_function_v2(
         db, name_p, n_arg, e_text_rep, p_app,
         x_func, x_step, x_final, x_destroy):
@@ -35,7 +37,7 @@ def sqlite3_create_function_v2(
 
 
 @proxy(signatures.get("sqlite3_create_window_function"),
-       jit_options={"cache": True})
+       jit_options=jit_options)
 def sqlite3_create_window_function(
         db, name_p, n_arg, e_text_rep, p_app,
         x_step, x_final, x_value, x_inverse, x_destroy):
@@ -45,16 +47,16 @@ def sqlite3_create_window_function(
          x_step, x_final, x_value, x_inverse, x_destroy))
 
 
-@proxy(signatures.get("sqlite3_aggregate_context"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_aggregate_context"), jit_options=jit_options)
 def sqlite3_aggregate_context(ctx, n_bytes):
     return _call_lib_func("sqlite3_aggregate_context", (ctx, n_bytes))
 
 
-@proxy(signatures.get("sqlite3_user_data"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_user_data"), jit_options=jit_options)
 def sqlite3_user_data(ctx):
     return _call_lib_func("sqlite3_user_data", (ctx,))
 
 
-@proxy(signatures.get("sqlite3_context_db_handle"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_context_db_handle"), jit_options=jit_options)
 def sqlite3_context_db_handle(ctx):
     return _call_lib_func("sqlite3_context_db_handle", (ctx,))

--- a/numbox/core/bindings/_sqlite_udf_helpers.py
+++ b/numbox/core/bindings/_sqlite_udf_helpers.py
@@ -21,17 +21,19 @@ per-group meminfo leak. Only ``xFinal`` releases the slot.
 Mechanism: per-UDAF callback source is generated with the state type and the user functions
 baked in as module globals (so the calls inline), written to a content-addressed
 anchor file under numba's cache dir (reusing numbox.utils.preprocessing), and the
-``@njit(cache=True)`` impls cache across processes. The anchor's content hash
+impls (``@njit(**jit_options)`` -- the numbox-wide config, default ``cache=True``)
+cache across processes. The anchor's content hash
 folds a cloudpickle of the user functions' code objects so editing a body --
 including a numeric literal -- invalidates correctly.
 
 **Caller requirements.** Callbacks may be plain Python functions or already-jitted
 callables (``@njit``/``@proxy``); plain ones are compiled with ``njit`` (see
-``_prepare_callbacks``). The generated ``@njit(cache=True)`` impls cache and
-invalidate correctly even when the state-type class and the callbacks
-are defined in ``__main__`` -- the anchor key is content-addressed on a
-``cloudpickle`` of each callback's ``__code__`` (plus ``repr(state_type)`` and
-the numba/numbox versions), never on ``__module__`` (see ``_digest``); the
+``_prepare_callbacks``). The generated impls (``@njit(**jit_options)``, default
+``cache=True``) cache and invalidate correctly even when the state-type class and
+the callbacks are defined in ``__main__`` -- the anchor key is content-addressed
+on a ``cloudpickle`` of each callback's ``__code__`` (plus ``repr(state_type)``,
+the resolved ``jit_options``, and the numba/numbox versions), never on
+``__module__`` (see ``_digest``); the
 subprocess tests ``test_xprocess_cache_no_growth`` /
 ``test_invalidation_on_literal_edit`` exercise this ``__main__`` path. The one
 case that does require a stable ``__module__`` is a *caller-side*
@@ -49,6 +51,7 @@ from numba.core.types import StructRef
 from numba.extending import is_jitted
 
 import numbox
+from numbox.core.configurations import jit_options
 from numbox.core.bindings._sqlite_conn import sqlite3_errmsg
 from numbox.core.bindings._sqlite_constants import (
     SQLITE_DETERMINISTIC,
@@ -86,10 +89,11 @@ _orphan_anchor_sweep(_ANCHOR_SUBDIR)
 
 
 # Generated-source templates. Baked global names: _state_type, _init, _step,
-# _finalize, _inverse, _value. Each impl is @njit(cache=True) so it caches
-# cross-process; the user fns inline because they are module globals here.
+# _finalize, _inverse, _value, jit_options. Each impl is @njit(**jit_options)
+# (numbox-wide config, default cache=True) so it caches cross-process; the user
+# fns inline because they are module globals here.
 _XSTEP_SRC = '''
-@njit(cache=True)
+@njit(**jit_options)
 def _xstep_impl(ctx, argc, argv_pp):
     agg = sqlite3_aggregate_context(ctx, 8)
     if agg == 0:
@@ -108,7 +112,7 @@ def _xstep_impl(ctx, argc, argv_pp):
 '''
 
 _XFINAL_SRC = '''
-@njit(cache=True)
+@njit(**jit_options)
 def _xfinal_impl(ctx):
     agg = sqlite3_aggregate_context(ctx, 0)
     if agg == 0:
@@ -142,7 +146,7 @@ def _xfinal_impl(ctx):
 '''
 
 _XINVERSE_SRC = '''
-@njit(cache=True)
+@njit(**jit_options)
 def _xinverse_impl(ctx, argc, argv_pp):
     agg = sqlite3_aggregate_context(ctx, 0)
     if agg == 0:
@@ -157,7 +161,7 @@ def _xinverse_impl(ctx, argc, argv_pp):
 '''
 
 _XVALUE_SRC = '''
-@njit(cache=True)
+@njit(**jit_options)
 def _xvalue_impl(ctx):
     agg = sqlite3_aggregate_context(ctx, 0)
     if agg == 0:
@@ -231,7 +235,7 @@ def _prepare_callbacks(**fns):
 def _digest(state_type, fns):
     """Content hash that invalidates when the state type, the user functions
     (co_consts-sensitive, via cloudpickle of the code object -- NOT bare
-    co_code), or the numba/numbox versions change."""
+    co_code), the resolved ``jit_options``, or the numba/numbox versions change."""
     h = hashlib.sha256()
     h.update(repr(state_type).encode("utf-8"))
     h.update(numba.__version__.encode("utf-8"))
@@ -241,6 +245,9 @@ def _digest(state_type, fns):
     # numba version above and the code-object hash below do the real
     # invalidating work (proven by test_invalidation_on_literal_edit).
     h.update((numbox.__version__ or "").encode("utf-8"))
+    # fold the resolved numbox-wide jit_options so flipping NUMBOX_JIT_OPTIONS
+    # (e.g. cache off) re-keys the anchor; numba's own cache also keys on flags.
+    h.update(repr(sorted(jit_options.items())).encode("utf-8"))
     for fn in fns:
         py = getattr(fn, "py_func", fn)
         h.update(cloudpickle.dumps(py.__code__))

--- a/numbox/core/bindings/_sqlite_udf_helpers.py
+++ b/numbox/core/bindings/_sqlite_udf_helpers.py
@@ -5,8 +5,8 @@ functions (xStep/xInverse/xValue/xFinal) that perform the per-group state
 lifecycle -- ``sqlite3_aggregate_context`` allocation + NULL guard, the single
 intp slot, init-on-first-step via ``export_meminfo``, ``borrow_structref``, and
 the release-in-xFinal-but-NOT-xValue rule -- so callers write only their
-``@njit`` ``init``/``step``/``finalize`` (and ``inverse``/``value`` for windows)
-state logic.
+``init``/``step``/``finalize`` (and ``inverse``/``value`` for windows) state
+logic, as plain Python or already-jitted (``@njit``/``@proxy``) functions.
 
 **Exception handling.** Each generated callback wraps the user
 step/inverse/value/finalize call in a ``try``/``except`` that reports a
@@ -26,8 +26,10 @@ anchor file under numba's cache dir (reusing numbox.utils.preprocessing), and th
 folds a cloudpickle of the user functions' code objects so editing a body --
 including a numeric literal -- invalidates correctly.
 
-**Caller requirements.** The generated ``@njit(cache=True)`` impls cache and
-invalidate correctly even when the state-type class and the ``@njit`` callbacks
+**Caller requirements.** Callbacks may be plain Python functions or already-jitted
+callables (``@njit``/``@proxy``); plain ones are compiled with ``njit`` (see
+``_prepare_callbacks``). The generated ``@njit(cache=True)`` impls cache and
+invalidate correctly even when the state-type class and the callbacks
 are defined in ``__main__`` -- the anchor key is content-addressed on a
 ``cloudpickle`` of each callback's ``__code__`` (plus ``repr(state_type)`` and
 the numba/numbox versions), never on ``__module__`` (see ``_digest``); the
@@ -207,14 +209,24 @@ def _validate_state_type(state_type):
             "(e.g. MyStateType([('x', int64)])), got %r" % (state_type,))
 
 
-def _validate_callbacks(**fns):
-    """Reject non-``@njit`` callbacks up front with a clear message; otherwise a
-    plain Python callable surfaces as a cryptic numba ``TypingError`` when it
-    fails to bake into the generated source."""
+def _prepare_callbacks(**fns):
+    """Return ``fns`` with each callback ensured numba-compiled: an already
+    jitted callable (``@njit``, ``@proxy``, ...) passes through; a plain Python
+    function is wrapped with ``njit``. The callbacks are inlined into the
+    generated ``@njit(cache=True)`` impls, so a lazy ``njit`` (no explicit
+    signature) suffices -- the impl drives specialization -- and the
+    content-addressed anchor (keyed on ``py_func.__code__``) provides the
+    cross-process caching, so callbacks need no ``cache=True`` of their own."""
+    prepared = {}
     for role, fn in fns.items():
-        if not is_jitted(fn):
+        if is_jitted(fn):
+            prepared[role] = fn
+        elif callable(fn):
+            prepared[role] = njit(fn)
+        else:
             raise TypeError(
-                "%s must be an @njit-compiled function, got %r" % (role, fn))
+                "%s must be a callable (plain Python or @njit), got %r" % (role, fn))
+    return prepared
 
 
 def _digest(state_type, fns):
@@ -271,21 +283,24 @@ def register_aggregate(db, name, n_arg, state_type, init, step, finalize,
                        *, deterministic=False):
     """Register a structref-backed aggregate UDAF.
 
+    Callbacks may be plain Python or already-jitted (``@njit``/``@proxy``); plain
+    functions are compiled with ``njit``.
+
     :param db: connection pointer (intp), as returned by ``sqlite3_open``.
     :param name: SQL function name (str); the C-string lifetime is handled here.
     :param n_arg: argument count, or -1 for variadic.
     :param state_type: the numba structref *instance* type for per-group state.
-    :param init: ``@njit`` ``() -> state`` returning a fresh state.
-    :param step: ``@njit`` ``(state, ctx, argc, argv_pp)`` updating state.
-    :param finalize: ``@njit`` ``(state, ctx)`` writing the result.
+    :param init: ``() -> state`` returning a fresh state.
+    :param step: ``(state, ctx, argc, argv_pp)`` updating state.
+    :param finalize: ``(state, ctx)`` writing the result.
     :param deterministic: OR-in ``SQLITE_DETERMINISTIC``.
     :returns: a keep-alive handle the caller MUST retain (see ``_UDAFHandle``).
     """
     _validate_state_type(state_type)
-    _validate_callbacks(init=init, step=step, finalize=finalize)
+    fns = _prepare_callbacks(init=init, step=step, finalize=finalize)
     ns = _compile_callbacks(
         _stem("udaf_", name), [_XSTEP_SRC, _XFINAL_SRC], state_type,
-        {"_init": init, "_step": step, "_finalize": finalize})
+        {"_init": fns["init"], "_step": fns["step"], "_finalize": fns["finalize"]})
     xstep_impl = ns["_xstep_impl"]
     xfinal_impl = ns["_xfinal_impl"]
 
@@ -305,7 +320,7 @@ def register_aggregate(db, name, n_arg, state_type, init, step, finalize,
     if rc != SQLITE_OK:
         _raise_rc(db, name, rc)
     return _UDAFHandle(step_cb, final_cb, xstep_impl, xfinal_impl,
-                       init, step, finalize)
+                       fns["init"], fns["step"], fns["finalize"])
 
 
 def register_window(db, name, n_arg, state_type, init, step, inverse, value,
@@ -318,13 +333,13 @@ def register_window(db, name, n_arg, state_type, init, step, inverse, value,
     releases the meminfo.
     """
     _validate_state_type(state_type)
-    _validate_callbacks(init=init, step=step, inverse=inverse, value=value,
-                        finalize=finalize)
+    fns = _prepare_callbacks(init=init, step=step, inverse=inverse, value=value,
+                             finalize=finalize)
     ns = _compile_callbacks(
         _stem("wudaf_", name),
         [_XSTEP_SRC, _XINVERSE_SRC, _XVALUE_SRC, _XFINAL_SRC], state_type,
-        {"_init": init, "_step": step, "_inverse": inverse,
-         "_value": value, "_finalize": finalize})
+        {"_init": fns["init"], "_step": fns["step"], "_inverse": fns["inverse"],
+         "_value": fns["value"], "_finalize": fns["finalize"]})
     xstep_impl = ns["_xstep_impl"]
     xinverse_impl = ns["_xinverse_impl"]
     xvalue_impl = ns["_xvalue_impl"]
@@ -356,4 +371,5 @@ def register_window(db, name, n_arg, state_type, init, step, inverse, value,
         _raise_rc(db, name, rc)
     return _UDAFHandle(step_cb, inverse_cb, value_cb, final_cb,
                        xstep_impl, xinverse_impl, xvalue_impl, xfinal_impl,
-                       init, step, inverse, value, finalize)
+                       fns["init"], fns["step"], fns["inverse"],
+                       fns["value"], fns["finalize"])

--- a/numbox/core/bindings/_sqlite_udf_helpers.py
+++ b/numbox/core/bindings/_sqlite_udf_helpers.py
@@ -18,8 +18,7 @@ be a silent wrong result; the in-body catch also lets numba run the borrowed
 state's reference-count decrement, which the unwind would otherwise skip -- a
 per-group meminfo leak. Only ``xFinal`` releases the slot.
 
-Mechanism (see docs/superpowers/specs/2026-05-29-sqlite-udaf-registration-helper-design.md):
-per-UDAF callback source is generated with the state type and the user functions
+Mechanism: per-UDAF callback source is generated with the state type and the user functions
 baked in as module globals (so the calls inline), written to a content-addressed
 anchor file under numba's cache dir (reusing numbox.utils.preprocessing), and the
 ``@njit(cache=True)`` impls cache across processes. The anchor's content hash

--- a/numbox/core/bindings/_sqlite_udf_helpers.py
+++ b/numbox/core/bindings/_sqlite_udf_helpers.py
@@ -194,17 +194,6 @@ def _xvalue_impl(ctx):
 '''
 
 
-class _UDAFHandle:
-    """Keeps the generated ``cfunc`` callbacks (and the user functions they bake
-    in) alive. SQLite holds raw pointers to the cfuncs; if this handle is
-    garbage-collected the pointers dangle and the next call segfaults. **The
-    caller MUST retain the returned handle for as long as the UDAF is used.**"""
-    __slots__ = ("_keep",)
-
-    def __init__(self, *objs):
-        self._keep = objs
-
-
 def _validate_state_type(state_type):
     if not isinstance(state_type, StructRef):
         raise TypeError(
@@ -300,7 +289,9 @@ def register_aggregate(db, name, n_arg, state_type, init, step, finalize,
     :param step: ``(state, ctx, argc, argv_pp)`` updating state.
     :param finalize: ``(state, ctx)`` writing the result.
     :param deterministic: OR-in ``SQLITE_DETERMINISTIC``.
-    :returns: a keep-alive handle the caller MUST retain (see ``_UDAFHandle``).
+
+    Returns ``None``; the generated callbacks need not be retained -- numba keeps
+    the compiled cfunc code and dispatchers resident for the process lifetime.
     """
     _validate_state_type(state_type)
     fns = _prepare_callbacks(init=init, step=step, finalize=finalize)
@@ -325,8 +316,6 @@ def register_aggregate(db, name, n_arg, state_type, init, step, finalize,
             step_cb.address, final_cb.address, 0)
     if rc != SQLITE_OK:
         _raise_rc(db, name, rc)
-    return _UDAFHandle(step_cb, final_cb, xstep_impl, xfinal_impl,
-                       fns["init"], fns["step"], fns["finalize"])
 
 
 def register_window(db, name, n_arg, state_type, init, step, inverse, value,
@@ -375,7 +364,3 @@ def register_window(db, name, n_arg, state_type, init, step, inverse, value,
             value_cb.address, inverse_cb.address, 0)
     if rc != SQLITE_OK:
         _raise_rc(db, name, rc)
-    return _UDAFHandle(step_cb, inverse_cb, value_cb, final_cb,
-                       xstep_impl, xinverse_impl, xvalue_impl, xfinal_impl,
-                       fns["init"], fns["step"], fns["inverse"],
-                       fns["value"], fns["finalize"])

--- a/numbox/core/bindings/_sqlite_udf_helpers.py
+++ b/numbox/core/bindings/_sqlite_udf_helpers.py
@@ -1,0 +1,359 @@
+"""Higher-level registration helpers for structref-backed SQLite UDAFs.
+
+``register_aggregate`` / ``register_window`` generate the SQLite callback
+functions (xStep/xInverse/xValue/xFinal) that perform the per-group state
+lifecycle -- ``sqlite3_aggregate_context`` allocation + NULL guard, the single
+intp slot, init-on-first-step via ``export_meminfo``, ``borrow_structref``, and
+the release-in-xFinal-but-NOT-xValue rule -- so callers write only their
+``@njit`` ``init``/``step``/``finalize`` (and ``inverse``/``value`` for windows)
+state logic.
+
+**Exception handling.** Each generated callback wraps the user
+step/inverse/value/finalize call in a ``try``/``except`` that reports a
+descriptive error via ``sqlite3_result_error`` (e.g. "error in user step
+callback", with code ``SQLITE_ERROR``) when the user callback raises.
+A numba ``@cfunc`` otherwise SWALLOWS the exception (it prints "Exception
+ignored" and returns the zero default without unwinding into SQLite), which would
+be a silent wrong result; the in-body catch also lets numba run the borrowed
+state's reference-count decrement, which the unwind would otherwise skip -- a
+per-group meminfo leak. Only ``xFinal`` releases the slot.
+
+Mechanism (see docs/superpowers/specs/2026-05-29-sqlite-udaf-registration-helper-design.md):
+per-UDAF callback source is generated with the state type and the user functions
+baked in as module globals (so the calls inline), written to a content-addressed
+anchor file under numba's cache dir (reusing numbox.utils.preprocessing), and the
+``@njit(cache=True)`` impls cache across processes. The anchor's content hash
+folds a cloudpickle of the user functions' code objects so editing a body --
+including a numeric literal -- invalidates correctly.
+
+**Caller requirements.** The generated ``@njit(cache=True)`` impls cache and
+invalidate correctly even when the state-type class and the ``@njit`` callbacks
+are defined in ``__main__`` -- the anchor key is content-addressed on a
+``cloudpickle`` of each callback's ``__code__`` (plus ``repr(state_type)`` and
+the numba/numbox versions), never on ``__module__`` (see ``_digest``); the
+subprocess tests ``test_xprocess_cache_no_growth`` /
+``test_invalidation_on_literal_edit`` exercise this ``__main__`` path. The one
+case that does require a stable ``__module__`` is a *caller-side*
+``@njit(cache=True)`` callback -- numba refuses to cache functions defined in
+``__main__`` -- so for deployments where callbacks are themselves cached, define
+the state-type class and callbacks in an importable module.
+"""
+import ctypes
+import hashlib
+
+import numba
+from numba import cfunc, types
+from numba.core.serialize import cloudpickle
+from numba.core.types import StructRef
+from numba.extending import is_jitted
+
+import numbox
+from numbox.core.bindings._sqlite_conn import sqlite3_errmsg
+from numbox.core.bindings._sqlite_constants import (
+    SQLITE_DETERMINISTIC,
+    SQLITE_OK,
+    SQLITE_UTF8,
+)
+from numbox.core.bindings._sqlite_udf import (
+    sqlite3_create_function_v2,
+    sqlite3_create_window_function,
+)
+from numbox.utils.cstrings import c_string
+from numbox.utils.preprocessing import (
+    _anchor_path,
+    _materialize_anchor,
+    _orphan_anchor_sweep,
+)
+
+# These names are referenced by the GENERATED anchor source; importing them here
+# puts them in this module's __dict__, which seeds the exec namespace below.
+import numpy as np  # noqa: F401
+from numba import carray, njit  # noqa: F401
+from numbox.core.bindings._sqlite_result import sqlite3_result_error  # noqa: F401
+from numbox.core.bindings._sqlite_udf import sqlite3_aggregate_context  # noqa: F401
+from numbox.utils.lowlevel import _cast_int_to_void_p, get_unicode_data_p  # noqa: F401
+from numbox.utils.meminfo import (  # noqa: F401
+    borrow_structref,
+    export_meminfo,
+    release_meminfo,
+)
+
+__all__ = ["register_aggregate", "register_window"]
+
+_ANCHOR_SUBDIR = "numbox-sqlite-udaf"
+_orphan_anchor_sweep(_ANCHOR_SUBDIR)
+
+
+# Generated-source templates. Baked global names: _state_type, _init, _step,
+# _finalize, _inverse, _value. Each impl is @njit(cache=True) so it caches
+# cross-process; the user fns inline because they are module globals here.
+_XSTEP_SRC = '''
+@njit(cache=True)
+def _xstep_impl(ctx, argc, argv_pp):
+    agg = sqlite3_aggregate_context(ctx, 8)
+    if agg == 0:
+        return
+    slot = carray(_cast_int_to_void_p(agg), (1,), dtype=np.intp)
+    if slot[0] == 0:
+        try:
+            slot[0] = export_meminfo(_init())
+        except Exception:
+            sqlite3_result_error(ctx, get_unicode_data_p("error in user init callback"), -1)
+            return
+    try:
+        _step(borrow_structref(_state_type, slot[0]), ctx, argc, argv_pp)
+    except Exception:
+        sqlite3_result_error(ctx, get_unicode_data_p("error in user step callback"), -1)
+'''
+
+_XFINAL_SRC = '''
+@njit(cache=True)
+def _xfinal_impl(ctx):
+    agg = sqlite3_aggregate_context(ctx, 0)
+    if agg == 0:
+        try:
+            _state = _init()
+        except Exception:
+            sqlite3_result_error(ctx, get_unicode_data_p("error in user init callback"), -1)
+            return
+        try:
+            _finalize(_state, ctx)
+        except Exception:
+            sqlite3_result_error(ctx, get_unicode_data_p("error in user finalize callback"), -1)
+        return
+    slot = carray(_cast_int_to_void_p(agg), (1,), dtype=np.intp)
+    if slot[0] == 0:
+        try:
+            _state = _init()
+        except Exception:
+            sqlite3_result_error(ctx, get_unicode_data_p("error in user init callback"), -1)
+            return
+        try:
+            _finalize(_state, ctx)
+        except Exception:
+            sqlite3_result_error(ctx, get_unicode_data_p("error in user finalize callback"), -1)
+        return
+    try:
+        _finalize(borrow_structref(_state_type, slot[0]), ctx)
+    except Exception:
+        sqlite3_result_error(ctx, get_unicode_data_p("error in user finalize callback"), -1)
+    release_meminfo(slot[0])
+'''
+
+_XINVERSE_SRC = '''
+@njit(cache=True)
+def _xinverse_impl(ctx, argc, argv_pp):
+    agg = sqlite3_aggregate_context(ctx, 0)
+    if agg == 0:
+        return
+    slot = carray(_cast_int_to_void_p(agg), (1,), dtype=np.intp)
+    if slot[0] == 0:
+        return
+    try:
+        _inverse(borrow_structref(_state_type, slot[0]), ctx, argc, argv_pp)
+    except Exception:
+        sqlite3_result_error(ctx, get_unicode_data_p("error in user inverse callback"), -1)
+'''
+
+_XVALUE_SRC = '''
+@njit(cache=True)
+def _xvalue_impl(ctx):
+    agg = sqlite3_aggregate_context(ctx, 0)
+    if agg == 0:
+        try:
+            _state = _init()
+        except Exception:
+            sqlite3_result_error(ctx, get_unicode_data_p("error in user init callback"), -1)
+            return
+        try:
+            _value(_state, ctx)
+        except Exception:
+            sqlite3_result_error(ctx, get_unicode_data_p("error in user value callback"), -1)
+        return
+    slot = carray(_cast_int_to_void_p(agg), (1,), dtype=np.intp)
+    if slot[0] == 0:
+        try:
+            _state = _init()
+        except Exception:
+            sqlite3_result_error(ctx, get_unicode_data_p("error in user init callback"), -1)
+            return
+        try:
+            _value(_state, ctx)
+        except Exception:
+            sqlite3_result_error(ctx, get_unicode_data_p("error in user value callback"), -1)
+        return
+    try:
+        _value(borrow_structref(_state_type, slot[0]), ctx)
+    except Exception:
+        sqlite3_result_error(ctx, get_unicode_data_p("error in user value callback"), -1)
+'''
+
+
+class _UDAFHandle:
+    """Keeps the generated ``cfunc`` callbacks (and the user functions they bake
+    in) alive. SQLite holds raw pointers to the cfuncs; if this handle is
+    garbage-collected the pointers dangle and the next call segfaults. **The
+    caller MUST retain the returned handle for as long as the UDAF is used.**"""
+    __slots__ = ("_keep",)
+
+    def __init__(self, *objs):
+        self._keep = objs
+
+
+def _validate_state_type(state_type):
+    if not isinstance(state_type, StructRef):
+        raise TypeError(
+            "state_type must be a numba StructRef instance "
+            "(e.g. MyStateType([('x', int64)])), got %r" % (state_type,))
+
+
+def _validate_callbacks(**fns):
+    """Reject non-``@njit`` callbacks up front with a clear message; otherwise a
+    plain Python callable surfaces as a cryptic numba ``TypingError`` when it
+    fails to bake into the generated source."""
+    for role, fn in fns.items():
+        if not is_jitted(fn):
+            raise TypeError(
+                "%s must be an @njit-compiled function, got %r" % (role, fn))
+
+
+def _digest(state_type, fns):
+    """Content hash that invalidates when the state type, the user functions
+    (co_consts-sensitive, via cloudpickle of the code object -- NOT bare
+    co_code), or the numba/numbox versions change."""
+    h = hashlib.sha256()
+    h.update(repr(state_type).encode("utf-8"))
+    h.update(numba.__version__.encode("utf-8"))
+    # numbox.__version__ is "" upstream (the package version derives from it via
+    # pyproject's dynamic attr), so this fold is currently inert; it is kept so
+    # digests auto-invalidate should numbox ever set a real __version__. The
+    # numba version above and the code-object hash below do the real
+    # invalidating work (proven by test_invalidation_on_literal_edit).
+    h.update((numbox.__version__ or "").encode("utf-8"))
+    for fn in fns:
+        py = getattr(fn, "py_func", fn)
+        h.update(cloudpickle.dumps(py.__code__))
+    return h.hexdigest()[:16]
+
+
+def _compile_callbacks(stem, srcs, state_type, fns):
+    """Generate + content-address-anchor + exec the @njit(cache=True) impls.
+
+    ``fns`` maps generated global names (``_init``, ``_step``, ...) to user
+    callables. Returns the exec namespace (contains ``_xstep_impl`` etc.)."""
+    digest = _digest(state_type, list(fns.values()))
+    code_txt = "# udaf-digest: %s\n%s" % (digest, "".join(srcs))
+    # globals() is this module's __dict__; it carries __name__, which numba's
+    # warm-cache Environment rebuild requires when reloading the cached impls.
+    ns = {**globals(), "_state_type": state_type, **fns}
+    anchor = _anchor_path(_ANCHOR_SUBDIR, stem, code_txt)
+    _materialize_anchor(anchor, code_txt)
+    code = compile(code_txt, str(anchor), mode="exec")
+    exec(code, ns)  # nosec B102 - JIT codegen of internal source
+    return ns
+
+
+def _raise_rc(db, name, rc):
+    msg_p = sqlite3_errmsg(db)
+    detail = ""
+    if msg_p:
+        detail = ": " + ctypes.cast(
+            msg_p, ctypes.c_char_p).value.decode("utf-8", "replace")
+    raise RuntimeError(
+        "sqlite3 UDAF registration failed for %r (rc=%d)%s" % (name, rc, detail))
+
+
+def _stem(prefix, name):
+    return prefix + "".join(c if c.isalnum() else "_" for c in name)
+
+
+def register_aggregate(db, name, n_arg, state_type, init, step, finalize,
+                       *, deterministic=False):
+    """Register a structref-backed aggregate UDAF.
+
+    :param db: connection pointer (intp), as returned by ``sqlite3_open``.
+    :param name: SQL function name (str); the C-string lifetime is handled here.
+    :param n_arg: argument count, or -1 for variadic.
+    :param state_type: the numba structref *instance* type for per-group state.
+    :param init: ``@njit`` ``() -> state`` returning a fresh state.
+    :param step: ``@njit`` ``(state, ctx, argc, argv_pp)`` updating state.
+    :param finalize: ``@njit`` ``(state, ctx)`` writing the result.
+    :param deterministic: OR-in ``SQLITE_DETERMINISTIC``.
+    :returns: a keep-alive handle the caller MUST retain (see ``_UDAFHandle``).
+    """
+    _validate_state_type(state_type)
+    _validate_callbacks(init=init, step=step, finalize=finalize)
+    ns = _compile_callbacks(
+        _stem("udaf_", name), [_XSTEP_SRC, _XFINAL_SRC], state_type,
+        {"_init": init, "_step": step, "_finalize": finalize})
+    xstep_impl = ns["_xstep_impl"]
+    xfinal_impl = ns["_xfinal_impl"]
+
+    @cfunc(types.void(types.intp, types.int32, types.intp))
+    def step_cb(ctx, argc, argv):
+        xstep_impl(ctx, argc, argv)
+
+    @cfunc(types.void(types.intp))
+    def final_cb(ctx):
+        xfinal_impl(ctx)
+
+    flags = SQLITE_UTF8 | (SQLITE_DETERMINISTIC if deterministic else 0)
+    with c_string(name) as name_p:
+        rc = sqlite3_create_function_v2(
+            db, name_p, n_arg, flags, 0, 0,
+            step_cb.address, final_cb.address, 0)
+    if rc != SQLITE_OK:
+        _raise_rc(db, name, rc)
+    return _UDAFHandle(step_cb, final_cb, xstep_impl, xfinal_impl,
+                       init, step, finalize)
+
+
+def register_window(db, name, n_arg, state_type, init, step, inverse, value,
+                    finalize, *, deterministic=False):
+    """Register a structref-backed window UDAF.
+
+    Same as :func:`register_aggregate` plus ``inverse(state, ctx, argc,
+    argv_pp)`` (un-applies a row; state already exists) and ``value(state,
+    ctx)`` (emits the running result WITHOUT releasing). Only ``xFinal``
+    releases the meminfo.
+    """
+    _validate_state_type(state_type)
+    _validate_callbacks(init=init, step=step, inverse=inverse, value=value,
+                        finalize=finalize)
+    ns = _compile_callbacks(
+        _stem("wudaf_", name),
+        [_XSTEP_SRC, _XINVERSE_SRC, _XVALUE_SRC, _XFINAL_SRC], state_type,
+        {"_init": init, "_step": step, "_inverse": inverse,
+         "_value": value, "_finalize": finalize})
+    xstep_impl = ns["_xstep_impl"]
+    xinverse_impl = ns["_xinverse_impl"]
+    xvalue_impl = ns["_xvalue_impl"]
+    xfinal_impl = ns["_xfinal_impl"]
+
+    @cfunc(types.void(types.intp, types.int32, types.intp))
+    def step_cb(ctx, argc, argv):
+        xstep_impl(ctx, argc, argv)
+
+    @cfunc(types.void(types.intp, types.int32, types.intp))
+    def inverse_cb(ctx, argc, argv):
+        xinverse_impl(ctx, argc, argv)
+
+    @cfunc(types.void(types.intp))
+    def value_cb(ctx):
+        xvalue_impl(ctx)
+
+    @cfunc(types.void(types.intp))
+    def final_cb(ctx):
+        xfinal_impl(ctx)
+
+    flags = SQLITE_UTF8 | (SQLITE_DETERMINISTIC if deterministic else 0)
+    with c_string(name) as name_p:
+        rc = sqlite3_create_window_function(
+            db, name_p, n_arg, flags, 0,
+            step_cb.address, final_cb.address,
+            value_cb.address, inverse_cb.address, 0)
+    if rc != SQLITE_OK:
+        _raise_rc(db, name, rc)
+    return _UDAFHandle(step_cb, inverse_cb, value_cb, final_cb,
+                       xstep_impl, xinverse_impl, xvalue_impl, xfinal_impl,
+                       init, step, inverse, value, finalize)

--- a/numbox/core/bindings/_sqlite_value.py
+++ b/numbox/core/bindings/_sqlite_value.py
@@ -7,7 +7,9 @@ at the appropriate index.
 from numbox.core.bindings.call import _call_lib_func
 from numbox.core.bindings.signatures import signatures
 from numbox.core.bindings.utils import load_lib
+from numbox.core.configurations import jit_options
 from numbox.core.proxy.proxy import proxy
+
 
 __all__ = [
     "sqlite3_value_int", "sqlite3_value_int64", "sqlite3_value_double",
@@ -22,66 +24,66 @@ __all__ = [
 load_lib("sqlite3")
 
 
-@proxy(signatures.get("sqlite3_value_int"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_value_int"), jit_options=jit_options)
 def sqlite3_value_int(value_p):
     return _call_lib_func("sqlite3_value_int", (value_p,))
 
 
-@proxy(signatures.get("sqlite3_value_int64"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_value_int64"), jit_options=jit_options)
 def sqlite3_value_int64(value_p):
     return _call_lib_func("sqlite3_value_int64", (value_p,))
 
 
-@proxy(signatures.get("sqlite3_value_double"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_value_double"), jit_options=jit_options)
 def sqlite3_value_double(value_p):
     return _call_lib_func("sqlite3_value_double", (value_p,))
 
 
-@proxy(signatures.get("sqlite3_value_text"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_value_text"), jit_options=jit_options)
 def sqlite3_value_text(value_p):
     return _call_lib_func("sqlite3_value_text", (value_p,))
 
 
-@proxy(signatures.get("sqlite3_value_blob"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_value_blob"), jit_options=jit_options)
 def sqlite3_value_blob(value_p):
     return _call_lib_func("sqlite3_value_blob", (value_p,))
 
 
-@proxy(signatures.get("sqlite3_value_bytes"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_value_bytes"), jit_options=jit_options)
 def sqlite3_value_bytes(value_p):
     return _call_lib_func("sqlite3_value_bytes", (value_p,))
 
 
-@proxy(signatures.get("sqlite3_value_type"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_value_type"), jit_options=jit_options)
 def sqlite3_value_type(value_p):
     return _call_lib_func("sqlite3_value_type", (value_p,))
 
 
-@proxy(signatures.get("sqlite3_value_numeric_type"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_value_numeric_type"), jit_options=jit_options)
 def sqlite3_value_numeric_type(value_p):
     return _call_lib_func("sqlite3_value_numeric_type", (value_p,))
 
 
-@proxy(signatures.get("sqlite3_value_nochange"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_value_nochange"), jit_options=jit_options)
 def sqlite3_value_nochange(value_p):
     return _call_lib_func("sqlite3_value_nochange", (value_p,))
 
 
-@proxy(signatures.get("sqlite3_value_frombind"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_value_frombind"), jit_options=jit_options)
 def sqlite3_value_frombind(value_p):
     return _call_lib_func("sqlite3_value_frombind", (value_p,))
 
 
-@proxy(signatures.get("sqlite3_value_subtype"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_value_subtype"), jit_options=jit_options)
 def sqlite3_value_subtype(value_p):
     return _call_lib_func("sqlite3_value_subtype", (value_p,))
 
 
-@proxy(signatures.get("sqlite3_value_dup"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_value_dup"), jit_options=jit_options)
 def sqlite3_value_dup(value_p):
     return _call_lib_func("sqlite3_value_dup", (value_p,))
 
 
-@proxy(signatures.get("sqlite3_value_free"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_value_free"), jit_options=jit_options)
 def sqlite3_value_free(value_p):
     return _call_lib_func("sqlite3_value_free", (value_p,))

--- a/numbox/core/bindings/_stdio.py
+++ b/numbox/core/bindings/_stdio.py
@@ -17,6 +17,7 @@ from numba.core.types import intp
 from numba.extending import intrinsic
 
 from numbox.core.bindings.utils import extract_literal_str, load_lib, platform_
+from numbox.core.configurations import jit_options
 from numbox.core.proxy.proxy import proxy
 
 
@@ -73,19 +74,19 @@ def _stdio_handle(typingctx, name_ty):
     return sig, codegen
 
 
-@proxy(intp(), jit_options={"cache": True})
+@proxy(intp(), jit_options=jit_options)
 def stdout():
     """Return the current process's stdout FILE* as intp. See module docstring."""
     return _stdio_handle("stdout")
 
 
-@proxy(intp(), jit_options={"cache": True})
+@proxy(intp(), jit_options=jit_options)
 def stderr():
     """Return the current process's stderr FILE* as intp. See module docstring."""
     return _stdio_handle("stderr")
 
 
-@proxy(intp(), jit_options={"cache": True})
+@proxy(intp(), jit_options=jit_options)
 def stdin():
     """Return the current process's stdin FILE* as intp. See module docstring."""
     return _stdio_handle("stdin")

--- a/numbox/core/bindings/_strerror.py
+++ b/numbox/core/bindings/_strerror.py
@@ -32,6 +32,7 @@ from numba.core.types import int32, int64, intp
 from numba.extending import intrinsic
 
 from numbox.core.bindings.utils import intp_ll_type, platform_, load_lib
+from numbox.core.configurations import jit_options
 from numbox.core.proxy.proxy import proxy
 
 
@@ -113,7 +114,7 @@ def _render_ir_for_probe():
     return str(module)
 
 
-@proxy(int32(int64, intp, intp), jit_options={"cache": True})
+@proxy(int32(int64, intp, intp), jit_options=jit_options)
 def strerror_safe(errnum, buf, buflen):
     """Write the error message for errnum into buf (length buflen).
 

--- a/numbox/core/work/builder.py
+++ b/numbox/core/work/builder.py
@@ -167,11 +167,6 @@ def make_graph(
     for derived_ in all_derived_:
         line_ = _derived_line(derived_, ns, initializers, derive_hashes, _make_args, jit_options)
         code_txt.write(f"\n\t{line_}")
-    # No node types in the key: numba dispatches the generated _make by argument
-    # signature, so identical-structure graphs with different init types share the
-    # _make name and compile/load separate overloads correctly (pinned by
-    # test_make_graph_distinct_types_dispatch). The init *value* is deliberately
-    # absent too -- a non-deterministic repr (numpy.empty) would churn the cache.
     hash_str = f"code_block = {code_txt.getvalue()} derive_hashes = {derive_hashes}"
     hash_ = code_block_hash(hash_str)
     access_nodes_names = [n.name for n in access_nodes]

--- a/numbox/core/work/builder.py
+++ b/numbox/core/work/builder.py
@@ -167,7 +167,8 @@ def make_graph(
     for derived_ in all_derived_:
         line_ = _derived_line(derived_, ns, initializers, derive_hashes, _make_args, jit_options)
         code_txt.write(f"\n\t{line_}")
-    hash_str = f"code_block = {code_txt.getvalue()} initializers = {list(initializers.values())} derive_hashes = {derive_hashes}"  # noqa: E501
+    init_types = [str(get_ty(s)) for s in (*all_inputs_, *all_derived_)]
+    hash_str = f"code_block = {code_txt.getvalue()} init_types = {init_types} derive_hashes = {derive_hashes}"  # noqa: E501
     hash_ = code_block_hash(hash_str)
     access_nodes_names = [n.name for n in access_nodes]
     tup_ = ", ".join(access_nodes_names) + ","

--- a/numbox/core/work/builder.py
+++ b/numbox/core/work/builder.py
@@ -167,8 +167,12 @@ def make_graph(
     for derived_ in all_derived_:
         line_ = _derived_line(derived_, ns, initializers, derive_hashes, _make_args, jit_options)
         code_txt.write(f"\n\t{line_}")
-    init_types = [str(get_ty(s)) for s in (*all_inputs_, *all_derived_)]
-    hash_str = f"code_block = {code_txt.getvalue()} init_types = {init_types} derive_hashes = {derive_hashes}"  # noqa: E501
+    # No node types in the key: numba dispatches the generated _make by argument
+    # signature, so identical-structure graphs with different init types share the
+    # _make name and compile/load separate overloads correctly (pinned by
+    # test_make_graph_distinct_types_dispatch). The init *value* is deliberately
+    # absent too -- a non-deterministic repr (numpy.empty) would churn the cache.
+    hash_str = f"code_block = {code_txt.getvalue()} derive_hashes = {derive_hashes}"
     hash_ = code_block_hash(hash_str)
     access_nodes_names = [n.name for n in access_nodes]
     tup_ = ", ".join(access_nodes_names) + ","

--- a/test/core/test_builder.py
+++ b/test/core/test_builder.py
@@ -467,13 +467,6 @@ def test_9():
     assert isclose(d1.data, 3.14)
 
 
-# Regression guard: make_graph's cached _make function must be keyed on node
-# TYPES, not init-value contents -- else a non-deterministic init repr (e.g.
-# numpy.empty's uninitialized bytes) mints a fresh .nbc every process, growing
-# the cache without bound. The value is injected per run (PROBE_VAL) so it
-# DIFFERS between the two processes while the TYPE stays identical; this catches
-# the regression deterministically on every platform rather than relying on
-# np.empty happening to return distinct garbage across processes.
 _GRAPH_DRIVER = textwrap.dedent('''
     import os
     import numpy as np
@@ -506,9 +499,6 @@ def test_make_graph_cache_key_content_independent(tmp_path):
         "contents (cache key depends on init values, not just types)")
 
 
-# With node types out of the hash, identical-structure graphs with different init
-# TYPES collide on one _make name; numba dispatches the generated _make by argument
-# signature, so each loads its own overload correctly across a shared cache dir.
 _TYPED_GRAPH_DRIVER = textwrap.dedent('''
     import sys
     from numbox.core.work.builder import End, Derived, make_graph

--- a/test/core/test_builder.py
+++ b/test/core/test_builder.py
@@ -468,20 +468,26 @@ def test_9():
 
 
 # Regression guard: make_graph's cached _make function must be keyed on node
-# TYPES, not init-value contents. A numpy.empty init (uninitialized memory,
-# non-deterministic repr) must not write a fresh .nbc on every process.
+# TYPES, not init-value contents -- else a non-deterministic init repr (e.g.
+# numpy.empty's uninitialized bytes) mints a fresh .nbc every process, growing
+# the cache without bound. The value is injected per run (PROBE_VAL) so it
+# DIFFERS between the two processes while the TYPE stays identical; this catches
+# the regression deterministically on every platform rather than relying on
+# np.empty happening to return distinct garbage across processes.
 _GRAPH_DRIVER = textwrap.dedent('''
+    import os
     import numpy as np
     from numbox.core.work.builder import End, make_graph
-    make_graph(End(name="probe_a", init_value=np.empty((4,), np.float64)))
+    v = np.full((4,), float(os.environ["PROBE_VAL"]), np.float64)
+    make_graph(End(name="probe_a", init_value=v))
     print("OK")
 ''')
 
 
-def _run_graph_driver(tmp_path, cache):
+def _run_graph_driver(tmp_path, cache, probe_val):
     script = tmp_path / "graph_drv.py"
     script.write_text(_GRAPH_DRIVER)
-    env = dict(os.environ, NUMBA_CACHE_DIR=str(cache))
+    env = dict(os.environ, NUMBA_CACHE_DIR=str(cache), PROBE_VAL=probe_val)
     out = subprocess.run([sys.executable, str(script)], env=env,
                          capture_output=True, text=True, timeout=600)
     assert out.returncode == 0, out.stderr
@@ -490,14 +496,14 @@ def _run_graph_driver(tmp_path, cache):
 def test_make_graph_cache_key_content_independent(tmp_path):
     cache = tmp_path / "nbcache"
     cache.mkdir()
-    _run_graph_driver(tmp_path, cache)               # cold: compiles + caches
+    _run_graph_driver(tmp_path, cache, "1.0")        # cold: compiles + caches
     n_cold = sum(1 for _ in cache.rglob("builder._make*.nbc"))
     assert n_cold > 0
-    _run_graph_driver(tmp_path, cache)               # warm: np.empty garbage differs
+    _run_graph_driver(tmp_path, cache, "2.0")        # warm: same TYPE, different value
     n_warm = sum(1 for _ in cache.rglob("builder._make*.nbc"))
     assert n_warm == n_cold, (
-        "make_graph wrote a new _make .nbc in a second process "
-        "(cache key depends on init contents)")
+        "make_graph wrote a new _make .nbc for a same-typed init with different "
+        "contents (cache key depends on init values, not just types)")
 
 
 if __name__ == "__main__":

--- a/test/core/test_builder.py
+++ b/test/core/test_builder.py
@@ -506,5 +506,44 @@ def test_make_graph_cache_key_content_independent(tmp_path):
         "contents (cache key depends on init values, not just types)")
 
 
+# With node types out of the hash, identical-structure graphs with different init
+# TYPES collide on one _make name; numba dispatches the generated _make by argument
+# signature, so each loads its own overload correctly across a shared cache dir.
+_TYPED_GRAPH_DRIVER = textwrap.dedent('''
+    import sys
+    from numbox.core.work.builder import End, Derived, make_graph
+
+    def inc(x):
+        return x + 1
+
+    t = sys.argv[1]
+    iv_e, iv_d = (2.0, 0.0) if t == "f" else (2, 0)
+    e = End(name="e", init_value=iv_e)
+    d = Derived(name="d", init_value=iv_d, sources=(e,), derive=inc)
+    acc = make_graph(d)
+    acc.d.calculate()
+    print("RESULT", t, acc.d.data, type(acc.d.data).__name__)
+''')
+
+
+def _run_typed_driver(tmp_path, cache, t):
+    script = tmp_path / ("typed_drv_%s.py" % t)
+    script.write_text(_TYPED_GRAPH_DRIVER)
+    env = dict(os.environ, NUMBA_CACHE_DIR=str(cache))
+    out = subprocess.run([sys.executable, str(script), t], env=env,
+                         capture_output=True, text=True, timeout=600)
+    assert out.returncode == 0, out.stderr
+    return [ln for ln in out.stdout.splitlines() if ln.startswith("RESULT")][0].split()
+
+
+def test_make_graph_distinct_types_dispatch(tmp_path):
+    cache = tmp_path / "nbcache_types"
+    cache.mkdir()
+    rf = _run_typed_driver(tmp_path, cache, "f")     # cold: float overload
+    ri = _run_typed_driver(tmp_path, cache, "i")     # warm dir: int overload, same _make name
+    assert rf == ["RESULT", "f", "3.0", "float"]
+    assert ri == ["RESULT", "i", "3", "int"]
+
+
 if __name__ == "__main__":
     collect_and_run_tests(__name__)

--- a/test/core/test_builder.py
+++ b/test/core/test_builder.py
@@ -1,3 +1,8 @@
+import os
+import subprocess
+import sys
+import textwrap
+
 import numpy
 import pytest
 
@@ -460,6 +465,39 @@ def test_9():
     assert d1.data == 0.0
     d1.calculate()
     assert isclose(d1.data, 3.14)
+
+
+# Regression guard: make_graph's cached _make function must be keyed on node
+# TYPES, not init-value contents. A numpy.empty init (uninitialized memory,
+# non-deterministic repr) must not write a fresh .nbc on every process.
+_GRAPH_DRIVER = textwrap.dedent('''
+    import numpy as np
+    from numbox.core.work.builder import End, make_graph
+    make_graph(End(name="probe_a", init_value=np.empty((4,), np.float64)))
+    print("OK")
+''')
+
+
+def _run_graph_driver(tmp_path, cache):
+    script = tmp_path / "graph_drv.py"
+    script.write_text(_GRAPH_DRIVER)
+    env = dict(os.environ, NUMBA_CACHE_DIR=str(cache))
+    out = subprocess.run([sys.executable, str(script)], env=env,
+                         capture_output=True, text=True, timeout=600)
+    assert out.returncode == 0, out.stderr
+
+
+def test_make_graph_cache_key_content_independent(tmp_path):
+    cache = tmp_path / "nbcache"
+    cache.mkdir()
+    _run_graph_driver(tmp_path, cache)               # cold: compiles + caches
+    n_cold = sum(1 for _ in cache.rglob("builder._make*.nbc"))
+    assert n_cold > 0
+    _run_graph_driver(tmp_path, cache)               # warm: np.empty garbage differs
+    n_warm = sum(1 for _ in cache.rglob("builder._make*.nbc"))
+    assert n_warm == n_cold, (
+        "make_graph wrote a new _make .nbc in a second process "
+        "(cache key depends on init contents)")
 
 
 if __name__ == "__main__":

--- a/test/core/test_sqlite_udf_helpers.py
+++ b/test/core/test_sqlite_udf_helpers.py
@@ -396,18 +396,38 @@ def test_registration_error_raises(monkeypatch):
     sqlite3_close(db)
 
 
-def test_non_njit_callback_rejected():
-    """A plain (non-@njit) callback is rejected up front with a clear TypeError
-    rather than a cryptic numba TypingError at bake time."""
-    import pytest
+def test_plain_python_callbacks_accepted():
+    """Plain (undecorated) Python callbacks are njit-wrapped by the helper and
+    work end-to-end -- callers need not pre-``@njit`` them."""
     db = _open_memory()
+    _make_table(db, [1, 2, 3, 4, 5])
+
+    def plain_init():
+        return SumState(nb_types.int64(0))
 
     def plain_step(state, ctx, argc, argv_pp):
-        pass
+        args = carray(_cast_int_to_void_p(argv_pp), (argc,), dtype=np.intp)
+        state.total += sqlite3_value_int64(args[0])
 
-    with pytest.raises(TypeError, match="step must be an @njit"):
+    def plain_finalize(state, ctx):
+        sqlite3_result_int64(ctx, state.total)
+
+    h = register_aggregate(db, "plain_sum", 1, sum_state_type,
+                           plain_init, plain_step, plain_finalize)
+    gc.collect()  # handle must keep callbacks alive
+    val, _cap = _read1_int64(db, "SELECT __cap(plain_sum(v)) FROM t")
+    sqlite3_close(db)
+    assert val == 15
+    assert h is not None
+
+
+def test_non_callable_callback_rejected():
+    """A non-callable callback is rejected up front with a clear TypeError."""
+    import pytest
+    db = _open_memory()
+    with pytest.raises(TypeError, match="step must be a callable"):
         register_aggregate(db, "bad_cb", 1, sum_state_type,
-                           sum_init, plain_step, sum_finalize)
+                           sum_init, 42, sum_finalize)
     sqlite3_close(db)
 
 

--- a/test/core/test_sqlite_udf_helpers.py
+++ b/test/core/test_sqlite_udf_helpers.py
@@ -1,0 +1,680 @@
+"""Tests for the structref-backed SQLite UDAF/window registration helpers."""
+import gc
+from ctypes import addressof, c_char_p, c_int64
+
+import numpy as np
+from numba import carray, cfunc, njit, types
+from numba.core import types as nb_types
+from numba.experimental import structref
+
+from numbox.core.bindings import (
+    SQLITE_OK,
+    SQLITE_UTF8,
+    register_aggregate,
+    register_window,
+    sqlite3_close,
+    sqlite3_create_function_v2,
+    sqlite3_errmsg,
+    sqlite3_exec,
+    sqlite3_open,
+    sqlite3_result_int,
+    sqlite3_result_int64,
+    sqlite3_user_data,
+    sqlite3_value_int64,
+)
+from numbox.utils.cstrings import c_string
+from numbox.utils.lowlevel import _cast_int_to_void_p
+
+
+# --- state type (module-level => importable, stable __module__) ---
+@structref.register
+class SumStateType(nb_types.StructRef):
+    def preprocess_fields(self, fields):
+        return tuple((n, nb_types.unliteral(t)) for n, t in fields)
+
+
+class SumState(structref.StructRefProxy):
+    def __new__(cls, total):
+        return structref.StructRefProxy.__new__(cls, total)
+
+
+structref.define_proxy(SumState, SumStateType, ["total"])
+sum_state_type = SumStateType([("total", nb_types.int64)])
+
+
+@njit
+def sum_init():
+    return SumState(nb_types.int64(0))
+
+
+@njit
+def sum_step(state, ctx, argc, argv_pp):
+    args = carray(_cast_int_to_void_p(argv_pp), (argc,), dtype=np.intp)
+    state.total += sqlite3_value_int64(args[0])
+
+
+@njit
+def sum_finalize(state, ctx):
+    sqlite3_result_int64(ctx, state.total)
+
+
+# --- test plumbing ---
+def _open_memory():
+    db_p = c_int64(0)
+    with c_string(":memory:") as name_p:
+        assert sqlite3_open(name_p, addressof(db_p)) == SQLITE_OK
+    return db_p.value
+
+
+def _make_table(db, values):
+    with c_string("CREATE TABLE t(v INTEGER)") as p:
+        assert sqlite3_exec(db, p, 0, 0, 0) == SQLITE_OK
+    for v in values:
+        with c_string("INSERT INTO t VALUES (%d)" % v) as p:
+            assert sqlite3_exec(db, p, 0, 0, 0) == SQLITE_OK
+
+
+def _errmsg(db):
+    """Decode sqlite3_errmsg(db) (the most recent error string) to a str."""
+    p = sqlite3_errmsg(db)
+    return c_char_p(p).value.decode("utf-8", "replace") if p else ""
+
+
+def _read1_int64(db, select_sql):
+    """Route a scalar SELECT through a capture UDF that stores arg0 into a
+    numpy buffer; returns (value, keepalive)."""
+    buf = np.zeros(1, dtype=np.int64)
+
+    @cfunc(types.void(types.intp, types.int32, types.intp))
+    def cap_cb(ctx, argc, argv):
+        ud = sqlite3_user_data(ctx)
+        args = carray(_cast_int_to_void_p(argv), (argc,), dtype=np.intp)
+        o = carray(_cast_int_to_void_p(ud), (1,), dtype=np.int64)
+        o[0] = sqlite3_value_int64(args[0])
+        sqlite3_result_int(ctx, 0)
+
+    with c_string("__cap") as cp:
+        assert sqlite3_create_function_v2(
+            db, cp, 1, SQLITE_UTF8, buf.ctypes.data, cap_cb.address, 0, 0, 0) == SQLITE_OK
+    with c_string(select_sql) as sp:
+        assert sqlite3_exec(db, sp, 0, 0, 0) == SQLITE_OK
+    return int(buf[0]), cap_cb
+
+
+def test_aggregate_sum():
+    db = _open_memory()
+    _make_table(db, [1, 2, 3, 4, 5])
+    h = register_aggregate(db, "my_sum", 1, sum_state_type,
+                           sum_init, sum_step, sum_finalize)
+    gc.collect()  # handle must keep callbacks alive
+    val, _cap = _read1_int64(db, "SELECT __cap(my_sum(v)) FROM t")
+    sqlite3_close(db)
+    assert val == 15
+    assert h is not None
+
+
+def test_aggregate_empty_group():
+    db = _open_memory()
+    _make_table(db, [])
+    h = register_aggregate(db, "my_sum", 1, sum_state_type,
+                           sum_init, sum_step, sum_finalize)
+    val, _cap = _read1_int64(db, "SELECT __cap(my_sum(v)) FROM t")
+    sqlite3_close(db)
+    assert val == 0
+    assert h is not None
+
+
+def test_aggregate_bad_state_type():
+    import pytest
+    db = _open_memory()
+    with pytest.raises(TypeError):
+        register_aggregate(db, "bad", 1, object(), sum_init, sum_step, sum_finalize)
+    sqlite3_close(db)
+
+
+import os                                            # noqa: E402
+import subprocess                                    # noqa: E402
+import sys                                           # noqa: E402
+import textwrap                                      # noqa: E402
+
+
+# A self-contained driver: defines a state type + sum UDAF in an importable
+# module, registers it, runs SELECT sum(v), prints the result. {MULT} is the
+# step multiplier (1 normally; flipped to prove invalidation).
+_DRIVER = textwrap.dedent('''
+    from ctypes import addressof, c_int64
+    import numpy as np
+    from numba import carray, cfunc, njit, types
+    from numba.core import types as nb_types
+    from numba.experimental import structref
+    from numbox.core.bindings import (
+        SQLITE_OK, SQLITE_UTF8, sqlite3_close, sqlite3_create_function_v2,
+        sqlite3_exec, sqlite3_open, sqlite3_result_int, sqlite3_result_int64,
+        sqlite3_user_data, sqlite3_value_int64)
+    from numbox.core.bindings._sqlite_udf_helpers import register_aggregate
+    from numbox.utils.cstrings import c_string
+    from numbox.utils.lowlevel import _cast_int_to_void_p
+
+    @structref.register
+    class StT(nb_types.StructRef):
+        def preprocess_fields(self, fields):
+            return tuple((n, nb_types.unliteral(t)) for n, t in fields)
+    class St(structref.StructRefProxy):
+        def __new__(cls, total):
+            return structref.StructRefProxy.__new__(cls, total)
+    structref.define_proxy(St, StT, ["total"])
+    st = StT([("total", nb_types.int64)])
+
+    @njit
+    def s_init():
+        return St(nb_types.int64(0))
+    @njit
+    def s_step(state, ctx, argc, argv_pp):
+        a = carray(_cast_int_to_void_p(argv_pp), (argc,), dtype=np.intp)
+        state.total += {MULT} * sqlite3_value_int64(a[0])
+    @njit
+    def s_fin(state, ctx):
+        sqlite3_result_int64(ctx, state.total)
+
+    db_p = c_int64(0)
+    with c_string(":memory:") as n:
+        sqlite3_open(n, addressof(db_p))
+    db = db_p.value
+    with c_string("CREATE TABLE t(v INTEGER)") as p:
+        sqlite3_exec(db, p, 0, 0, 0)
+    for v in (1, 2, 3, 4, 5):
+        with c_string("INSERT INTO t VALUES (%d)" % v) as p:
+            sqlite3_exec(db, p, 0, 0, 0)
+    h = register_aggregate(db, "f", 1, st, s_init, s_step, s_fin)
+    buf = np.zeros(1, dtype=np.int64)
+    @cfunc(types.void(types.intp, types.int32, types.intp))
+    def cap(ctx, argc, argv):
+        ud = sqlite3_user_data(ctx)
+        a = carray(_cast_int_to_void_p(argv), (argc,), dtype=np.intp)
+        o = carray(_cast_int_to_void_p(ud), (1,), dtype=np.int64)
+        o[0] = sqlite3_value_int64(a[0]); sqlite3_result_int(ctx, 0)
+    with c_string("cap") as cp:
+        sqlite3_create_function_v2(db, cp, 1, SQLITE_UTF8, buf.ctypes.data, cap.address, 0, 0, 0)
+    with c_string("SELECT cap(f(v)) FROM t") as sp:
+        sqlite3_exec(db, sp, 0, 0, 0)
+    print("RESULT", int(buf[0]))
+''')
+
+
+def _run_driver(tmp_path, cache_dir, mult):
+    script = tmp_path / ("drv_%d.py" % mult)
+    script.write_text(_DRIVER.replace("{MULT}", str(mult)))
+    env = dict(os.environ, NUMBA_CACHE_DIR=str(cache_dir))
+    out = subprocess.run([sys.executable, str(script)], env=env,
+                         capture_output=True, text=True, timeout=600)
+    assert out.returncode == 0, out.stderr
+    line = [ln for ln in out.stdout.splitlines() if ln.startswith("RESULT")][0]
+    return int(line.split()[1])
+
+
+def _count_nbc(cache_dir):
+    # Count only the generated UDAF impl caches (anchor stem "udaf_"/"wudaf_"),
+    # not the whole cache: scoping keeps the no-growth assertion immune to
+    # unrelated bindings whose compile timing could differ across the matrix.
+    return sum(1 for _ in cache_dir.rglob("*udaf*.nbc"))
+
+
+def test_xprocess_cache_no_growth(tmp_path):
+    cache = tmp_path / "nbcache"
+    cache.mkdir()
+    assert _run_driver(tmp_path, cache, 1) == 15      # cold: compiles + writes cache
+    n_cold = _count_nbc(cache)
+    assert n_cold > 0
+    assert _run_driver(tmp_path, cache, 1) == 15      # warm: must reuse, not append
+    assert _count_nbc(cache) == n_cold, "warm run grew the cache (C failure mode)"
+
+
+def test_invalidation_on_literal_edit(tmp_path):
+    cache = tmp_path / "nbcache"
+    cache.mkdir()
+    assert _run_driver(tmp_path, cache, 1) == 15       # step: += 1*v  => 15
+    assert _run_driver(tmp_path, cache, 3) == 45       # step: += 3*v  => 45 (not stale 15)
+
+
+@njit
+def w_inverse(state, ctx, argc, argv_pp):
+    args = carray(_cast_int_to_void_p(argv_pp), (argc,), dtype=np.intp)
+    state.total -= sqlite3_value_int64(args[0])
+
+
+@njit
+def w_value(state, ctx):
+    sqlite3_result_int64(ctx, state.total)
+
+
+def _read_window(db, select_sql, nrows):
+    meta = np.zeros(nrows + 1, dtype=np.int64)  # meta[0]=count, meta[1:]=values
+
+    @cfunc(types.void(types.intp, types.int32, types.intp))
+    def wcap_cb(ctx, argc, argv):
+        ud = sqlite3_user_data(ctx)
+        m = carray(_cast_int_to_void_p(ud), (nrows + 1,), dtype=np.int64)
+        i = m[0]
+        args = carray(_cast_int_to_void_p(argv), (argc,), dtype=np.intp)
+        m[1 + i] = sqlite3_value_int64(args[0])
+        m[0] = i + 1
+        sqlite3_result_int(ctx, 0)
+
+    with c_string("__wcap") as cp:
+        assert sqlite3_create_function_v2(
+            db, cp, 1, SQLITE_UTF8, meta.ctypes.data, wcap_cb.address, 0, 0, 0) == SQLITE_OK
+    with c_string(select_sql) as sp:
+        assert sqlite3_exec(db, sp, 0, 0, 0) == SQLITE_OK
+    return [int(meta[1 + i]) for i in range(int(meta[0]))], wcap_cb
+
+
+def test_window_running_sum():
+    db = _open_memory()
+    _make_table(db, [1, 2, 3, 4, 5])
+    h = register_window(db, "my_wsum", 1, sum_state_type,
+                        sum_init, sum_step, w_inverse, w_value, sum_finalize)
+    sql = ("SELECT __wcap(my_wsum(v) OVER "
+           "(ORDER BY v ROWS BETWEEN 1 PRECEDING AND CURRENT ROW)) "
+           "FROM t ORDER BY v")
+    vals, _cap = _read_window(db, sql, 5)
+    sqlite3_close(db)
+    assert vals == [1, 3, 5, 7, 9]
+    assert h is not None
+
+
+@njit
+def sum2_step(state, ctx, argc, argv_pp):  # distinct body => independent compiled callbacks
+    args = carray(_cast_int_to_void_p(argv_pp), (argc,), dtype=np.intp)
+    state.total += 2 * sqlite3_value_int64(args[0])
+
+
+def test_two_distinct_aggregates_no_collision():
+    db = _open_memory()
+    _make_table(db, [1, 2, 3, 4, 5])
+    h1 = register_aggregate(db, "my_sum", 1, sum_state_type,
+                            sum_init, sum_step, sum_finalize)
+    h2 = register_aggregate(db, "my_sum2", 1, sum_state_type,
+                            sum_init, sum2_step, sum_finalize)
+    v1, _c1 = _read1_int64(db, "SELECT __cap(my_sum(v)) FROM t")
+    v2, _c2 = _read1_int64(db, "SELECT __cap(my_sum2(v)) FROM t")
+    sqlite3_close(db)
+    assert (v1, v2) == (15, 30)
+    assert h1 is not None and h2 is not None
+
+
+def test_deterministic_flag():
+    db = _open_memory()
+    _make_table(db, [1, 2, 3, 4, 5])
+    h = register_aggregate(db, "my_sum_det", 1, sum_state_type,
+                           sum_init, sum_step, sum_finalize, deterministic=True)
+    val, _cap = _read1_int64(db, "SELECT __cap(my_sum_det(v)) FROM t")
+    sqlite3_close(db)
+    assert val == 15
+    assert h is not None
+
+
+def test_deterministic_flag_ors_bit(monkeypatch):
+    """deterministic=True must OR SQLITE_DETERMINISTIC into the flags passed to
+    sqlite3_create_function_v2, and the default must not. The flag is a
+    query-planner hint with no effect on an aggregate's value, so a result
+    assertion alone cannot guard this contract -- spy on the flags instead."""
+    import numbox.core.bindings._sqlite_udf_helpers as helpers
+    real = helpers.sqlite3_create_function_v2
+    seen = []
+
+    def spy(db, name_p, n_arg, flags, *rest):
+        seen.append(flags)
+        return real(db, name_p, n_arg, flags, *rest)
+
+    monkeypatch.setattr(helpers, "sqlite3_create_function_v2", spy)
+    db = _open_memory()
+    register_aggregate(db, "det_on", 1, sum_state_type,
+                       sum_init, sum_step, sum_finalize, deterministic=True)
+    register_aggregate(db, "det_off", 1, sum_state_type,
+                       sum_init, sum_step, sum_finalize)
+    sqlite3_close(db)
+    assert seen[0] & helpers.SQLITE_DETERMINISTIC
+    assert not (seen[1] & helpers.SQLITE_DETERMINISTIC)
+
+
+def test_no_meminfo_leak():
+    """The helper-generated lifecycle must preserve export/release balance."""
+    from numba.core.runtime import nrt
+    _nrt = nrt._nrt
+    if not hasattr(_nrt, "memsys_enable_stats"):
+        import pytest
+        pytest.skip("NRT allocation stats unavailable")
+    _nrt.memsys_enable_stats()
+    test_aggregate_sum()          # warm up JIT / one-time allocs
+    test_window_running_sum()
+    before = nrt.rtsys.get_allocation_stats()
+    for _ in range(10):
+        test_aggregate_sum()
+        test_window_running_sum()
+    after = nrt.rtsys.get_allocation_stats()
+    allocated = after.mi_alloc - before.mi_alloc
+    freed = after.mi_free - before.mi_free
+    assert allocated == freed, "meminfo imbalance: %d alloc, %d free" % (allocated, freed)
+
+
+def test_window_deterministic_flag_ors_bit(monkeypatch):
+    """register_window must OR SQLITE_DETERMINISTIC into the flags passed to
+    sqlite3_create_window_function when deterministic=True, and not otherwise."""
+    import numbox.core.bindings._sqlite_udf_helpers as helpers
+    real = helpers.sqlite3_create_window_function
+    seen = []
+
+    def spy(db, name_p, n_arg, flags, *rest):
+        seen.append(flags)
+        return real(db, name_p, n_arg, flags, *rest)
+
+    monkeypatch.setattr(helpers, "sqlite3_create_window_function", spy)
+    db = _open_memory()
+    register_window(db, "wdet_on", 1, sum_state_type, sum_init, sum_step,
+                    w_inverse, w_value, sum_finalize, deterministic=True)
+    register_window(db, "wdet_off", 1, sum_state_type, sum_init, sum_step,
+                    w_inverse, w_value, sum_finalize)
+    sqlite3_close(db)
+    assert seen[0] & helpers.SQLITE_DETERMINISTIC
+    assert not (seen[1] & helpers.SQLITE_DETERMINISTIC)
+
+
+def test_registration_error_raises(monkeypatch):
+    """A non-OK return from sqlite registration surfaces as a RuntimeError via
+    _raise_rc, not a silent success. The non-OK code is injected (rather than
+    relying on an out-of-range n_arg or an over-long name, whose rejection is
+    build-dependent -- SQLITE_MAX_FUNCTION_ARG and name limits vary), so the
+    test is portable across sqlite builds."""
+    import pytest
+    import numbox.core.bindings._sqlite_udf_helpers as helpers
+    monkeypatch.setattr(helpers, "sqlite3_create_function_v2",
+                        lambda *a, **k: 1)  # non-OK rc (SQLITE_ERROR)
+    db = _open_memory()
+    with pytest.raises(RuntimeError, match="registration failed"):
+        register_aggregate(db, "err", 1, sum_state_type,
+                           sum_init, sum_step, sum_finalize)
+    sqlite3_close(db)
+
+
+def test_non_njit_callback_rejected():
+    """A plain (non-@njit) callback is rejected up front with a clear TypeError
+    rather than a cryptic numba TypingError at bake time."""
+    import pytest
+    db = _open_memory()
+
+    def plain_step(state, ctx, argc, argv_pp):
+        pass
+
+    with pytest.raises(TypeError, match="step must be an @njit"):
+        register_aggregate(db, "bad_cb", 1, sum_state_type,
+                           sum_init, plain_step, sum_finalize)
+    sqlite3_close(db)
+
+
+# --- multi-field state + multi-arg UDAF parity ---
+@structref.register
+class PairStateType(nb_types.StructRef):
+    def preprocess_fields(self, fields):
+        return tuple((n, nb_types.unliteral(t)) for n, t in fields)
+
+
+class PairState(structref.StructRefProxy):
+    def __new__(cls, sa, sb):
+        return structref.StructRefProxy.__new__(cls, sa, sb)
+
+
+structref.define_proxy(PairState, PairStateType, ["sa", "sb"])
+pair_state_type = PairStateType([("sa", nb_types.int64), ("sb", nb_types.int64)])
+
+
+@njit
+def pair_init():
+    return PairState(nb_types.int64(0), nb_types.int64(0))
+
+
+@njit
+def pair_step(state, ctx, argc, argv_pp):
+    args = carray(_cast_int_to_void_p(argv_pp), (argc,), dtype=np.intp)
+    state.sa += sqlite3_value_int64(args[0])
+    state.sb += sqlite3_value_int64(args[1])
+
+
+@njit
+def pair_finalize(state, ctx):
+    sqlite3_result_int64(ctx, state.sa + 10 * state.sb)
+
+
+def test_multiarg_multifield_state():
+    db = _open_memory()
+    with c_string("CREATE TABLE t2(a INTEGER, b INTEGER)") as p:
+        assert sqlite3_exec(db, p, 0, 0, 0) == SQLITE_OK
+    for a, b in [(1, 4), (2, 5), (3, 6)]:
+        with c_string("INSERT INTO t2 VALUES (%d, %d)" % (a, b)) as p:
+            assert sqlite3_exec(db, p, 0, 0, 0) == SQLITE_OK
+    h = register_aggregate(db, "pairsum", 2, pair_state_type,
+                           pair_init, pair_step, pair_finalize)
+    val, _cap = _read1_int64(db, "SELECT __cap(pairsum(a, b)) FROM t2")
+    sqlite3_close(db)
+    assert val == 156  # sa=1+2+3=6, sb=4+5+6=15 => 6 + 10*15
+    assert h is not None
+
+
+@njit
+def raising_finalize(state, ctx):
+    raise ValueError("boom from finalize")
+
+
+def test_finalize_exception_surfaces_error_and_no_leak():
+    """A raising finalize must fail the query (xFinal reports SQLITE_ERROR) and
+    must not leak the exported meminfo slot -- xFinal releases in a try/except."""
+    from numba.core.runtime import nrt
+    _nrt = nrt._nrt
+    if not hasattr(_nrt, "memsys_enable_stats"):
+        import pytest
+        pytest.skip("NRT allocation stats unavailable")
+
+    db = _open_memory()
+    _make_table(db, [1, 2, 3, 4, 5])
+    h = register_aggregate(db, "raise_fin", 1, sum_state_type,
+                           sum_init, sum_step, raising_finalize)
+    with c_string("SELECT raise_fin(v) FROM t") as sp:
+        rc = sqlite3_exec(db, sp, 0, 0, 0)
+    assert rc != SQLITE_OK  # error surfaced to sqlite, not a silent wrong result
+    assert "finalize callback" in _errmsg(db)  # descriptive message, not the generic code
+
+    _nrt.memsys_enable_stats()
+    with c_string("SELECT raise_fin(v) FROM t") as sp:  # warm
+        sqlite3_exec(db, sp, 0, 0, 0)
+    before = nrt.rtsys.get_allocation_stats()
+    for _ in range(10):
+        with c_string("SELECT raise_fin(v) FROM t") as sp:
+            sqlite3_exec(db, sp, 0, 0, 0)
+    after = nrt.rtsys.get_allocation_stats()
+    sqlite3_close(db)
+    allocated = after.mi_alloc - before.mi_alloc
+    freed = after.mi_free - before.mi_free
+    assert allocated == freed, "leak on raising finalize: %d alloc, %d free" % (allocated, freed)
+    assert h is not None
+
+
+@njit
+def raising_step(state, ctx, argc, argv_pp):
+    raise ValueError("boom from step")
+
+
+def test_step_exception_surfaces_error_and_no_leak():
+    """A raising step must fail the query (xStep reports SQLITE_ERROR) instead of
+    silently dropping rows, and must not leak the borrowed state meminfo."""
+    from numba.core.runtime import nrt
+    _nrt = nrt._nrt
+    if not hasattr(_nrt, "memsys_enable_stats"):
+        import pytest
+        pytest.skip("NRT allocation stats unavailable")
+
+    db = _open_memory()
+    _make_table(db, [1, 2, 3, 4, 5])
+    h = register_aggregate(db, "raise_step", 1, sum_state_type,
+                           sum_init, raising_step, sum_finalize)
+    with c_string("SELECT raise_step(v) FROM t") as sp:
+        rc = sqlite3_exec(db, sp, 0, 0, 0)
+    assert rc != SQLITE_OK  # raising step fails the query, not a silent wrong result
+    assert "step callback" in _errmsg(db)  # descriptive message, not the generic code
+
+    _nrt.memsys_enable_stats()
+    with c_string("SELECT raise_step(v) FROM t") as sp:  # warm
+        sqlite3_exec(db, sp, 0, 0, 0)
+    before = nrt.rtsys.get_allocation_stats()
+    for _ in range(10):
+        with c_string("SELECT raise_step(v) FROM t") as sp:
+            sqlite3_exec(db, sp, 0, 0, 0)
+    after = nrt.rtsys.get_allocation_stats()
+    sqlite3_close(db)
+    allocated = after.mi_alloc - before.mi_alloc
+    freed = after.mi_free - before.mi_free
+    assert allocated == freed, "leak on raising step: %d alloc, %d free" % (allocated, freed)
+    assert h is not None
+
+
+_WIN_SQL = ("SELECT %s(v) OVER (ORDER BY v ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) "
+            "FROM t ORDER BY v")
+
+
+@njit
+def raising_value(state, ctx):
+    raise ValueError("boom from value")
+
+
+def test_value_exception_surfaces_error_and_no_leak():
+    """A raising window value must fail the query (xValue reports SQLITE_ERROR)
+    instead of emitting a stale value, and must not leak the borrowed meminfo."""
+    from numba.core.runtime import nrt
+    _nrt = nrt._nrt
+    if not hasattr(_nrt, "memsys_enable_stats"):
+        import pytest
+        pytest.skip("NRT allocation stats unavailable")
+
+    db = _open_memory()
+    _make_table(db, [1, 2, 3, 4, 5])
+    h = register_window(db, "raise_wval", 1, sum_state_type, sum_init, sum_step,
+                        w_inverse, raising_value, sum_finalize)
+    with c_string(_WIN_SQL % "raise_wval") as sp:
+        rc = sqlite3_exec(db, sp, 0, 0, 0)
+    assert rc != SQLITE_OK
+    assert "value callback" in _errmsg(db)  # descriptive message, not the generic code
+
+    _nrt.memsys_enable_stats()
+    with c_string(_WIN_SQL % "raise_wval") as sp:  # warm
+        sqlite3_exec(db, sp, 0, 0, 0)
+    before = nrt.rtsys.get_allocation_stats()
+    for _ in range(10):
+        with c_string(_WIN_SQL % "raise_wval") as sp:
+            sqlite3_exec(db, sp, 0, 0, 0)
+    after = nrt.rtsys.get_allocation_stats()
+    sqlite3_close(db)
+    allocated = after.mi_alloc - before.mi_alloc
+    freed = after.mi_free - before.mi_free
+    assert allocated == freed, "leak on raising value: %d alloc, %d free" % (allocated, freed)
+    assert h is not None
+
+
+@njit
+def raising_inverse(state, ctx, argc, argv_pp):
+    raise ValueError("boom from inverse")
+
+
+def test_inverse_exception_surfaces_error_and_no_leak():
+    """A raising window inverse must fail the query and must not leak the borrowed
+    meminfo. (SQLite does not document xInverse error propagation, but it is
+    observed on the system sqlite; the load-bearing guarantee is no-leak.)"""
+    from numba.core.runtime import nrt
+    _nrt = nrt._nrt
+    if not hasattr(_nrt, "memsys_enable_stats"):
+        import pytest
+        pytest.skip("NRT allocation stats unavailable")
+
+    db = _open_memory()
+    _make_table(db, [1, 2, 3, 4, 5])
+    h = register_window(db, "raise_winv", 1, sum_state_type, sum_init, sum_step,
+                        raising_inverse, w_value, sum_finalize)
+    with c_string(_WIN_SQL % "raise_winv") as sp:
+        rc = sqlite3_exec(db, sp, 0, 0, 0)
+    assert rc != SQLITE_OK
+
+    _nrt.memsys_enable_stats()
+    with c_string(_WIN_SQL % "raise_winv") as sp:  # warm
+        sqlite3_exec(db, sp, 0, 0, 0)
+    before = nrt.rtsys.get_allocation_stats()
+    for _ in range(10):
+        with c_string(_WIN_SQL % "raise_winv") as sp:
+            sqlite3_exec(db, sp, 0, 0, 0)
+    after = nrt.rtsys.get_allocation_stats()
+    sqlite3_close(db)
+    allocated = after.mi_alloc - before.mi_alloc
+    freed = after.mi_free - before.mi_free
+    assert allocated == freed, "leak on raising inverse: %d alloc, %d free" % (allocated, freed)
+    assert h is not None
+
+
+def test_finalize_exception_empty_group_surfaces_error():
+    """A raising finalize on an EMPTY group (xFinal's no-state branch, where no
+    xStep ran so the aggregate context is NULL) must also fail the query, not be
+    silently swallowed -- the empty-group branch is guarded like the borrow path."""
+    db = _open_memory()
+    _make_table(db, [])  # empty: xStep never runs -> xFinal hits the no-state branch
+    h = register_aggregate(db, "raise_fin_empty", 1, sum_state_type,
+                           sum_init, sum_step, raising_finalize)
+    with c_string("SELECT raise_fin_empty(v) FROM t") as sp:
+        rc = sqlite3_exec(db, sp, 0, 0, 0)
+    msg = _errmsg(db)
+    sqlite3_close(db)
+    assert rc != SQLITE_OK  # raising finalize on an empty group must fail loudly
+    assert "finalize callback" in msg  # descriptive message even on the empty-group path
+    assert h is not None
+
+
+@njit
+def init_raise():
+    s = SumState(nb_types.int64(0))
+    if s.total >= 0:  # always true at runtime; keeps the St return type for typing
+        raise ValueError("boom from init")
+    return s
+
+
+def test_init_exception_surfaces_error_no_unraisable():
+    """A raising init (called at xStep's first-row export) must be caught and
+    reported as 'error in user init callback', NOT swallowed by the @cfunc
+    boundary as an 'Exception ignored' unraisable."""
+    db = _open_memory()
+    _make_table(db, [1, 2, 3])
+    h = register_aggregate(db, "raise_init", 1, sum_state_type,
+                           init_raise, sum_step, sum_finalize)
+    captured = []
+    old_hook = sys.unraisablehook
+    sys.unraisablehook = lambda a: captured.append(a)
+    try:
+        with c_string("SELECT raise_init(v) FROM t") as sp:
+            rc = sqlite3_exec(db, sp, 0, 0, 0)
+        msg = _errmsg(db)
+    finally:
+        sys.unraisablehook = old_hook
+    sqlite3_close(db)
+    assert not captured, "raising init leaked an unraisable (swallowed): %r" % (captured,)
+    assert rc != SQLITE_OK
+    assert "init callback" in msg  # accurate role, not a mislabeled finalize error
+    assert h is not None
+
+
+def test_init_exception_empty_group_surfaces_error():
+    """A raising init on an empty group (xFinal's no-state branch) must report
+    'error in user init callback', not the mislabeled 'finalize callback'."""
+    db = _open_memory()
+    _make_table(db, [])
+    h = register_aggregate(db, "raise_init_empty", 1, sum_state_type,
+                           init_raise, sum_step, sum_finalize)
+    with c_string("SELECT raise_init_empty(v) FROM t") as sp:
+        rc = sqlite3_exec(db, sp, 0, 0, 0)
+    msg = _errmsg(db)
+    sqlite3_close(db)
+    assert rc != SQLITE_OK
+    assert "init callback" in msg
+    assert h is not None

--- a/test/core/test_sqlite_udf_helpers.py
+++ b/test/core/test_sqlite_udf_helpers.py
@@ -104,24 +104,20 @@ def _read1_int64(db, select_sql):
 def test_aggregate_sum():
     db = _open_memory()
     _make_table(db, [1, 2, 3, 4, 5])
-    h = register_aggregate(db, "my_sum", 1, sum_state_type,
-                           sum_init, sum_step, sum_finalize)
-    gc.collect()  # handle must keep callbacks alive
+    register_aggregate(db, "my_sum", 1, sum_state_type, sum_init, sum_step, sum_finalize)
+    gc.collect()  # no handle retained; callbacks survive GC (numba keeps the JIT code alive)
     val, _cap = _read1_int64(db, "SELECT __cap(my_sum(v)) FROM t")
     sqlite3_close(db)
     assert val == 15
-    assert h is not None
 
 
 def test_aggregate_empty_group():
     db = _open_memory()
     _make_table(db, [])
-    h = register_aggregate(db, "my_sum", 1, sum_state_type,
-                           sum_init, sum_step, sum_finalize)
+    register_aggregate(db, "my_sum", 1, sum_state_type, sum_init, sum_step, sum_finalize)
     val, _cap = _read1_int64(db, "SELECT __cap(my_sum(v)) FROM t")
     sqlite3_close(db)
     assert val == 0
-    assert h is not None
 
 
 def test_aggregate_bad_state_type():
@@ -185,7 +181,7 @@ _DRIVER = textwrap.dedent('''
     for v in (1, 2, 3, 4, 5):
         with c_string("INSERT INTO t VALUES (%d)" % v) as p:
             sqlite3_exec(db, p, 0, 0, 0)
-    h = register_aggregate(db, "f", 1, st, s_init, s_step, s_fin)
+    register_aggregate(db, "f", 1, st, s_init, s_step, s_fin)
     buf = np.zeros(1, dtype=np.int64)
     @cfunc(types.void(types.intp, types.int32, types.intp))
     def cap(ctx, argc, argv):
@@ -288,15 +284,13 @@ def _read_window(db, select_sql, nrows):
 def test_window_running_sum():
     db = _open_memory()
     _make_table(db, [1, 2, 3, 4, 5])
-    h = register_window(db, "my_wsum", 1, sum_state_type,
-                        sum_init, sum_step, w_inverse, w_value, sum_finalize)
+    register_window(db, "my_wsum", 1, sum_state_type, sum_init, sum_step, w_inverse, w_value, sum_finalize)
     sql = ("SELECT __wcap(my_wsum(v) OVER "
            "(ORDER BY v ROWS BETWEEN 1 PRECEDING AND CURRENT ROW)) "
            "FROM t ORDER BY v")
     vals, _cap = _read_window(db, sql, 5)
     sqlite3_close(db)
     assert vals == [1, 3, 5, 7, 9]
-    assert h is not None
 
 
 @njit
@@ -308,26 +302,21 @@ def sum2_step(state, ctx, argc, argv_pp):  # distinct body => independent compil
 def test_two_distinct_aggregates_no_collision():
     db = _open_memory()
     _make_table(db, [1, 2, 3, 4, 5])
-    h1 = register_aggregate(db, "my_sum", 1, sum_state_type,
-                            sum_init, sum_step, sum_finalize)
-    h2 = register_aggregate(db, "my_sum2", 1, sum_state_type,
-                            sum_init, sum2_step, sum_finalize)
+    register_aggregate(db, "my_sum", 1, sum_state_type, sum_init, sum_step, sum_finalize)
+    register_aggregate(db, "my_sum2", 1, sum_state_type, sum_init, sum2_step, sum_finalize)
     v1, _c1 = _read1_int64(db, "SELECT __cap(my_sum(v)) FROM t")
     v2, _c2 = _read1_int64(db, "SELECT __cap(my_sum2(v)) FROM t")
     sqlite3_close(db)
     assert (v1, v2) == (15, 30)
-    assert h1 is not None and h2 is not None
 
 
 def test_deterministic_flag():
     db = _open_memory()
     _make_table(db, [1, 2, 3, 4, 5])
-    h = register_aggregate(db, "my_sum_det", 1, sum_state_type,
-                           sum_init, sum_step, sum_finalize, deterministic=True)
+    register_aggregate(db, "my_sum_det", 1, sum_state_type, sum_init, sum_step, sum_finalize, deterministic=True)
     val, _cap = _read1_int64(db, "SELECT __cap(my_sum_det(v)) FROM t")
     sqlite3_close(db)
     assert val == 15
-    assert h is not None
 
 
 def test_deterministic_flag_ors_bit(monkeypatch):
@@ -345,10 +334,8 @@ def test_deterministic_flag_ors_bit(monkeypatch):
 
     monkeypatch.setattr(helpers, "sqlite3_create_function_v2", spy)
     db = _open_memory()
-    register_aggregate(db, "det_on", 1, sum_state_type,
-                       sum_init, sum_step, sum_finalize, deterministic=True)
-    register_aggregate(db, "det_off", 1, sum_state_type,
-                       sum_init, sum_step, sum_finalize)
+    register_aggregate(db, "det_on", 1, sum_state_type, sum_init, sum_step, sum_finalize, deterministic=True)
+    register_aggregate(db, "det_off", 1, sum_state_type, sum_init, sum_step, sum_finalize)
     sqlite3_close(db)
     assert seen[0] & helpers.SQLITE_DETERMINISTIC
     assert not (seen[1] & helpers.SQLITE_DETERMINISTIC)
@@ -387,10 +374,8 @@ def test_window_deterministic_flag_ors_bit(monkeypatch):
 
     monkeypatch.setattr(helpers, "sqlite3_create_window_function", spy)
     db = _open_memory()
-    register_window(db, "wdet_on", 1, sum_state_type, sum_init, sum_step,
-                    w_inverse, w_value, sum_finalize, deterministic=True)
-    register_window(db, "wdet_off", 1, sum_state_type, sum_init, sum_step,
-                    w_inverse, w_value, sum_finalize)
+    register_window(db, "wdet_on", 1, sum_state_type, sum_init, sum_step, w_inverse, w_value, sum_finalize, deterministic=True)
+    register_window(db, "wdet_off", 1, sum_state_type, sum_init, sum_step, w_inverse, w_value, sum_finalize)
     sqlite3_close(db)
     assert seen[0] & helpers.SQLITE_DETERMINISTIC
     assert not (seen[1] & helpers.SQLITE_DETERMINISTIC)
@@ -408,8 +393,7 @@ def test_registration_error_raises(monkeypatch):
                         lambda *a, **k: 1)  # non-OK rc (SQLITE_ERROR)
     db = _open_memory()
     with pytest.raises(RuntimeError, match="registration failed"):
-        register_aggregate(db, "err", 1, sum_state_type,
-                           sum_init, sum_step, sum_finalize)
+        register_aggregate(db, "err", 1, sum_state_type, sum_init, sum_step, sum_finalize)
     sqlite3_close(db)
 
 
@@ -429,13 +413,11 @@ def test_plain_python_callbacks_accepted():
     def plain_finalize(state, ctx):
         sqlite3_result_int64(ctx, state.total)
 
-    h = register_aggregate(db, "plain_sum", 1, sum_state_type,
-                           plain_init, plain_step, plain_finalize)
-    gc.collect()  # handle must keep callbacks alive
+    register_aggregate(db, "plain_sum", 1, sum_state_type, plain_init, plain_step, plain_finalize)
+    gc.collect()  # no handle retained; plain callbacks njit-wrapped, survive GC too
     val, _cap = _read1_int64(db, "SELECT __cap(plain_sum(v)) FROM t")
     sqlite3_close(db)
     assert val == 15
-    assert h is not None
 
 
 def test_non_callable_callback_rejected():
@@ -443,8 +425,7 @@ def test_non_callable_callback_rejected():
     import pytest
     db = _open_memory()
     with pytest.raises(TypeError, match="step must be a callable"):
-        register_aggregate(db, "bad_cb", 1, sum_state_type,
-                           sum_init, 42, sum_finalize)
+        register_aggregate(db, "bad_cb", 1, sum_state_type, sum_init, 42, sum_finalize)
     sqlite3_close(db)
 
 
@@ -488,12 +469,10 @@ def test_multiarg_multifield_state():
     for a, b in [(1, 4), (2, 5), (3, 6)]:
         with c_string("INSERT INTO t2 VALUES (%d, %d)" % (a, b)) as p:
             assert sqlite3_exec(db, p, 0, 0, 0) == SQLITE_OK
-    h = register_aggregate(db, "pairsum", 2, pair_state_type,
-                           pair_init, pair_step, pair_finalize)
+    register_aggregate(db, "pairsum", 2, pair_state_type, pair_init, pair_step, pair_finalize)
     val, _cap = _read1_int64(db, "SELECT __cap(pairsum(a, b)) FROM t2")
     sqlite3_close(db)
     assert val == 156  # sa=1+2+3=6, sb=4+5+6=15 => 6 + 10*15
-    assert h is not None
 
 
 @njit
@@ -512,8 +491,7 @@ def test_finalize_exception_surfaces_error_and_no_leak():
 
     db = _open_memory()
     _make_table(db, [1, 2, 3, 4, 5])
-    h = register_aggregate(db, "raise_fin", 1, sum_state_type,
-                           sum_init, sum_step, raising_finalize)
+    register_aggregate(db, "raise_fin", 1, sum_state_type, sum_init, sum_step, raising_finalize)
     with c_string("SELECT raise_fin(v) FROM t") as sp:
         rc = sqlite3_exec(db, sp, 0, 0, 0)
     assert rc != SQLITE_OK  # error surfaced to sqlite, not a silent wrong result
@@ -531,7 +509,6 @@ def test_finalize_exception_surfaces_error_and_no_leak():
     allocated = after.mi_alloc - before.mi_alloc
     freed = after.mi_free - before.mi_free
     assert allocated == freed, "leak on raising finalize: %d alloc, %d free" % (allocated, freed)
-    assert h is not None
 
 
 @njit
@@ -550,8 +527,7 @@ def test_step_exception_surfaces_error_and_no_leak():
 
     db = _open_memory()
     _make_table(db, [1, 2, 3, 4, 5])
-    h = register_aggregate(db, "raise_step", 1, sum_state_type,
-                           sum_init, raising_step, sum_finalize)
+    register_aggregate(db, "raise_step", 1, sum_state_type, sum_init, raising_step, sum_finalize)
     with c_string("SELECT raise_step(v) FROM t") as sp:
         rc = sqlite3_exec(db, sp, 0, 0, 0)
     assert rc != SQLITE_OK  # raising step fails the query, not a silent wrong result
@@ -569,7 +545,6 @@ def test_step_exception_surfaces_error_and_no_leak():
     allocated = after.mi_alloc - before.mi_alloc
     freed = after.mi_free - before.mi_free
     assert allocated == freed, "leak on raising step: %d alloc, %d free" % (allocated, freed)
-    assert h is not None
 
 
 _WIN_SQL = ("SELECT %s(v) OVER (ORDER BY v ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) "
@@ -592,8 +567,7 @@ def test_value_exception_surfaces_error_and_no_leak():
 
     db = _open_memory()
     _make_table(db, [1, 2, 3, 4, 5])
-    h = register_window(db, "raise_wval", 1, sum_state_type, sum_init, sum_step,
-                        w_inverse, raising_value, sum_finalize)
+    register_window(db, "raise_wval", 1, sum_state_type, sum_init, sum_step, w_inverse, raising_value, sum_finalize)
     with c_string(_WIN_SQL % "raise_wval") as sp:
         rc = sqlite3_exec(db, sp, 0, 0, 0)
     assert rc != SQLITE_OK
@@ -611,7 +585,6 @@ def test_value_exception_surfaces_error_and_no_leak():
     allocated = after.mi_alloc - before.mi_alloc
     freed = after.mi_free - before.mi_free
     assert allocated == freed, "leak on raising value: %d alloc, %d free" % (allocated, freed)
-    assert h is not None
 
 
 @njit
@@ -631,8 +604,7 @@ def test_inverse_exception_surfaces_error_and_no_leak():
 
     db = _open_memory()
     _make_table(db, [1, 2, 3, 4, 5])
-    h = register_window(db, "raise_winv", 1, sum_state_type, sum_init, sum_step,
-                        raising_inverse, w_value, sum_finalize)
+    register_window(db, "raise_winv", 1, sum_state_type, sum_init, sum_step, raising_inverse, w_value, sum_finalize)
     with c_string(_WIN_SQL % "raise_winv") as sp:
         rc = sqlite3_exec(db, sp, 0, 0, 0)
     assert rc != SQLITE_OK
@@ -649,7 +621,6 @@ def test_inverse_exception_surfaces_error_and_no_leak():
     allocated = after.mi_alloc - before.mi_alloc
     freed = after.mi_free - before.mi_free
     assert allocated == freed, "leak on raising inverse: %d alloc, %d free" % (allocated, freed)
-    assert h is not None
 
 
 def test_finalize_exception_empty_group_surfaces_error():
@@ -658,15 +629,13 @@ def test_finalize_exception_empty_group_surfaces_error():
     silently swallowed -- the empty-group branch is guarded like the borrow path."""
     db = _open_memory()
     _make_table(db, [])  # empty: xStep never runs -> xFinal hits the no-state branch
-    h = register_aggregate(db, "raise_fin_empty", 1, sum_state_type,
-                           sum_init, sum_step, raising_finalize)
+    register_aggregate(db, "raise_fin_empty", 1, sum_state_type, sum_init, sum_step, raising_finalize)
     with c_string("SELECT raise_fin_empty(v) FROM t") as sp:
         rc = sqlite3_exec(db, sp, 0, 0, 0)
     msg = _errmsg(db)
     sqlite3_close(db)
     assert rc != SQLITE_OK  # raising finalize on an empty group must fail loudly
     assert "finalize callback" in msg  # descriptive message even on the empty-group path
-    assert h is not None
 
 
 @njit
@@ -683,8 +652,7 @@ def test_init_exception_surfaces_error_no_unraisable():
     boundary as an 'Exception ignored' unraisable."""
     db = _open_memory()
     _make_table(db, [1, 2, 3])
-    h = register_aggregate(db, "raise_init", 1, sum_state_type,
-                           init_raise, sum_step, sum_finalize)
+    register_aggregate(db, "raise_init", 1, sum_state_type, init_raise, sum_step, sum_finalize)
     captured = []
     old_hook = sys.unraisablehook
     sys.unraisablehook = lambda a: captured.append(a)
@@ -698,7 +666,6 @@ def test_init_exception_surfaces_error_no_unraisable():
     assert not captured, "raising init leaked an unraisable (swallowed): %r" % (captured,)
     assert rc != SQLITE_OK
     assert "init callback" in msg  # accurate role, not a mislabeled finalize error
-    assert h is not None
 
 
 def test_init_exception_empty_group_surfaces_error():
@@ -706,12 +673,10 @@ def test_init_exception_empty_group_surfaces_error():
     'error in user init callback', not the mislabeled 'finalize callback'."""
     db = _open_memory()
     _make_table(db, [])
-    h = register_aggregate(db, "raise_init_empty", 1, sum_state_type,
-                           init_raise, sum_step, sum_finalize)
+    register_aggregate(db, "raise_init_empty", 1, sum_state_type, init_raise, sum_step, sum_finalize)
     with c_string("SELECT raise_init_empty(v) FROM t") as sp:
         rc = sqlite3_exec(db, sp, 0, 0, 0)
     msg = _errmsg(db)
     sqlite3_close(db)
     assert rc != SQLITE_OK
     assert "init callback" in msg
-    assert h is not None

--- a/test/core/test_sqlite_udf_helpers.py
+++ b/test/core/test_sqlite_udf_helpers.py
@@ -236,6 +236,23 @@ def test_invalidation_on_literal_edit(tmp_path):
     assert _run_driver(tmp_path, cache, 3) == 45       # step: += 3*v  => 45 (not stale 15)
 
 
+def test_jit_options_cache_disabled_honored(tmp_path):
+    """Generated impls honor the numbox-wide jit_options: with NUMBOX_JIT_OPTIONS
+    cache off, the UDAF still computes correctly and writes no impl .nbc."""
+    cache = tmp_path / "nbcache_nocache"
+    cache.mkdir()
+    script = tmp_path / "drv_nocache.py"
+    script.write_text(_DRIVER.replace("{MULT}", "1"))
+    env = dict(os.environ, NUMBA_CACHE_DIR=str(cache),
+               NUMBOX_JIT_OPTIONS='{"cache": false}')
+    out = subprocess.run([sys.executable, str(script)], env=env,
+                         capture_output=True, text=True, timeout=600)
+    assert out.returncode == 0, out.stderr
+    result = [ln for ln in out.stdout.splitlines() if ln.startswith("RESULT")][0]
+    assert int(result.split()[1]) == 15                # correct with cache disabled
+    assert _count_nbc(cache) == 0, "cache disabled but a udaf impl .nbc was written"
+
+
 @njit
 def w_inverse(state, ctx, argc, argv_pp):
     args = carray(_cast_int_to_void_p(argv_pp), (argc,), dtype=np.intp)


### PR DESCRIPTION
Routine sync of `main` with `upstream/main` (`dc710e0`) after the phase-3 UDAF/window registration helper landed upstream. Brings in 12 already-merged, already-reviewed upstream commits — no new fork-authored code — so there is nothing here to re-review.

Highlights:
- [#19](https://github.com/Goykhman/numbox/pull/19) — SQLite UDAF/window registration helpers (merged upstream at [`faff7e6`](https://github.com/Goykhman/numbox/commit/faff7e6)), plus Goykhman's post-merge comment cleanup [`dc710e0`](https://github.com/Goykhman/numbox/commit/dc710e0)
- [`4d7c435`](https://github.com/Goykhman/numbox/commit/4d7c435) — bindings proxies now honor `jit_options`

A **merge**, not a fast-forward: fork `main` is diverged (carries the fork-only `CLAUDE.md` and the expanded `numbox_ci.yml` matrix), so `upstream/main` is not an ancestor. Merge is conflict-free (common ancestor [`6243a80`](https://github.com/Goykhman/numbox/commit/6243a80)); fork-only files untouched.
