### PR TITLE
refactor(utils): extract _digest into numbox.utils.digest

### DIFF
--- a/docs/numbox.utils.rst
+++ b/docs/numbox.utils.rst
@@ -112,6 +112,14 @@ validity check.
    :show-inheritance:
    :undoc-members:
 
+numbox.utils.digest
+-------------------
+
+.. automodule:: numbox.utils.digest
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
 numbox.utils.lowlevel
 ---------------------
 

--- a/numbox/core/bindings/_sqlite_udf_helpers.py
+++ b/numbox/core/bindings/_sqlite_udf_helpers.py
@@ -33,7 +33,7 @@ callables (``@njit``/``@proxy``); plain ones are compiled with ``njit`` (see
 the callbacks are defined in ``__main__`` -- the anchor key is content-addressed
 on a ``cloudpickle`` of each callback's ``__code__`` (plus ``repr(state_type)``,
 the resolved ``jit_options``, and the numba/numbox versions), never on
-``__module__`` (see ``_digest``); the
+``__module__`` (see ``numbox.utils.digest.digest``); the
 subprocess tests ``test_xprocess_cache_no_growth`` /
 ``test_invalidation_on_literal_edit`` exercise this ``__main__`` path. The one
 case that does require a stable ``__module__`` is a *caller-side*
@@ -42,16 +42,11 @@ case that does require a stable ``__module__`` is a *caller-side*
 the state-type class and callbacks in an importable module.
 """
 import ctypes
-import hashlib
 
-import numba
 from numba import cfunc, types
-from numba.core.serialize import cloudpickle
 from numba.core.types import StructRef
 from numba.extending import is_jitted
 
-import numbox
-from numbox.core.configurations import jit_options
 from numbox.core.bindings._sqlite_conn import sqlite3_errmsg
 from numbox.core.bindings._sqlite_constants import (
     SQLITE_DETERMINISTIC,
@@ -63,6 +58,7 @@ from numbox.core.bindings._sqlite_udf import (
     sqlite3_create_window_function,
 )
 from numbox.utils.cstrings import c_string
+from numbox.utils.digest import digest
 from numbox.utils.preprocessing import (
     _anchor_path,
     _materialize_anchor,
@@ -73,6 +69,7 @@ from numbox.utils.preprocessing import (
 # puts them in this module's __dict__, which seeds the exec namespace below.
 import numpy as np  # noqa: F401
 from numba import carray, njit  # noqa: F401
+from numbox.core.configurations import jit_options  # noqa: F401
 from numbox.core.bindings._sqlite_result import sqlite3_result_error  # noqa: F401
 from numbox.core.bindings._sqlite_udf import sqlite3_aggregate_context  # noqa: F401
 from numbox.utils.lowlevel import _cast_int_to_void_p, get_unicode_data_p  # noqa: F401
@@ -221,35 +218,13 @@ def _prepare_callbacks(**fns):
     return prepared
 
 
-def _digest(state_type, fns):
-    """Content hash that invalidates when the state type, the user functions
-    (co_consts-sensitive, via cloudpickle of the code object -- NOT bare
-    co_code), the resolved ``jit_options``, or the numba/numbox versions change."""
-    h = hashlib.sha256()
-    h.update(repr(state_type).encode("utf-8"))
-    h.update(numba.__version__.encode("utf-8"))
-    # numbox.__version__ is "" upstream (the package version derives from it via
-    # pyproject's dynamic attr), so this fold is currently inert; it is kept so
-    # digests auto-invalidate should numbox ever set a real __version__. The
-    # numba version above and the code-object hash below do the real
-    # invalidating work (proven by test_invalidation_on_literal_edit).
-    h.update((numbox.__version__ or "").encode("utf-8"))
-    # fold the resolved numbox-wide jit_options so flipping NUMBOX_JIT_OPTIONS
-    # (e.g. cache off) re-keys the anchor; numba's own cache also keys on flags.
-    h.update(repr(sorted(jit_options.items())).encode("utf-8"))
-    for fn in fns:
-        py = getattr(fn, "py_func", fn)
-        h.update(cloudpickle.dumps(py.__code__))
-    return h.hexdigest()[:16]
-
-
 def _compile_callbacks(stem, srcs, state_type, fns):
     """Generate + content-address-anchor + exec the @njit(cache=True) impls.
 
     ``fns`` maps generated global names (``_init``, ``_step``, ...) to user
     callables. Returns the exec namespace (contains ``_xstep_impl`` etc.)."""
-    digest = _digest(state_type, list(fns.values()))
-    code_txt = "# udaf-digest: %s\n%s" % (digest, "".join(srcs))
+    udaf_digest = digest(state_type, list(fns.values()))
+    code_txt = "# udaf-digest: %s\n%s" % (udaf_digest, "".join(srcs))
     # globals() is this module's __dict__; it carries __name__, which numba's
     # warm-cache Environment rebuild requires when reloading the cached impls.
     ns = {**globals(), "_state_type": state_type, **fns}

--- a/numbox/utils/digest.py
+++ b/numbox/utils/digest.py
@@ -35,5 +35,6 @@ def digest(subject, fns):
     h.update(repr(sorted(jit_options.items())).encode("utf-8"))
     for fn in fns:
         py = getattr(fn, "py_func", fn)
-        h.update(cloudpickle.dumps(py.__code__))
+        code = getattr(py, "__code__", py)
+        h.update(cloudpickle.dumps(code))
     return h.hexdigest()[:16]

--- a/numbox/utils/digest.py
+++ b/numbox/utils/digest.py
@@ -1,0 +1,39 @@
+"""Content-addressed digest for cache keys and anchor identifiers.
+
+``digest`` produces a short, stable hash that invalidates when the subject's
+``repr``, the user functions (``co_consts``-sensitive, via cloudpickle of the
+code object -- NOT bare ``co_code``), the resolved ``jit_options``, or the
+numba/numbox versions change. The SQLite UDAF registration anchors are one
+consumer; any content-addressed cache that mixes a type/identifier with user
+callbacks can reuse it.
+"""
+import hashlib
+
+import numba
+from numba.core.serialize import cloudpickle
+
+import numbox
+from numbox.core.configurations import jit_options
+
+
+def digest(subject, fns):
+    """Content hash that invalidates when ``subject`` (by ``repr``), the user
+    functions (``co_consts``-sensitive, via cloudpickle of the code object --
+    NOT bare ``co_code``), the resolved ``jit_options``, or the numba/numbox
+    versions change."""
+    h = hashlib.sha256()
+    h.update(repr(subject).encode("utf-8"))
+    h.update(numba.__version__.encode("utf-8"))
+    # numbox.__version__ is "" upstream (the package version derives from it via
+    # pyproject's dynamic attr), so this fold is currently inert; it is kept so
+    # digests auto-invalidate should numbox ever set a real __version__. The
+    # numba version above and the code-object hash below do the real
+    # invalidating work (proven by test_invalidation_on_literal_edit).
+    h.update((numbox.__version__ or "").encode("utf-8"))
+    # fold the resolved numbox-wide jit_options so flipping NUMBOX_JIT_OPTIONS
+    # (e.g. cache off) re-keys the digest; numba's own cache also keys on flags.
+    h.update(repr(sorted(jit_options.items())).encode("utf-8"))
+    for fn in fns:
+        py = getattr(fn, "py_func", fn)
+        h.update(cloudpickle.dumps(py.__code__))
+    return h.hexdigest()[:16]

--- a/test/utils/test_digest.py
+++ b/test/utils/test_digest.py
@@ -1,0 +1,46 @@
+from numbox.utils.digest import digest
+from test.auxiliary_utils import collect_and_run_tests
+
+
+def test_digest_is_deterministic():
+    def cb(x):
+        return x + 1
+    assert digest("StateType", (cb,)) == digest("StateType", (cb,))
+
+
+def test_digest_length_is_16():
+    def cb(x):
+        return x
+    assert len(digest("StateType", (cb,))) == 16
+
+
+def test_digest_varies_with_subject():
+    def cb(x):
+        return x
+    assert digest("AType", (cb,)) != digest("BType", (cb,))
+
+
+def test_digest_varies_with_function_literal():
+    # co_consts-sensitive: bodies differing only by a numeric literal must produce
+    # different digests (cloudpickle of __code__, not bare co_code which is identical here).
+    def cb_one(x):
+        return x + 1
+
+    def cb_two(x):
+        return x + 2
+
+    assert digest("StateType", (cb_one,)) != digest("StateType", (cb_two,))
+
+
+def test_digest_varies_with_jit_options(monkeypatch):
+    from numbox.utils import digest as digest_mod
+
+    def cb(x):
+        return x
+    before = digest("StateType", (cb,))
+    monkeypatch.setitem(digest_mod.jit_options, "cache", not digest_mod.jit_options.get("cache", True))
+    assert digest("StateType", (cb,)) != before
+
+
+if __name__ == '__main__':
+    collect_and_run_tests(__name__)

--- a/test/utils/test_digest.py
+++ b/test/utils/test_digest.py
@@ -1,3 +1,5 @@
+import functools
+
 from numbox.utils.digest import digest
 from test.auxiliary_utils import collect_and_run_tests
 
@@ -40,6 +42,25 @@ def test_digest_varies_with_jit_options(monkeypatch):
     before = digest("StateType", (cb,))
     monkeypatch.setitem(digest_mod.jit_options, "cache", not digest_mod.jit_options.get("cache", True))
     assert digest("StateType", (cb,)) != before
+
+
+def test_digest_accepts_codeless_callable():
+    # a callable with no __code__ (builtin, functools.partial, callable object)
+    # must hash via cloudpickle of the object itself instead of raising.
+    assert len(digest("StateType", (functools.partial(len),))) == 16
+
+
+def test_digest_codeless_callable_captures_state():
+    # object-fallback hashes the whole object, so differing partial args (state)
+    # yield different digests -- which __call__.__code__ alone would miss.
+    one = digest("StateType", (functools.partial(len, "a"),))
+    two = digest("StateType", (functools.partial(len, "ab"),))
+    assert one != two
+
+
+def test_digest_empty_inputs_deterministic():
+    assert digest("", ()) == digest("", ())
+    assert len(digest("", ())) == 16
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Extracts the content-addressed digest helper out of `_sqlite_udf_helpers` into its own reusable module, per [@Goykhman's request on #19](https://github.com/Goykhman/numbox/pull/19#discussion_r3333392569) (design notes in #40).

- New [`numbox/utils/digest.py`](https://github.com/nelson2005/numbox/blob/feat/digest-util/numbox/utils/digest.py) exposing a public `digest(subject, fns)` — moved verbatim from the old `_digest` (param `state_type` → `subject`). Same `sha256` over `repr(subject)` + numba/numbox versions + resolved `jit_options` + `cloudpickle(__code__)` per callback, truncated `[:16]`.
- `_sqlite_udf_helpers` now imports it; the local `_digest` and its now-orphaned `hashlib` / `numba` / `cloudpickle` / `numbox` imports are removed; `jit_options` joins the generated-source `# noqa: F401` group.
- **Behavior is identical** — `digest` produces the same hashes, so no cache invalidation. Scope is this extraction only; the other content-hash sites (`make_graph`, `highlevel`, `_anchor_path`) are untouched (see [#40](https://github.com/nelson2005/numbox/issues/40)).
- Adds `test/utils/test_digest.py` (determinism, `[:16]` length, sensitivity to `subject` / `co_consts` literal edits / `jit_options`) and a `numbox.utils.digest` docs section.

Verified locally: full suite 567 passed / 2 skipped, flake8 + doc-codeblock-flake8 + sphinx all clean.
