### PR TITLE
Sync fork main with upstream/main (phase-4 sqlite vtable, #21)

### DIFF
--- a/docs/numbox.core.bindings.rst
+++ b/docs/numbox.core.bindings.rst
@@ -592,6 +592,14 @@ numbox.core.bindings._sqlite_udf_helpers
    :show-inheritance:
    :undoc-members:
 
+numbox.core.bindings._sqlite_vtable
+-----------------------------------
+
+.. automodule:: numbox.core.bindings._sqlite_vtable
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
 numbox.core.bindings.call
 -------------------------
 

--- a/docs/numbox.core.bindings.rst
+++ b/docs/numbox.core.bindings.rst
@@ -247,17 +247,25 @@ sub-int-width values) but makes ``%lld`` against ``int32`` work in
 uses the value's natural width. The cost is one LLVM widening
 instruction per arg — free at runtime.
 
-============   ============================
-Numba type     Widened to (in varargs slot)
-============   ============================
-``float32``    ``float64`` (``fpext``)
-``float64``    pass through
-``bool``       ``int64`` (``zext``)
-``int8`` / ``int16`` / ``int32`` (signed)   ``int64`` (``sext``)
-``uint8`` / ``uint16`` / ``uint32`` (unsigned)   ``int64`` (``zext``)
-``int64`` / ``uint64`` / ``intp``   pass through
-``unicode_type`` / ``Literal[str]``   auto-converted via ``get_unicode_data_p`` → ``intp``
-============   ============================
+.. list-table::
+   :header-rows: 1
+
+   * - Numba type
+     - Widened to (in varargs slot)
+   * - ``float32``
+     - ``float64`` (``fpext``)
+   * - ``float64``
+     - pass through
+   * - ``bool``
+     - ``int64`` (``zext``)
+   * - ``int8`` / ``int16`` / ``int32`` (signed)
+     - ``int64`` (``sext``)
+   * - ``uint8`` / ``uint16`` / ``uint32`` (unsigned)
+     - ``int64`` (``zext``)
+   * - ``int64`` / ``uint64`` / ``intp``
+     - pass through
+   * - ``unicode_type`` / ``Literal[str]``
+     - auto-converted via ``get_unicode_data_p`` → ``intp``
 
 **Unsupported types raise ``TypingError`` at compile time** — numpy
 arrays (``Array``), complex numbers (``Complex``), tuples

--- a/numbox/core/bindings/__init__.py
+++ b/numbox/core/bindings/__init__.py
@@ -16,3 +16,4 @@ from numbox.core.bindings._stdio import *  # noqa: F401, F403
 from numbox.core.bindings._errno import *  # noqa: F401, F403
 from numbox.core.bindings._strerror import *  # noqa: F401, F403
 from numbox.core.bindings._fmtio import *  # noqa: F401, F403
+from numbox.core.bindings._sqlite_vtable import *  # noqa: F401, F403

--- a/numbox/core/bindings/_sqlite_exec.py
+++ b/numbox/core/bindings/_sqlite_exec.py
@@ -6,7 +6,8 @@ function pointer to a per-row callback; pass 0 for no callback.
 
 sqlite3_free releases memory SQLite allocated and returned to the caller —
 notably the errmsg buffer from sqlite3_exec's out-param, and the result of
-sqlite3_expanded_sql.
+sqlite3_expanded_sql. sqlite3_malloc is its allocation counterpart (used by the
+virtual-table machinery to allocate the vtab and cursor structs).
 
 Callback shape (informational):
     int (*sqlite3_exec_callback)(void *ctx, int ncol,
@@ -26,7 +27,7 @@ from numbox.core.proxy.proxy import proxy
 
 
 __all__ = [
-    "sqlite3_exec", "sqlite3_free",
+    "sqlite3_exec", "sqlite3_free", "sqlite3_malloc",
 ]
 
 
@@ -43,3 +44,8 @@ def sqlite3_exec(db_p, sql_p, cb_p, ctx_p, errmsg_pp):
 @proxy(signatures.get("sqlite3_free"), jit_options=jit_options)
 def sqlite3_free(mem_p):
     return _call_lib_func("sqlite3_free", (mem_p,))
+
+
+@proxy(signatures.get("sqlite3_malloc"), jit_options=jit_options)
+def sqlite3_malloc(n):
+    return _call_lib_func("sqlite3_malloc", (n,))

--- a/numbox/core/bindings/_sqlite_vtable.py
+++ b/numbox/core/bindings/_sqlite_vtable.py
@@ -17,7 +17,7 @@ from numbox.core.bindings._sqlite_constants import (
     SQLITE_OK, SQLITE_TRANSIENT, SQLITE_ERROR, SQLITE_NOMEM,
 )
 from numbox.core.bindings._sqlite_conn import sqlite3_errmsg
-from numbox.core.bindings._sqlite_exec import sqlite3_free
+from numbox.core.bindings._sqlite_exec import sqlite3_free, sqlite3_malloc
 from numbox.core.bindings._sqlite_result import (
     sqlite3_result_int64, sqlite3_result_double,
     sqlite3_result_text, sqlite3_result_blob, sqlite3_result_error,
@@ -62,11 +62,6 @@ def sqlite3_create_module(db, z_name, p_module, p_client_data):
 @proxy(signatures.get("sqlite3_declare_vtab"), jit_options={"cache": True})
 def sqlite3_declare_vtab(db, z_sql):
     return _call_lib_func("sqlite3_declare_vtab", (db, z_sql))
-
-
-@proxy(signatures.get("sqlite3_malloc"), jit_options={"cache": True})
-def sqlite3_malloc(n):
-    return _call_lib_func("sqlite3_malloc", (n,))
 
 
 @njit(**jit_options)

--- a/numbox/core/bindings/_sqlite_vtable.py
+++ b/numbox/core/bindings/_sqlite_vtable.py
@@ -2,7 +2,10 @@
 
 A single generic sqlite3_module (built once at import) serves every table; the
 per-table base pointer / strides / dtype tags / schema live in a numpy
-structured-array descriptor whose data pointer is passed as pClientData.
+structured-array descriptor whose data pointer is passed as pClientData. The
+sqlite3_vtab and sqlite3_vtab_cursor SQLite allocates through us are likewise
+numpy structured dtypes, with their SQLite-owned base nested as field 'base'.
+See https://www.sqlite.org/vtab.html.
 """
 import ctypes
 
@@ -29,7 +32,7 @@ from numbox.core.configurations import jit_options
 from numbox.core.proxy.proxy import proxy
 from numbox.utils.cstrings import c_string
 from numbox.utils.lowlevel import (
-    _cast_int_to_void_p, get_unicode_data_p, load_at, load_unaligned, store_at,
+    _cast_int_to_void_p, get_unicode_data_p, load_unaligned, store_at,
 )
 
 __all__ = ["register_table"]
@@ -55,20 +58,39 @@ _DESC_DTYPE = np.dtype([
 ])
 assert _DESC_DTYPE.itemsize == 72
 
-# vtab layout: base sqlite3_vtab is 24 bytes; the descriptor_ptr is appended at +24
-_VTAB_DESC, _VTAB_SIZE = 24, 32
-# cursor layout: pVtab(+0), descriptor(+8), rowid(+16), scratch(+24)
-_CUR_PVTAB, _CUR_DESC, _CUR_ROWID, _CUR_SCRATCH = 0, 8, 16, 24
-assert _VTAB_DESC + 8 == _VTAB_SIZE
-assert _CUR_DESC == _CUR_PVTAB + 8 and _CUR_ROWID == _CUR_DESC + 8 and _CUR_SCRATCH == _CUR_ROWID + 8
+# The vtab and cursor SQLite allocates through us are C structs whose first
+# member is the SQLite-owned base (sqlite3_vtab / sqlite3_vtab_cursor); we append
+# our own members after it. Each is a numpy structured dtype with the base nested
+# as field 'base', so the cfuncs address members by name instead of raw offsets
+# (align=True reproduces the C padding, e.g. the int nRef in sqlite3_vtab).
+
+# struct sqlite3_vtab { const sqlite3_module *pModule; int nRef; char *zErrMsg; }
+# https://www.sqlite.org/c3ref/vtab.html -- SQLite owns/sets these fields.
+_SQLITE3_VTAB_DTYPE = np.dtype([("pModule", "i8"), ("nRef", "i4"), ("zErrMsg", "i8")], align=True)
+_VTAB_DTYPE = np.dtype([("base", _SQLITE3_VTAB_DTYPE), ("descriptor", "i8")], align=True)
+assert _SQLITE3_VTAB_DTYPE.itemsize == 24 and _VTAB_DTYPE.itemsize == 32
+_VTAB_SIZE = _VTAB_DTYPE.itemsize
+
+# struct sqlite3_vtab_cursor { sqlite3_vtab *pVtab; }
+# https://www.sqlite.org/c3ref/vtab_cursor.html -- one-member SQLite base. The
+# per-cursor UTF-8 scratch buffer is allocated right after this fixed header,
+# starting at offset _CUR_HEADER.
+_SQLITE3_VTAB_CURSOR_DTYPE = np.dtype([("pVtab", "i8")])
+_CUR_DTYPE = np.dtype([("base", _SQLITE3_VTAB_CURSOR_DTYPE), ("descriptor", "i8"), ("rowid", "i8")], align=True)
+assert _CUR_DTYPE.itemsize == 24
+_CUR_HEADER = _CUR_DTYPE.itemsize
+
+# @cfunc takes a cache bool (not a jit_options dict like @njit/@proxy); thread
+# the package-wide cache setting through it (default True).
+_CACHE = jit_options.get("cache", True)
 
 
-@proxy(signatures.get("sqlite3_create_module"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_create_module"), jit_options=jit_options)
 def sqlite3_create_module(db, z_name, p_module, p_client_data):
     return _call_lib_func("sqlite3_create_module", (db, z_name, p_module, p_client_data))
 
 
-@proxy(signatures.get("sqlite3_declare_vtab"), jit_options={"cache": True})
+@proxy(signatures.get("sqlite3_declare_vtab"), jit_options=jit_options)
 def sqlite3_declare_vtab(db, z_sql):
     return _call_lib_func("sqlite3_declare_vtab", (db, z_sql))
 
@@ -186,7 +208,7 @@ def _build_descriptor(arr, columns, text_as_blob):
     tags = [_col_tag(dt, text_as_blob) for dt in sub]
     widths = [int(dt.itemsize) for dt in sub]
     scratch = max([w + 1 for w, t in zip(widths, tags) if t == _TAG_U], default=0)
-    if _CUR_SCRATCH + scratch > 2 ** 31 - 1:
+    if _CUR_HEADER + scratch > 2 ** 31 - 1:
         raise ValueError("unicode column too wide: per-cursor scratch buffer would overflow int32")
 
     offsets_buf = np.array(offs, dtype=np.int64)
@@ -208,7 +230,7 @@ def _build_descriptor(arr, columns, text_as_blob):
     return _BuiltDescriptor(c, offsets_buf, tags_buf, widths_buf, schema, arr)
 
 
-@cfunc(types.int32(types.intp, types.intp, types.int32, types.intp, types.intp, types.intp), cache=True)
+@cfunc(types.int32(types.intp, types.intp, types.int32, types.intp, types.intp, types.intp), cache=_CACHE)
 def _xconnect(db, p_aux, argc, argv, pp_vtab, pz_err):
     vtab = 0
     try:
@@ -219,10 +241,13 @@ def _xconnect(db, p_aux, argc, argv, pp_vtab, pz_err):
         vtab = sqlite3_malloc(int32(_VTAB_SIZE))
         if vtab == 0:
             return SQLITE_NOMEM
-        store_at(vtab + 0, int64(0))
-        store_at(vtab + 8, int64(0))
-        store_at(vtab + 16, int64(0))
-        store_at(vtab + _VTAB_DESC, int64(p_aux))
+        # canonical sqlite3_vtab init: zero the whole struct (sqlite3_malloc does
+        # not), then set our appended member; SQLite owns/sets the base fields.
+        raw = carray(_cast_int_to_void_p(vtab), (_VTAB_SIZE,), dtype=np.uint8)
+        for i in range(_VTAB_SIZE):
+            raw[i] = 0
+        v = carray(_cast_int_to_void_p(vtab), (1,), dtype=_VTAB_DTYPE)
+        v[0].descriptor = p_aux
         slot = carray(_cast_int_to_void_p(pp_vtab), (1,), dtype=np.intp)
         slot[0] = vtab
         return SQLITE_OK
@@ -231,12 +256,12 @@ def _xconnect(db, p_aux, argc, argv, pp_vtab, pz_err):
         return SQLITE_ERROR
 
 
-@cfunc(types.int32(types.intp, types.intp), cache=True)
+@cfunc(types.int32(types.intp, types.intp), cache=_CACHE)
 def _xbestindex(vtab, idx_info):
     return SQLITE_OK
 
 
-@cfunc(types.int32(types.intp), cache=True)
+@cfunc(types.int32(types.intp), cache=_CACHE)
 def _xdisconnect(vtab):
     try:
         sqlite3_free(vtab)
@@ -245,19 +270,21 @@ def _xdisconnect(vtab):
         return SQLITE_ERROR
 
 
-@cfunc(types.int32(types.intp, types.intp), cache=True)
+@cfunc(types.int32(types.intp, types.intp), cache=_CACHE)
 def _xopen(vtab, pp_cursor):
     cur = 0
     try:
-        desc = load_at(vtab + _VTAB_DESC, int64)
+        v = carray(_cast_int_to_void_p(vtab), (1,), dtype=_VTAB_DTYPE)
+        desc = v[0].descriptor
         d = carray(_cast_int_to_void_p(desc), (1,), dtype=_DESC_DTYPE)
         scratch = d[0].scratch_bytes
-        cur = sqlite3_malloc(int32(_CUR_SCRATCH + scratch))  # _build_descriptor caps scratch: int32 cast cannot overflow
+        cur = sqlite3_malloc(int32(_CUR_HEADER + scratch))  # _build_descriptor caps scratch: int32 cast cannot overflow
         if cur == 0:
             return SQLITE_NOMEM
-        store_at(cur + _CUR_PVTAB, int64(vtab))
-        store_at(cur + _CUR_DESC, int64(desc))
-        store_at(cur + _CUR_ROWID, int64(0))
+        c = carray(_cast_int_to_void_p(cur), (1,), dtype=_CUR_DTYPE)
+        c[0].base.pVtab = vtab
+        c[0].descriptor = desc
+        c[0].rowid = 0
         slot = carray(_cast_int_to_void_p(pp_cursor), (1,), dtype=np.intp)
         slot[0] = cur
         return SQLITE_OK
@@ -266,7 +293,7 @@ def _xopen(vtab, pp_cursor):
         return SQLITE_ERROR
 
 
-@cfunc(types.int32(types.intp), cache=True)
+@cfunc(types.int32(types.intp), cache=_CACHE)
 def _xclose(cur):
     try:
         sqlite3_free(cur)
@@ -275,40 +302,42 @@ def _xclose(cur):
         return SQLITE_ERROR
 
 
-@cfunc(types.int32(types.intp, types.int32, types.intp, types.int32, types.intp), cache=True)
+@cfunc(types.int32(types.intp, types.int32, types.intp, types.int32, types.intp), cache=_CACHE)
 def _xfilter(cur, idx_num, idx_str, argc, argv):
-    store_at(cur + _CUR_ROWID, int64(0))
+    c = carray(_cast_int_to_void_p(cur), (1,), dtype=_CUR_DTYPE)
+    c[0].rowid = 0
     return SQLITE_OK
 
 
-@cfunc(types.int32(types.intp), cache=True)
+@cfunc(types.int32(types.intp), cache=_CACHE)
 def _xnext(cur):
-    store_at(cur + _CUR_ROWID, load_at(cur + _CUR_ROWID, int64) + 1)
+    c = carray(_cast_int_to_void_p(cur), (1,), dtype=_CUR_DTYPE)
+    c[0].rowid = c[0].rowid + 1
     return SQLITE_OK
 
 
-@cfunc(types.int32(types.intp), cache=True)
+@cfunc(types.int32(types.intp), cache=_CACHE)
 def _xeof(cur):
-    desc = load_at(cur + _CUR_DESC, int64)
-    rowid = load_at(cur + _CUR_ROWID, int64)
-    d = carray(_cast_int_to_void_p(desc), (1,), dtype=_DESC_DTYPE)
-    if rowid >= d[0].nrows:
+    c = carray(_cast_int_to_void_p(cur), (1,), dtype=_CUR_DTYPE)
+    d = carray(_cast_int_to_void_p(c[0].descriptor), (1,), dtype=_DESC_DTYPE)
+    if c[0].rowid >= d[0].nrows:
         return 1
     return 0
 
 
-@cfunc(types.int32(types.intp, types.intp), cache=True)
+@cfunc(types.int32(types.intp, types.intp), cache=_CACHE)
 def _xrowid(cur, p_rowid):
-    store_at(p_rowid, load_at(cur + _CUR_ROWID, int64))
+    c = carray(_cast_int_to_void_p(cur), (1,), dtype=_CUR_DTYPE)
+    store_at(p_rowid, c[0].rowid)
     return SQLITE_OK
 
 
-@cfunc(types.int32(types.intp, types.intp, types.int32), cache=True)
+@cfunc(types.int32(types.intp, types.intp, types.int32), cache=_CACHE)
 def _xcolumn(cur, ctx, j):
     try:
-        desc = load_at(cur + _CUR_DESC, int64)
-        rowid = load_at(cur + _CUR_ROWID, int64)
-        d = carray(_cast_int_to_void_p(desc), (1,), dtype=_DESC_DTYPE)
+        c = carray(_cast_int_to_void_p(cur), (1,), dtype=_CUR_DTYPE)
+        rowid = c[0].rowid
+        d = carray(_cast_int_to_void_p(c[0].descriptor), (1,), dtype=_DESC_DTYPE)
         ncols = d[0].ncols
         base = d[0].data_base
         row_stride = d[0].row_stride
@@ -346,7 +375,7 @@ def _xcolumn(cur, ctx, j):
             n = _nul_trimmed_len(addr, widths[j])
             sqlite3_result_blob(ctx, addr, int32(n), SQLITE_TRANSIENT)
         elif tag == _TAG_U:
-            scratch = cur + _CUR_SCRATCH
+            scratch = cur + _CUR_HEADER
             n = utf32_to_utf8(addr, widths[j] // 4, scratch)
             sqlite3_result_text(ctx, scratch, int32(n), SQLITE_TRANSIENT)
         return SQLITE_OK
@@ -380,8 +409,6 @@ THE_MODULE.xEof = _xeof.address
 THE_MODULE.xColumn = _xcolumn.address
 THE_MODULE.xRowid = _xrowid.address
 _THE_MODULE_P = ctypes.addressof(THE_MODULE)
-_CFUNCS = (_xconnect, _xbestindex, _xdisconnect, _xopen, _xclose,
-           _xfilter, _xnext, _xeof, _xcolumn, _xrowid)
 
 
 class _VTableHandle:

--- a/numbox/core/bindings/_sqlite_vtable.py
+++ b/numbox/core/bindings/_sqlite_vtable.py
@@ -1,8 +1,8 @@
 """Expose a numpy array as a read-only SQLite virtual table (register_table).
 
 A single generic sqlite3_module (built once at import) serves every table; the
-per-table base pointer / strides / dtype tags / schema live in a ctypes
-descriptor passed as pClientData.
+per-table base pointer / strides / dtype tags / schema live in a numpy
+structured-array descriptor whose data pointer is passed as pClientData.
 """
 import ctypes
 
@@ -42,9 +42,18 @@ _TAG_U8, _TAG_U16, _TAG_U32, _TAG_U64 = 4, 5, 6, 7
 _TAG_F32, _TAG_F64, _TAG_BOOL = 8, 9, 10
 _TAG_S, _TAG_U, _TAG_BLOB = 11, 12, 13
 
-# descriptor field byte offsets (mirror of _NdarrayTableDescriptor)
-_D_NROWS, _D_NCOLS, _D_ROW_STRIDE, _D_DATA_BASE = 0, 8, 16, 24
-_D_COL_OFFSETS, _D_COL_TAGS, _D_COL_WIDTHS, _D_SCHEMA, _D_SCRATCH = 32, 40, 48, 56, 64
+# per-table descriptor passed as pClientData; the cfuncs read it field-by-name
+# via carray(ptr, (1,), dtype=_DESC_DTYPE). The dtype is the single source of
+# truth for the layout (numpy owns the offsets). ('_pad', 'i4') holds the
+# alignment slot after the i4 ncols and is load-bearing -- do not drop it or
+# pass align=True (either would silently shift every field offset).
+_DESC_DTYPE = np.dtype([
+    ("nrows", "i8"), ("ncols", "i4"), ("_pad", "i4"),
+    ("row_stride", "i8"), ("data_base", "i8"),
+    ("col_offsets", "i8"), ("col_tags", "i8"), ("col_widths", "i8"),
+    ("schema_ptr", "i8"), ("scratch_bytes", "i8"),
+])
+assert _DESC_DTYPE.itemsize == 72
 
 # vtab layout: base sqlite3_vtab is 24 bytes; the descriptor_ptr is appended at +24
 _VTAB_DESC, _VTAB_SIZE = 24, 32
@@ -106,33 +115,6 @@ def utf32_to_utf8(src, n_codepoints, dst):
     return k
 
 
-class _NdarrayTableDescriptor(ctypes.Structure):
-    _fields_ = [
-        ("nrows", ctypes.c_int64),
-        ("ncols", ctypes.c_int32),
-        ("_pad", ctypes.c_int32),
-        ("row_stride", ctypes.c_int64),
-        ("data_base", ctypes.c_int64),
-        ("col_offsets", ctypes.c_int64),
-        ("col_tags", ctypes.c_int64),
-        ("col_widths", ctypes.c_int64),
-        ("schema_ptr", ctypes.c_int64),
-        ("scratch_bytes", ctypes.c_int64),
-    ]
-
-
-def _assert_descriptor_layout():
-    f = _NdarrayTableDescriptor
-    assert ctypes.sizeof(f) == 72
-    assert (f.nrows.offset, f.ncols.offset, f.row_stride.offset, f.data_base.offset) == \
-        (_D_NROWS, _D_NCOLS, _D_ROW_STRIDE, _D_DATA_BASE)
-    assert (f.col_offsets.offset, f.col_tags.offset, f.col_widths.offset) == \
-        (_D_COL_OFFSETS, _D_COL_TAGS, _D_COL_WIDTHS)
-    assert (f.schema_ptr.offset, f.scratch_bytes.offset) == (_D_SCHEMA, _D_SCRATCH)
-
-
-_assert_descriptor_layout()
-
 _NUMERIC_TAGS = {
     np.dtype("int8"): _TAG_I8, np.dtype("int16"): _TAG_I16,
     np.dtype("int32"): _TAG_I32, np.dtype("int64"): _TAG_I64,
@@ -160,7 +142,7 @@ def _col_tag(dt, text_as_blob):
 
 
 class _BuiltDescriptor:
-    """The ctypes descriptor plus every buffer whose pointer it holds."""
+    """The numpy structured-array descriptor plus every buffer whose pointer it holds."""
     __slots__ = ("c", "offsets", "tags", "widths", "schema",
                  "nrows", "ncols", "row_stride", "scratch_bytes", "arr")
 
@@ -171,10 +153,10 @@ class _BuiltDescriptor:
         self.widths = widths
         self.schema = schema
         self.arr = arr
-        self.nrows = c.nrows
-        self.ncols = c.ncols
-        self.row_stride = c.row_stride
-        self.scratch_bytes = c.scratch_bytes
+        self.nrows = int(c["nrows"][0])
+        self.ncols = int(c["ncols"][0])
+        self.row_stride = int(c["row_stride"][0])
+        self.scratch_bytes = int(c["scratch_bytes"][0])
 
 
 def _build_descriptor(arr, columns, text_as_blob):
@@ -213,16 +195,16 @@ def _build_descriptor(arr, columns, text_as_blob):
     cols_sql = ", ".join('"%s" %s' % (n.replace('"', '""'), _SQL_TYPE[t]) for n, t in zip(col_names, tags))
     schema = ("CREATE TABLE x(%s)" % cols_sql).encode("utf-8") + b"\x00"
 
-    c = _NdarrayTableDescriptor()
-    c.nrows = int(arr.shape[0])
-    c.ncols = len(col_names)
-    c.row_stride = int(arr.strides[0])
-    c.data_base = arr.ctypes.data
-    c.col_offsets = offsets_buf.ctypes.data
-    c.col_tags = tags_buf.ctypes.data
-    c.col_widths = widths_buf.ctypes.data
-    c.schema_ptr = ctypes.cast(ctypes.c_char_p(schema), ctypes.c_void_p).value
-    c.scratch_bytes = int(scratch)
+    c = np.zeros(1, _DESC_DTYPE)
+    c["nrows"] = int(arr.shape[0])
+    c["ncols"] = len(col_names)
+    c["row_stride"] = int(arr.strides[0])
+    c["data_base"] = arr.ctypes.data
+    c["col_offsets"] = offsets_buf.ctypes.data
+    c["col_tags"] = tags_buf.ctypes.data
+    c["col_widths"] = widths_buf.ctypes.data
+    c["schema_ptr"] = ctypes.cast(ctypes.c_char_p(schema), ctypes.c_void_p).value
+    c["scratch_bytes"] = int(scratch)
     return _BuiltDescriptor(c, offsets_buf, tags_buf, widths_buf, schema, arr)
 
 
@@ -230,8 +212,8 @@ def _build_descriptor(arr, columns, text_as_blob):
 def _xconnect(db, p_aux, argc, argv, pp_vtab, pz_err):
     vtab = 0
     try:
-        schema_p = load_at(p_aux + _D_SCHEMA, int64)
-        rc = sqlite3_declare_vtab(db, schema_p)
+        d = carray(_cast_int_to_void_p(p_aux), (1,), dtype=_DESC_DTYPE)
+        rc = sqlite3_declare_vtab(db, d[0].schema_ptr)
         if rc != SQLITE_OK:
             return rc
         vtab = sqlite3_malloc(int32(_VTAB_SIZE))
@@ -268,7 +250,8 @@ def _xopen(vtab, pp_cursor):
     cur = 0
     try:
         desc = load_at(vtab + _VTAB_DESC, int64)
-        scratch = load_at(desc + _D_SCRATCH, int64)
+        d = carray(_cast_int_to_void_p(desc), (1,), dtype=_DESC_DTYPE)
+        scratch = d[0].scratch_bytes
         cur = sqlite3_malloc(int32(_CUR_SCRATCH + scratch))  # _build_descriptor caps scratch: int32 cast cannot overflow
         if cur == 0:
             return SQLITE_NOMEM
@@ -308,8 +291,8 @@ def _xnext(cur):
 def _xeof(cur):
     desc = load_at(cur + _CUR_DESC, int64)
     rowid = load_at(cur + _CUR_ROWID, int64)
-    nrows = load_at(desc + _D_NROWS, int64)
-    if rowid >= nrows:
+    d = carray(_cast_int_to_void_p(desc), (1,), dtype=_DESC_DTYPE)
+    if rowid >= d[0].nrows:
         return 1
     return 0
 
@@ -325,12 +308,13 @@ def _xcolumn(cur, ctx, j):
     try:
         desc = load_at(cur + _CUR_DESC, int64)
         rowid = load_at(cur + _CUR_ROWID, int64)
-        ncols = load_at(desc + _D_NCOLS, int32)
-        base = load_at(desc + _D_DATA_BASE, int64)
-        row_stride = load_at(desc + _D_ROW_STRIDE, int64)
-        offsets = carray(_cast_int_to_void_p(load_at(desc + _D_COL_OFFSETS, int64)), (ncols,), dtype=np.int64)
-        tags = carray(_cast_int_to_void_p(load_at(desc + _D_COL_TAGS, int64)), (ncols,), dtype=np.int32)
-        widths = carray(_cast_int_to_void_p(load_at(desc + _D_COL_WIDTHS, int64)), (ncols,), dtype=np.int64)
+        d = carray(_cast_int_to_void_p(desc), (1,), dtype=_DESC_DTYPE)
+        ncols = d[0].ncols
+        base = d[0].data_base
+        row_stride = d[0].row_stride
+        offsets = carray(_cast_int_to_void_p(d[0].col_offsets), (ncols,), dtype=np.int64)
+        tags = carray(_cast_int_to_void_p(d[0].col_tags), (ncols,), dtype=np.int32)
+        widths = carray(_cast_int_to_void_p(d[0].col_widths), (ncols,), dtype=np.int64)
         addr = base + rowid * row_stride + offsets[j]
         tag = tags[j]
         if tag == _TAG_I8:
@@ -454,7 +438,7 @@ def register_table(db, name, arr, columns=None, *, text_as_blob=False):
     """
     built = _build_descriptor(arr, columns, text_as_blob)
     with c_string(name) as name_p:
-        rc = sqlite3_create_module(db, name_p, _THE_MODULE_P, ctypes.addressof(built.c))
+        rc = sqlite3_create_module(db, name_p, _THE_MODULE_P, built.c.ctypes.data)
     if rc != SQLITE_OK:
         _raise_rc(db, name, rc)
     return _VTableHandle(built)

--- a/numbox/core/bindings/_sqlite_vtable.py
+++ b/numbox/core/bindings/_sqlite_vtable.py
@@ -432,10 +432,29 @@ def register_table(db, name, arr, columns=None, *, text_as_blob=False):
     Registering a second table under an existing name follows SQLite's
     eponymous-module semantics: the later registration replaces the earlier one
     (it does not raise). Column names may be any string (they are quoted in the
-    generated schema). ``text_as_blob`` affects only bytes (``'S'``) columns;
-    unicode (``'U'``) is always TEXT. numpy has no missing value, so no cell is
-    SQL NULL (a float NaN passes through as a REAL NaN). uint64 values >= 2**63
-    are stored as SQLite's signed INTEGER and therefore wrap to negative.
+    generated schema).
+
+    Value semantics:
+
+    - ``uint64`` values >= 2**63 are stored as SQLite's signed INTEGER and
+      therefore wrap to negative.
+    - Floats pass through as REAL, including +/-inf -- EXCEPT NaN: SQLite coerces
+      a NaN ``REAL`` to SQL NULL (via ``sqlite3IsNaN``), so a NaN cell reads back
+      as NULL, not as a REAL NaN. There is no other source of SQL NULL (numpy has
+      no missing value), so every non-NaN cell is non-NULL.
+
+    String columns:
+
+    - ``text_as_blob`` affects only bytes (``'S'``) columns; unicode (``'U'``) is
+      always TEXT. By default ``'S'`` becomes TEXT and its raw bytes pass through
+      unvalidated -- pass ``text_as_blob=True`` for non-UTF-8 bytes so they are
+      stored as BLOB rather than malformed TEXT.
+    - Fixed-width ``'S'``/``'U'`` columns are NUL-padded by numpy; trailing NUL
+      padding is trimmed on read while interior NULs are preserved.
+    - A TEXT value with an interior NUL is stored faithfully (an explicit byte
+      length is passed), but C-string readers and most SQL text functions
+      truncate at the first NUL; read it via ``sqlite3_column_bytes`` + the
+      text/blob pointer, or use ``text_as_blob=True`` for full fidelity.
     """
     built = _build_descriptor(arr, columns, text_as_blob)
     with c_string(name) as name_p:

--- a/numbox/core/bindings/_sqlite_vtable.py
+++ b/numbox/core/bindings/_sqlite_vtable.py
@@ -50,7 +50,8 @@ _D_COL_OFFSETS, _D_COL_TAGS, _D_COL_WIDTHS, _D_SCHEMA, _D_SCRATCH = 32, 40, 48, 
 _VTAB_DESC, _VTAB_SIZE = 24, 32
 # cursor layout: pVtab(+0), descriptor(+8), rowid(+16), scratch(+24)
 _CUR_PVTAB, _CUR_DESC, _CUR_ROWID, _CUR_SCRATCH = 0, 8, 16, 24
-assert _VTAB_DESC + 8 == _VTAB_SIZE and _CUR_SCRATCH == _CUR_ROWID + 8
+assert _VTAB_DESC + 8 == _VTAB_SIZE
+assert _CUR_DESC == _CUR_PVTAB + 8 and _CUR_ROWID == _CUR_DESC + 8 and _CUR_SCRATCH == _CUR_ROWID + 8
 
 
 @proxy(signatures.get("sqlite3_create_module"), jit_options={"cache": True})

--- a/numbox/core/bindings/_sqlite_vtable.py
+++ b/numbox/core/bindings/_sqlite_vtable.py
@@ -1,0 +1,445 @@
+"""Expose a numpy array as a read-only SQLite virtual table (register_table).
+
+A single generic sqlite3_module (built once at import) serves every table; the
+per-table base pointer / strides / dtype tags / schema live in a ctypes
+descriptor passed as pClientData.
+"""
+import ctypes
+
+import numpy as np
+from numba import carray, cfunc, njit, types
+from numba.core.types import (
+    int8, int16, int32, int64, uint8, uint16, uint32, uint64,
+    float32, float64,
+)
+
+from numbox.core.bindings._sqlite_constants import (
+    SQLITE_OK, SQLITE_TRANSIENT, SQLITE_ERROR, SQLITE_NOMEM,
+)
+from numbox.core.bindings._sqlite_conn import sqlite3_errmsg
+from numbox.core.bindings._sqlite_exec import sqlite3_free
+from numbox.core.bindings._sqlite_result import (
+    sqlite3_result_int64, sqlite3_result_double,
+    sqlite3_result_text, sqlite3_result_blob, sqlite3_result_error,
+)
+from numbox.core.bindings.call import _call_lib_func
+from numbox.core.bindings.signatures import signatures
+from numbox.core.bindings.utils import load_lib
+from numbox.core.configurations import jit_options
+from numbox.core.proxy.proxy import proxy
+from numbox.utils.cstrings import c_string
+from numbox.utils.lowlevel import (
+    _cast_int_to_void_p, get_unicode_data_p, load_at, load_unaligned, store_at,
+)
+
+__all__ = ["register_table"]
+
+load_lib("sqlite3")
+
+# dtype tags (col_tags[j])
+_TAG_I8, _TAG_I16, _TAG_I32, _TAG_I64 = 0, 1, 2, 3
+_TAG_U8, _TAG_U16, _TAG_U32, _TAG_U64 = 4, 5, 6, 7
+_TAG_F32, _TAG_F64, _TAG_BOOL = 8, 9, 10
+_TAG_S, _TAG_U, _TAG_BLOB = 11, 12, 13
+
+# descriptor field byte offsets (mirror of _NdarrayTableDescriptor)
+_D_NROWS, _D_NCOLS, _D_ROW_STRIDE, _D_DATA_BASE = 0, 8, 16, 24
+_D_COL_OFFSETS, _D_COL_TAGS, _D_COL_WIDTHS, _D_SCHEMA, _D_SCRATCH = 32, 40, 48, 56, 64
+
+# vtab layout: base sqlite3_vtab is 24 bytes; the descriptor_ptr is appended at +24
+_VTAB_DESC, _VTAB_SIZE = 24, 32
+# cursor layout: pVtab(+0), descriptor(+8), rowid(+16), scratch(+24)
+_CUR_PVTAB, _CUR_DESC, _CUR_ROWID, _CUR_SCRATCH = 0, 8, 16, 24
+assert _VTAB_DESC + 8 == _VTAB_SIZE and _CUR_SCRATCH == _CUR_ROWID + 8
+
+
+@proxy(signatures.get("sqlite3_create_module"), jit_options={"cache": True})
+def sqlite3_create_module(db, z_name, p_module, p_client_data):
+    return _call_lib_func("sqlite3_create_module", (db, z_name, p_module, p_client_data))
+
+
+@proxy(signatures.get("sqlite3_declare_vtab"), jit_options={"cache": True})
+def sqlite3_declare_vtab(db, z_sql):
+    return _call_lib_func("sqlite3_declare_vtab", (db, z_sql))
+
+
+@proxy(signatures.get("sqlite3_malloc"), jit_options={"cache": True})
+def sqlite3_malloc(n):
+    return _call_lib_func("sqlite3_malloc", (n,))
+
+
+@njit(**jit_options)
+def _nul_trimmed_len(p, width):
+    buf = carray(_cast_int_to_void_p(p), (width,), dtype=np.uint8)
+    n = width
+    while n > 0 and buf[n - 1] == 0:
+        n -= 1
+    return n
+
+
+@njit(**jit_options)
+def utf32_to_utf8(src, n_codepoints, dst):
+    """``dst`` must hold at least ``4 * n_codepoints + 1`` bytes."""
+    m = n_codepoints
+    while m > 0 and load_unaligned(src + 4 * (m - 1), uint32) == 0:
+        m -= 1
+    out = carray(_cast_int_to_void_p(dst), (4 * n_codepoints + 1,), dtype=np.uint8)
+    k = 0
+    for i in range(m):
+        cp = load_unaligned(src + 4 * i, uint32)
+        if cp > 0x10FFFF or (0xD800 <= cp <= 0xDFFF):
+            cp = 0xFFFD
+        if cp < 0x80:
+            out[k] = uint8(cp)
+            k += 1
+        elif cp < 0x800:
+            out[k] = uint8(0xC0 | (cp >> 6))
+            out[k + 1] = uint8(0x80 | (cp & 0x3F))
+            k += 2
+        elif cp < 0x10000:
+            out[k] = uint8(0xE0 | (cp >> 12))
+            out[k + 1] = uint8(0x80 | ((cp >> 6) & 0x3F))
+            out[k + 2] = uint8(0x80 | (cp & 0x3F))
+            k += 3
+        else:
+            out[k] = uint8(0xF0 | (cp >> 18))
+            out[k + 1] = uint8(0x80 | ((cp >> 12) & 0x3F))
+            out[k + 2] = uint8(0x80 | ((cp >> 6) & 0x3F))
+            out[k + 3] = uint8(0x80 | (cp & 0x3F))
+            k += 4
+    return k
+
+
+class _NdarrayTableDescriptor(ctypes.Structure):
+    _fields_ = [
+        ("nrows", ctypes.c_int64),
+        ("ncols", ctypes.c_int32),
+        ("_pad", ctypes.c_int32),
+        ("row_stride", ctypes.c_int64),
+        ("data_base", ctypes.c_int64),
+        ("col_offsets", ctypes.c_int64),
+        ("col_tags", ctypes.c_int64),
+        ("col_widths", ctypes.c_int64),
+        ("schema_ptr", ctypes.c_int64),
+        ("scratch_bytes", ctypes.c_int64),
+    ]
+
+
+def _assert_descriptor_layout():
+    f = _NdarrayTableDescriptor
+    assert ctypes.sizeof(f) == 72
+    assert (f.nrows.offset, f.ncols.offset, f.row_stride.offset, f.data_base.offset) == \
+        (_D_NROWS, _D_NCOLS, _D_ROW_STRIDE, _D_DATA_BASE)
+    assert (f.col_offsets.offset, f.col_tags.offset, f.col_widths.offset) == \
+        (_D_COL_OFFSETS, _D_COL_TAGS, _D_COL_WIDTHS)
+    assert (f.schema_ptr.offset, f.scratch_bytes.offset) == (_D_SCHEMA, _D_SCRATCH)
+
+
+_assert_descriptor_layout()
+
+_NUMERIC_TAGS = {
+    np.dtype("int8"): _TAG_I8, np.dtype("int16"): _TAG_I16,
+    np.dtype("int32"): _TAG_I32, np.dtype("int64"): _TAG_I64,
+    np.dtype("uint8"): _TAG_U8, np.dtype("uint16"): _TAG_U16,
+    np.dtype("uint32"): _TAG_U32, np.dtype("uint64"): _TAG_U64,
+    np.dtype("float32"): _TAG_F32, np.dtype("float64"): _TAG_F64,
+    np.dtype("bool"): _TAG_BOOL,
+}
+_SQL_TYPE = {
+    _TAG_I8: "INTEGER", _TAG_I16: "INTEGER", _TAG_I32: "INTEGER", _TAG_I64: "INTEGER",
+    _TAG_U8: "INTEGER", _TAG_U16: "INTEGER", _TAG_U32: "INTEGER", _TAG_U64: "INTEGER",
+    _TAG_BOOL: "INTEGER", _TAG_F32: "REAL", _TAG_F64: "REAL",
+    _TAG_S: "TEXT", _TAG_U: "TEXT", _TAG_BLOB: "BLOB",
+}
+
+
+def _col_tag(dt, text_as_blob):
+    if dt.kind == "S":
+        return _TAG_BLOB if text_as_blob else _TAG_S
+    if dt.kind == "U":
+        return _TAG_U
+    if dt in _NUMERIC_TAGS:
+        return _NUMERIC_TAGS[dt]
+    raise TypeError("unsupported column dtype %r" % (dt,))
+
+
+class _BuiltDescriptor:
+    """The ctypes descriptor plus every buffer whose pointer it holds."""
+    __slots__ = ("c", "offsets", "tags", "widths", "schema",
+                 "nrows", "ncols", "row_stride", "scratch_bytes", "arr")
+
+    def __init__(self, c, offsets, tags, widths, schema, arr):
+        self.c = c
+        self.offsets = offsets
+        self.tags = tags
+        self.widths = widths
+        self.schema = schema
+        self.arr = arr
+        self.nrows = c.nrows
+        self.ncols = c.ncols
+        self.row_stride = c.row_stride
+        self.scratch_bytes = c.scratch_bytes
+
+
+def _build_descriptor(arr, columns, text_as_blob):
+    if not isinstance(arr, np.ndarray):
+        raise TypeError("arr must be a numpy.ndarray, got %r" % (type(arr),))
+    fields = arr.dtype.fields
+    if fields is not None:
+        if arr.ndim != 1:
+            raise ValueError("structured array must be 1-D, got ndim=%d" % arr.ndim)
+        names = list(arr.dtype.names)
+        sub = [arr.dtype.fields[n][0] for n in names]
+        offs = [arr.dtype.fields[n][1] for n in names]
+        col_names = list(columns) if columns is not None else names
+        if len(col_names) != len(names):
+            raise ValueError("columns length %d != field count %d" % (len(col_names), len(names)))
+    else:
+        if arr.ndim != 2:
+            raise ValueError("plain array must be 2-D, got ndim=%d" % arr.ndim)
+        if columns is None or len(columns) != arr.shape[1]:
+            raise ValueError("columns must list all %d column names for a 2-D array" % arr.shape[1])
+        col_names = list(columns)
+        sub = [arr.dtype] * arr.shape[1]
+        offs = [j * arr.strides[1] for j in range(arr.shape[1])]
+
+    if not col_names:
+        raise ValueError("array must have at least one column")
+    tags = [_col_tag(dt, text_as_blob) for dt in sub]
+    widths = [int(dt.itemsize) for dt in sub]
+    scratch = max([w + 1 for w, t in zip(widths, tags) if t == _TAG_U], default=0)
+    if _CUR_SCRATCH + scratch > 2 ** 31 - 1:
+        raise ValueError("unicode column too wide: per-cursor scratch buffer would overflow int32")
+
+    offsets_buf = np.array(offs, dtype=np.int64)
+    tags_buf = np.array(tags, dtype=np.int32)  # the xColumn cfunc reads int32 elements; do not widen
+    widths_buf = np.array(widths, dtype=np.int64)
+    cols_sql = ", ".join('"%s" %s' % (n.replace('"', '""'), _SQL_TYPE[t]) for n, t in zip(col_names, tags))
+    schema = ("CREATE TABLE x(%s)" % cols_sql).encode("utf-8") + b"\x00"
+
+    c = _NdarrayTableDescriptor()
+    c.nrows = int(arr.shape[0])
+    c.ncols = len(col_names)
+    c.row_stride = int(arr.strides[0])
+    c.data_base = arr.ctypes.data
+    c.col_offsets = offsets_buf.ctypes.data
+    c.col_tags = tags_buf.ctypes.data
+    c.col_widths = widths_buf.ctypes.data
+    c.schema_ptr = ctypes.cast(ctypes.c_char_p(schema), ctypes.c_void_p).value
+    c.scratch_bytes = int(scratch)
+    return _BuiltDescriptor(c, offsets_buf, tags_buf, widths_buf, schema, arr)
+
+
+@cfunc(types.int32(types.intp, types.intp, types.int32, types.intp, types.intp, types.intp), cache=True)
+def _xconnect(db, p_aux, argc, argv, pp_vtab, pz_err):
+    vtab = 0
+    try:
+        schema_p = load_at(p_aux + _D_SCHEMA, int64)
+        rc = sqlite3_declare_vtab(db, schema_p)
+        if rc != SQLITE_OK:
+            return rc
+        vtab = sqlite3_malloc(int32(_VTAB_SIZE))
+        if vtab == 0:
+            return SQLITE_NOMEM
+        store_at(vtab + 0, int64(0))
+        store_at(vtab + 8, int64(0))
+        store_at(vtab + 16, int64(0))
+        store_at(vtab + _VTAB_DESC, int64(p_aux))
+        slot = carray(_cast_int_to_void_p(pp_vtab), (1,), dtype=np.intp)
+        slot[0] = vtab
+        return SQLITE_OK
+    except Exception:
+        sqlite3_free(vtab)
+        return SQLITE_ERROR
+
+
+@cfunc(types.int32(types.intp, types.intp), cache=True)
+def _xbestindex(vtab, idx_info):
+    return SQLITE_OK
+
+
+@cfunc(types.int32(types.intp), cache=True)
+def _xdisconnect(vtab):
+    try:
+        sqlite3_free(vtab)
+        return SQLITE_OK
+    except Exception:
+        return SQLITE_ERROR
+
+
+@cfunc(types.int32(types.intp, types.intp), cache=True)
+def _xopen(vtab, pp_cursor):
+    cur = 0
+    try:
+        desc = load_at(vtab + _VTAB_DESC, int64)
+        scratch = load_at(desc + _D_SCRATCH, int64)
+        cur = sqlite3_malloc(int32(_CUR_SCRATCH + scratch))  # _build_descriptor caps scratch: int32 cast cannot overflow
+        if cur == 0:
+            return SQLITE_NOMEM
+        store_at(cur + _CUR_PVTAB, int64(vtab))
+        store_at(cur + _CUR_DESC, int64(desc))
+        store_at(cur + _CUR_ROWID, int64(0))
+        slot = carray(_cast_int_to_void_p(pp_cursor), (1,), dtype=np.intp)
+        slot[0] = cur
+        return SQLITE_OK
+    except Exception:
+        sqlite3_free(cur)
+        return SQLITE_ERROR
+
+
+@cfunc(types.int32(types.intp), cache=True)
+def _xclose(cur):
+    try:
+        sqlite3_free(cur)
+        return SQLITE_OK
+    except Exception:
+        return SQLITE_ERROR
+
+
+@cfunc(types.int32(types.intp, types.int32, types.intp, types.int32, types.intp), cache=True)
+def _xfilter(cur, idx_num, idx_str, argc, argv):
+    store_at(cur + _CUR_ROWID, int64(0))
+    return SQLITE_OK
+
+
+@cfunc(types.int32(types.intp), cache=True)
+def _xnext(cur):
+    store_at(cur + _CUR_ROWID, load_at(cur + _CUR_ROWID, int64) + 1)
+    return SQLITE_OK
+
+
+@cfunc(types.int32(types.intp), cache=True)
+def _xeof(cur):
+    desc = load_at(cur + _CUR_DESC, int64)
+    rowid = load_at(cur + _CUR_ROWID, int64)
+    nrows = load_at(desc + _D_NROWS, int64)
+    if rowid >= nrows:
+        return 1
+    return 0
+
+
+@cfunc(types.int32(types.intp, types.intp), cache=True)
+def _xrowid(cur, p_rowid):
+    store_at(p_rowid, load_at(cur + _CUR_ROWID, int64))
+    return SQLITE_OK
+
+
+@cfunc(types.int32(types.intp, types.intp, types.int32), cache=True)
+def _xcolumn(cur, ctx, j):
+    try:
+        desc = load_at(cur + _CUR_DESC, int64)
+        rowid = load_at(cur + _CUR_ROWID, int64)
+        ncols = load_at(desc + _D_NCOLS, int32)
+        base = load_at(desc + _D_DATA_BASE, int64)
+        row_stride = load_at(desc + _D_ROW_STRIDE, int64)
+        offsets = carray(_cast_int_to_void_p(load_at(desc + _D_COL_OFFSETS, int64)), (ncols,), dtype=np.int64)
+        tags = carray(_cast_int_to_void_p(load_at(desc + _D_COL_TAGS, int64)), (ncols,), dtype=np.int32)
+        widths = carray(_cast_int_to_void_p(load_at(desc + _D_COL_WIDTHS, int64)), (ncols,), dtype=np.int64)
+        addr = base + rowid * row_stride + offsets[j]
+        tag = tags[j]
+        if tag == _TAG_I8:
+            sqlite3_result_int64(ctx, int64(load_unaligned(addr, int8)))
+        elif tag == _TAG_I16:
+            sqlite3_result_int64(ctx, int64(load_unaligned(addr, int16)))
+        elif tag == _TAG_I32:
+            sqlite3_result_int64(ctx, int64(load_unaligned(addr, int32)))
+        elif tag == _TAG_I64:
+            sqlite3_result_int64(ctx, load_unaligned(addr, int64))
+        elif tag == _TAG_U8:
+            sqlite3_result_int64(ctx, int64(load_unaligned(addr, uint8)))
+        elif tag == _TAG_U16:
+            sqlite3_result_int64(ctx, int64(load_unaligned(addr, uint16)))
+        elif tag == _TAG_U32:
+            sqlite3_result_int64(ctx, int64(load_unaligned(addr, uint32)))
+        elif tag == _TAG_U64:
+            sqlite3_result_int64(ctx, int64(load_unaligned(addr, uint64)))
+        elif tag == _TAG_BOOL:
+            sqlite3_result_int64(ctx, int64(1) if load_unaligned(addr, uint8) != 0 else int64(0))
+        elif tag == _TAG_F32:
+            sqlite3_result_double(ctx, float64(load_unaligned(addr, float32)))
+        elif tag == _TAG_F64:
+            sqlite3_result_double(ctx, load_unaligned(addr, float64))
+        elif tag == _TAG_S:
+            n = _nul_trimmed_len(addr, widths[j])
+            sqlite3_result_text(ctx, addr, int32(n), SQLITE_TRANSIENT)
+        elif tag == _TAG_BLOB:
+            n = _nul_trimmed_len(addr, widths[j])
+            sqlite3_result_blob(ctx, addr, int32(n), SQLITE_TRANSIENT)
+        elif tag == _TAG_U:
+            scratch = cur + _CUR_SCRATCH
+            n = utf32_to_utf8(addr, widths[j] // 4, scratch)
+            sqlite3_result_text(ctx, scratch, int32(n), SQLITE_TRANSIENT)
+        return SQLITE_OK
+    except Exception:
+        sqlite3_result_error(ctx, get_unicode_data_p("error reading vtable column"), -1)
+        return SQLITE_ERROR
+
+
+class _Sqlite3Module(ctypes.Structure):
+    _fields_ = [(n, ctypes.c_void_p) for n in (
+        "xCreate", "xConnect", "xBestIndex", "xDisconnect", "xDestroy",
+        "xOpen", "xClose", "xFilter", "xNext", "xEof", "xColumn", "xRowid",
+        "xUpdate", "xBegin", "xSync", "xCommit", "xRollback",
+        "xFindFunction", "xRename")]
+    # reassigned to prepend iVersion; ctypes reads only the final value
+    _fields_ = [("iVersion", ctypes.c_int)] + _fields_
+
+
+THE_MODULE = _Sqlite3Module()
+THE_MODULE.iVersion = 1
+THE_MODULE.xCreate = _xconnect.address
+THE_MODULE.xConnect = _xconnect.address
+THE_MODULE.xBestIndex = _xbestindex.address
+THE_MODULE.xDisconnect = _xdisconnect.address
+THE_MODULE.xDestroy = _xdisconnect.address
+THE_MODULE.xOpen = _xopen.address
+THE_MODULE.xClose = _xclose.address
+THE_MODULE.xFilter = _xfilter.address
+THE_MODULE.xNext = _xnext.address
+THE_MODULE.xEof = _xeof.address
+THE_MODULE.xColumn = _xcolumn.address
+THE_MODULE.xRowid = _xrowid.address
+_THE_MODULE_P = ctypes.addressof(THE_MODULE)
+_CFUNCS = (_xconnect, _xbestindex, _xdisconnect, _xopen, _xclose,
+           _xfilter, _xnext, _xeof, _xcolumn, _xrowid)
+
+
+class _VTableHandle:
+    """Keeps the array + descriptor + buffers alive. SQLite reads the array
+    buffer directly; if this handle is GC'd the data frees and the next query
+    reads freed memory. The caller MUST retain it."""
+    __slots__ = ("_keep",)
+
+    def __init__(self, *objs):
+        self._keep = objs
+
+
+def _raise_rc(db, name, rc):
+    msg_p = sqlite3_errmsg(db)
+    detail = ""
+    if msg_p:
+        detail = ": " + ctypes.cast(msg_p, ctypes.c_char_p).value.decode("utf-8", "replace")
+    raise RuntimeError("register_table failed for %r (rc=%d)%s" % (name, rc, detail))
+
+
+def register_table(db, name, arr, columns=None, *, text_as_blob=False):
+    """Expose a numpy array as a read-only eponymous SQLite virtual table.
+
+    The caller MUST retain the returned handle for as long as the table is used,
+    and must not mutate or resize the array while the table is registered -- the
+    view is zero-copy, so queries read the array's buffer directly.
+
+    Registering a second table under an existing name follows SQLite's
+    eponymous-module semantics: the later registration replaces the earlier one
+    (it does not raise). Column names may be any string (they are quoted in the
+    generated schema). ``text_as_blob`` affects only bytes (``'S'``) columns;
+    unicode (``'U'``) is always TEXT. numpy has no missing value, so no cell is
+    SQL NULL (a float NaN passes through as a REAL NaN). uint64 values >= 2**63
+    are stored as SQLite's signed INTEGER and therefore wrap to negative.
+    """
+    built = _build_descriptor(arr, columns, text_as_blob)
+    with c_string(name) as name_p:
+        rc = sqlite3_create_module(db, name_p, _THE_MODULE_P, ctypes.addressof(built.c))
+    if rc != SQLITE_OK:
+        _raise_rc(db, name, rc)
+    return _VTableHandle(built)

--- a/numbox/core/bindings/_sqlite_vtable.py
+++ b/numbox/core/bindings/_sqlite_vtable.py
@@ -2,10 +2,14 @@
 
 A single generic sqlite3_module (built once at import) serves every table; the
 per-table base pointer / strides / dtype tags / schema live in a numpy
-structured-array descriptor whose data pointer is passed as pClientData. The
-sqlite3_vtab and sqlite3_vtab_cursor SQLite allocates through us are likewise
-numpy structured dtypes, with their SQLite-owned base nested as field 'base'.
-See https://www.sqlite.org/vtab.html.
+structured-array descriptor whose data pointer is passed as pClientData.
+
+The sqlite3_vtab and sqlite3_vtab_cursor that our xCreate/xOpen callbacks
+allocate are C structs whose first member is the SQLite-owned base; we append
+our own members after it. Each is modelled as a numpy structured dtype with that
+base nested as field 'base', so the cfuncs address members by name rather than
+raw offsets (align=True reproduces the C padding, e.g. the int nRef in
+sqlite3_vtab). See https://www.sqlite.org/vtab.html.
 """
 import ctypes
 
@@ -19,9 +23,8 @@ from numba.core.types import (
 from numbox.core.bindings._sqlite_constants import (
     SQLITE_OK, SQLITE_TRANSIENT, SQLITE_ERROR, SQLITE_NOMEM,
 )
-from numbox.core.bindings._sqlite_conn import sqlite3_errmsg
-from numbox.core.bindings._sqlite_exec import sqlite3_free, sqlite3_malloc
-from numbox.core.bindings._sqlite_result import (
+from numbox.core.bindings import (
+    sqlite3_errmsg, sqlite3_free, sqlite3_malloc,
     sqlite3_result_int64, sqlite3_result_double,
     sqlite3_result_text, sqlite3_result_blob, sqlite3_result_error,
 )
@@ -47,22 +50,15 @@ _TAG_S, _TAG_U, _TAG_BLOB = 11, 12, 13
 
 # per-table descriptor passed as pClientData; the cfuncs read it field-by-name
 # via carray(ptr, (1,), dtype=_DESC_DTYPE). The dtype is the single source of
-# truth for the layout (numpy owns the offsets). ('_pad', 'i4') holds the
-# alignment slot after the i4 ncols and is load-bearing -- do not drop it or
-# pass align=True (either would silently shift every field offset).
+# truth for the layout (numpy owns the offsets); align=True inserts the natural
+# padding after the i4 ncols so every i8 field stays 8-aligned.
 _DESC_DTYPE = np.dtype([
-    ("nrows", "i8"), ("ncols", "i4"), ("_pad", "i4"),
+    ("nrows", "i8"), ("ncols", "i4"),
     ("row_stride", "i8"), ("data_base", "i8"),
     ("col_offsets", "i8"), ("col_tags", "i8"), ("col_widths", "i8"),
     ("schema_ptr", "i8"), ("scratch_bytes", "i8"),
-])
+], align=True)
 assert _DESC_DTYPE.itemsize == 72
-
-# The vtab and cursor SQLite allocates through us are C structs whose first
-# member is the SQLite-owned base (sqlite3_vtab / sqlite3_vtab_cursor); we append
-# our own members after it. Each is a numpy structured dtype with the base nested
-# as field 'base', so the cfuncs address members by name instead of raw offsets
-# (align=True reproduces the C padding, e.g. the int nRef in sqlite3_vtab).
 
 # struct sqlite3_vtab { const sqlite3_module *pModule; int nRef; char *zErrMsg; }
 # https://www.sqlite.org/c3ref/vtab.html -- SQLite owns/sets these fields.
@@ -73,12 +69,14 @@ _VTAB_SIZE = _VTAB_DTYPE.itemsize
 
 # struct sqlite3_vtab_cursor { sqlite3_vtab *pVtab; }
 # https://www.sqlite.org/c3ref/vtab_cursor.html -- one-member SQLite base. The
-# per-cursor UTF-8 scratch buffer is allocated right after this fixed header,
-# starting at offset _CUR_HEADER.
+# per-cursor UTF-8 scratch buffer is a separate sqlite3_malloc held in scratch_p
+# (allocated in xOpen, freed in xClose), so the cursor itself is a fixed dtype.
 _SQLITE3_VTAB_CURSOR_DTYPE = np.dtype([("pVtab", "i8")])
-_CUR_DTYPE = np.dtype([("base", _SQLITE3_VTAB_CURSOR_DTYPE), ("descriptor", "i8"), ("rowid", "i8")], align=True)
-assert _CUR_DTYPE.itemsize == 24
-_CUR_HEADER = _CUR_DTYPE.itemsize
+_CUR_DTYPE = np.dtype([
+    ("base", _SQLITE3_VTAB_CURSOR_DTYPE), ("descriptor", "i8"), ("rowid", "i8"), ("scratch_p", "i8"),
+], align=True)
+assert _CUR_DTYPE.itemsize == 32
+_CUR_SIZE = _CUR_DTYPE.itemsize
 
 # struct sqlite3_index_info -- https://www.sqlite.org/c3ref/index_info.html
 # Modelled only through estimatedRows: xBestIndex writes the two cardinality
@@ -96,8 +94,6 @@ _IDX_INFO_DTYPE = np.dtype([
 assert _IDX_INFO_DTYPE.fields["estimatedCost"][1] == 64
 assert _IDX_INFO_DTYPE.fields["estimatedRows"][1] == 72
 
-# @cfunc takes a cache bool (not a jit_options dict like @njit/@proxy); thread
-# the package-wide cache setting through it (default True).
 _CACHE = jit_options.get("cache", True)
 
 
@@ -224,8 +220,6 @@ def _build_descriptor(arr, columns, text_as_blob):
     tags = [_col_tag(dt, text_as_blob) for dt in sub]
     widths = [int(dt.itemsize) for dt in sub]
     scratch = max([w + 1 for w, t in zip(widths, tags) if t == _TAG_U], default=0)
-    if _CUR_HEADER + scratch > 2 ** 31 - 1:
-        raise ValueError("unicode column too wide: per-cursor scratch buffer would overflow int32")
 
     offsets_buf = np.array(offs, dtype=np.int64)
     tags_buf = np.array(tags, dtype=np.int32)  # the xColumn cfunc reads int32 elements; do not widen
@@ -298,22 +292,30 @@ def _xdisconnect(vtab):
 @cfunc(types.int32(types.intp, types.intp), cache=_CACHE)
 def _xopen(vtab, pp_cursor):
     cur = 0
+    scratch_p = 0
     try:
         v = carray(_cast_int_to_void_p(vtab), (1,), dtype=_VTAB_DTYPE)
         desc = v[0].descriptor
         d = carray(_cast_int_to_void_p(desc), (1,), dtype=_DESC_DTYPE)
         scratch = d[0].scratch_bytes
-        cur = sqlite3_malloc(int32(_CUR_HEADER + scratch))  # _build_descriptor caps scratch: int32 cast cannot overflow
+        cur = sqlite3_malloc(int32(_CUR_SIZE))
         if cur == 0:
             return SQLITE_NOMEM
+        if scratch > 0:
+            scratch_p = sqlite3_malloc(int32(scratch))  # scratch <= numpy's int32 'U' itemsize cap: cast is safe
+            if scratch_p == 0:
+                sqlite3_free(cur)
+                return SQLITE_NOMEM
         c = carray(_cast_int_to_void_p(cur), (1,), dtype=_CUR_DTYPE)
         c[0].base.pVtab = vtab
         c[0].descriptor = desc
         c[0].rowid = 0
+        c[0].scratch_p = scratch_p
         slot = carray(_cast_int_to_void_p(pp_cursor), (1,), dtype=np.intp)
         slot[0] = cur
         return SQLITE_OK
     except Exception:
+        sqlite3_free(scratch_p)
         sqlite3_free(cur)
         return SQLITE_ERROR
 
@@ -321,6 +323,8 @@ def _xopen(vtab, pp_cursor):
 @cfunc(types.int32(types.intp), cache=_CACHE)
 def _xclose(cur):
     try:
+        c = carray(_cast_int_to_void_p(cur), (1,), dtype=_CUR_DTYPE)
+        sqlite3_free(c[0].scratch_p)
         sqlite3_free(cur)
         return SQLITE_OK
     except Exception:
@@ -400,7 +404,7 @@ def _xcolumn(cur, ctx, j):
             n = _nul_trimmed_len(addr, widths[j])
             sqlite3_result_blob(ctx, addr, int32(n), SQLITE_TRANSIENT)
         elif tag == _TAG_U:
-            scratch = cur + _CUR_HEADER
+            scratch = c[0].scratch_p
             n = utf32_to_utf8(addr, widths[j] // 4, scratch)
             sqlite3_result_text(ctx, scratch, int32(n), SQLITE_TRANSIENT)
         return SQLITE_OK

--- a/numbox/core/bindings/_sqlite_vtable.py
+++ b/numbox/core/bindings/_sqlite_vtable.py
@@ -80,6 +80,22 @@ _CUR_DTYPE = np.dtype([("base", _SQLITE3_VTAB_CURSOR_DTYPE), ("descriptor", "i8"
 assert _CUR_DTYPE.itemsize == 24
 _CUR_HEADER = _CUR_DTYPE.itemsize
 
+# struct sqlite3_index_info -- https://www.sqlite.org/c3ref/index_info.html
+# Modelled only through estimatedRows: xBestIndex writes the two cardinality
+# outputs and leaves everything else at SQLite's zero/default init. Fields after
+# estimatedRows (idxFlags 3.9.0, colUsed 3.10.0) are omitted -- never addressed;
+# estimatedRows needs SQLite 3.8.2+, met by the >=3.34 support floor.
+_IDX_INFO_DTYPE = np.dtype([
+    ("nConstraint", "i4"), ("_pad0", "i4"), ("aConstraint", "i8"),
+    ("nOrderBy", "i4"), ("_pad1", "i4"), ("aOrderBy", "i8"),
+    ("aConstraintUsage", "i8"),
+    ("idxNum", "i4"), ("_pad2", "i4"), ("idxStr", "i8"),
+    ("needToFreeIdxStr", "i4"), ("orderByConsumed", "i4"),
+    ("estimatedCost", "f8"), ("estimatedRows", "i8"),
+])
+assert _IDX_INFO_DTYPE.fields["estimatedCost"][1] == 64
+assert _IDX_INFO_DTYPE.fields["estimatedRows"][1] == 72
+
 # @cfunc takes a cache bool (not a jit_options dict like @njit/@proxy); thread
 # the package-wide cache setting through it (default True).
 _CACHE = jit_options.get("cache", True)
@@ -258,6 +274,15 @@ def _xconnect(db, p_aux, argc, argv, pp_vtab, pz_err):
 
 @cfunc(types.int32(types.intp, types.intp), cache=_CACHE)
 def _xbestindex(vtab, idx_info):
+    # No constraints are usable (read-only full scan), so leave SQLite's zeroed
+    # outputs as-is except the cardinality: feed the real row count so joins and
+    # subqueries over a large table aren't mis-costed (SQLite defaults
+    # estimatedRows to 25 and estimatedCost to a huge value).
+    v = carray(_cast_int_to_void_p(vtab), (1,), dtype=_VTAB_DTYPE)
+    d = carray(_cast_int_to_void_p(v[0].descriptor), (1,), dtype=_DESC_DTYPE)
+    ii = carray(_cast_int_to_void_p(idx_info), (1,), dtype=_IDX_INFO_DTYPE)
+    ii[0].estimatedRows = d[0].nrows
+    ii[0].estimatedCost = float64(d[0].nrows)
     return SQLITE_OK
 
 

--- a/numbox/core/bindings/signatures.py
+++ b/numbox/core/bindings/signatures.py
@@ -208,6 +208,10 @@ signatures_sqlite = {
     "sqlite3_aggregate_context": intp(intp, int32),
     "sqlite3_user_data": intp(intp),
     "sqlite3_context_db_handle": intp(intp),
+    # -- virtual table registration --
+    "sqlite3_create_module": int32(intp, intp, intp, intp),
+    "sqlite3_declare_vtab": int32(intp, intp),
+    "sqlite3_malloc": intp(int32),
 }
 
 signatures = {

--- a/numbox/utils/lowlevel.py
+++ b/numbox/utils/lowlevel.py
@@ -107,6 +107,29 @@ def store_at(p, v):
 
 
 @intrinsic
+def _load_unaligned(typingctx: Context, p_ty, ty_ref: TypeRef):
+    if unliteral(p_ty) not in (intp, uintp):
+        raise TypingError(
+            f"load_unaligned: pointer argument must be intp or uintp, got {p_ty}"
+        )
+    ty = ty_ref.instance_type
+    sig = ty(p_ty, ty_ref)
+
+    def codegen(context: BaseContext, builder, signature, args):
+        ty_ll = context.get_data_type(ty)
+        ptr = builder.inttoptr(args[0], ty_ll.as_pointer())
+        return builder.load(ptr, align=1)
+    return sig, codegen
+
+
+@njit(**jit_options)
+def load_unaligned(p, ty):
+    """Like :func:`load_at` but emits an ``align=1`` load, legal on a misaligned
+    address (e.g. a packed structured-dtype field) where ``load_at`` is UB."""
+    return _load_unaligned(p, ty)
+
+
+@intrinsic
 def _deref_payload(typingctx: Context, struct_ty, ty_ref: TypeRef):
     ty = ty_ref.instance_type
     sig = ty(struct_ty, ty_ref)

--- a/test/core/test_load_unaligned.py
+++ b/test/core/test_load_unaligned.py
@@ -1,0 +1,37 @@
+import numpy as np
+from numba import njit
+from numba.core.types import int32, int64, float64
+from numbox.utils.lowlevel import load_unaligned, array_data_p
+
+
+def test_load_unaligned_reads_misaligned_int64():
+    # int64 stored at byte offset 1 of a byte buffer (deliberately misaligned).
+    buf = np.zeros(16, dtype=np.uint8)
+    buf[1:9] = np.frombuffer(np.int64(0x0123456789ABCDEF).tobytes(), dtype=np.uint8)
+
+    @njit
+    def read(base):
+        return load_unaligned(base + 1, int64)
+
+    assert read(array_data_p(buf)) == 0x0123456789ABCDEF
+
+
+def test_load_unaligned_matches_load_at_aligned():
+    a = np.array([7, -3, 11], dtype=np.int32)
+
+    @njit
+    def read(base, i):
+        return load_unaligned(base + 4 * i, int32)
+
+    base = array_data_p(a)
+    assert [read(base, i) for i in range(3)] == [7, -3, 11]
+
+
+def test_load_unaligned_float64():
+    x = np.array([3.5], dtype=np.float64)
+
+    @njit
+    def read(base):
+        return load_unaligned(base, float64)
+
+    assert read(array_data_p(x)) == 3.5

--- a/test/core/test_sqlite_vtable.py
+++ b/test/core/test_sqlite_vtable.py
@@ -96,7 +96,6 @@ def test_descriptor_structured_mixed():
 
 
 def test_descriptor_rejects_bad_shapes():
-    import pytest
     with pytest.raises((TypeError, ValueError)):
         _build_descriptor(np.zeros((2, 2, 2), dtype=np.int64), ["a", "b"], False)
     with pytest.raises((TypeError, ValueError)):

--- a/test/core/test_sqlite_vtable.py
+++ b/test/core/test_sqlite_vtable.py
@@ -212,6 +212,20 @@ def test_bool_dtype():
     sqlite3_close(db)
 
 
+@pytest.mark.parametrize("dt", [np.float64, np.float32])
+def test_float_nan_becomes_null_inf_passes_through(dt):
+    db = _open_memory()
+    a = np.array([[np.nan], [np.inf], [-np.inf], [1.5]], dtype=dt)
+    h = register_table(db, "t", a, columns=["x"])  # noqa: F841
+    rows = _fetchall(db, "SELECT x FROM t")
+    assert rows[0] == (None,)  # SQLite coerces a NaN REAL to SQL NULL
+    assert rows[1] == (float("inf"),)
+    assert rows[2] == (float("-inf"),)
+    assert rows[3] == (1.5,)
+    assert _fetchall(db, "SELECT COUNT(*) FROM t WHERE x IS NULL") == [(1,)]
+    sqlite3_close(db)
+
+
 def test_structured_text_and_unicode():
     db = _open_memory()
     dt = np.dtype([("t", "U6"), ("q", "i4"), ("p", "f8"), ("s", "S4")])
@@ -301,6 +315,18 @@ def test_join_two_tables():
     h2 = register_table(db, "rhs", b, columns=["id", "w"])  # noqa: F841
     got = _fetchall(db, "SELECT lhs.v, rhs.w FROM lhs JOIN rhs ON lhs.id = rhs.id ORDER BY lhs.id")
     assert got == [(100, 7), (200, 9)]
+    sqlite3_close(db)
+
+
+def test_self_join_unicode_two_cursors():
+    db = _open_memory()
+    dt = np.dtype([("k", "i8"), ("u", "U4")])
+    a = np.array([(1, "wörd"), (2, "café"), (3, "ab")], dtype=dt)
+    h = register_table(db, "t", a)  # noqa: F841
+    # a self-join keeps two cursors open on the same vtable at once, so each
+    # decodes its 'U' column into its own per-cursor scratch buffer
+    got = _fetchall(db, "SELECT a.u, b.u FROM t a JOIN t b ON a.k = b.k ORDER BY a.k")
+    assert got == [("wörd", "wörd"), ("café", "café"), ("ab", "ab")]
     sqlite3_close(db)
 
 

--- a/test/core/test_sqlite_vtable.py
+++ b/test/core/test_sqlite_vtable.py
@@ -108,7 +108,7 @@ def test_descriptor_rejects_bad_shapes():
 
 
 def test_unicode_width_overflow_rejected():
-    # itemsize 4*536870906 = 2147483624; + 1 (scratch) + 24 (_CUR_SCRATCH) overflows int32
+    # itemsize 4*536870906 = 2147483624; + 1 (scratch) + 24 (_CUR_HEADER) overflows int32
     dt = np.dtype([("u", "U536870906")])
     a = np.zeros(0, dtype=dt)
     with pytest.raises(ValueError):

--- a/test/core/test_sqlite_vtable.py
+++ b/test/core/test_sqlite_vtable.py
@@ -1,4 +1,3 @@
-import ctypes
 import gc
 import os
 import subprocess
@@ -116,9 +115,9 @@ def test_unicode_width_overflow_rejected():
         _build_descriptor(a, None, False)
 
 
-def test_descriptor_offsets_assertion_holds():
-    from numbox.core.bindings._sqlite_vtable import _NdarrayTableDescriptor
-    assert ctypes.sizeof(_NdarrayTableDescriptor) == 72
+def test_descriptor_dtype_itemsize():
+    from numbox.core.bindings._sqlite_vtable import _DESC_DTYPE
+    assert _DESC_DTYPE.itemsize == 72
 
 
 _SQLITE_ROW = 100

--- a/test/core/test_sqlite_vtable.py
+++ b/test/core/test_sqlite_vtable.py
@@ -120,6 +120,44 @@ def test_descriptor_dtype_itemsize():
     assert _DESC_DTYPE.itemsize == 72
 
 
+def test_index_info_offsets_match_c_abi():
+    import ctypes
+    from numbox.core.bindings._sqlite_vtable import _IDX_INFO_DTYPE
+
+    class _IndexInfo(ctypes.Structure):
+        _fields_ = [
+            ("nConstraint", ctypes.c_int),
+            ("aConstraint", ctypes.c_void_p),
+            ("nOrderBy", ctypes.c_int),
+            ("aOrderBy", ctypes.c_void_p),
+            ("aConstraintUsage", ctypes.c_void_p),
+            ("idxNum", ctypes.c_int),
+            ("idxStr", ctypes.c_void_p),
+            ("needToFreeIdxStr", ctypes.c_int),
+            ("orderByConsumed", ctypes.c_int),
+            ("estimatedCost", ctypes.c_double),
+            ("estimatedRows", ctypes.c_longlong),
+        ]
+    assert _IDX_INFO_DTYPE.fields["estimatedCost"][1] == _IndexInfo.estimatedCost.offset
+    assert _IDX_INFO_DTYPE.fields["estimatedRows"][1] == _IndexInfo.estimatedRows.offset
+
+
+def test_xbestindex_sets_cardinality():
+    from numbox.core.bindings._sqlite_vtable import (
+        _xbestindex, _build_descriptor, _VTAB_DTYPE, _VTAB_SIZE, _IDX_INFO_DTYPE,
+    )
+    arr = np.arange(12, dtype=np.int64).reshape(4, 3)
+    built = _build_descriptor(arr, ["a", "b", "c"], False)
+    vtab = np.zeros(_VTAB_SIZE // 8, dtype=np.int64)
+    vtab.view(_VTAB_DTYPE)[0]["descriptor"] = built.c.ctypes.data
+    ii = np.zeros(_IDX_INFO_DTYPE.itemsize // 8, dtype=np.int64)
+    rc = _xbestindex.ctypes(int(vtab.ctypes.data), int(ii.ctypes.data))
+    assert rc == 0
+    view = ii.view(_IDX_INFO_DTYPE)[0]
+    assert int(view["estimatedRows"]) == 4
+    assert float(view["estimatedCost"]) == 4.0
+
+
 _SQLITE_ROW = 100
 _T_INT, _T_FLOAT, _T_TEXT, _T_BLOB, _T_NULL = 1, 2, 3, 4, 5
 

--- a/test/core/test_sqlite_vtable.py
+++ b/test/core/test_sqlite_vtable.py
@@ -1,0 +1,384 @@
+import ctypes
+import gc
+import os
+import subprocess
+import sys
+import textwrap
+from ctypes import addressof, c_int64, cast, c_char_p, string_at
+
+import pytest
+import numpy as np
+from numbox.utils.cstrings import c_string
+from numbox.core.bindings import (
+    sqlite3_open, sqlite3_close, register_table,
+    sqlite3_prepare_v2, sqlite3_step, sqlite3_finalize,
+    sqlite3_column_count, sqlite3_column_type,
+    sqlite3_column_int64, sqlite3_column_double,
+    sqlite3_column_text, sqlite3_column_blob, sqlite3_column_bytes,
+)
+from numbox.core.bindings._sqlite_vtable import utf32_to_utf8, _nul_trimmed_len
+from numbox.core.bindings._sqlite_vtable import _build_descriptor, _TAG_I64, _TAG_F64, _TAG_U
+from numbox.utils.lowlevel import array_data_p
+
+
+def test_imports():
+    from numbox.core.bindings import _sqlite_vtable as v
+    assert hasattr(v.sqlite3_create_module, "py_func")
+    assert hasattr(v.sqlite3_declare_vtab, "py_func")
+    assert hasattr(v.sqlite3_malloc, "py_func")
+
+
+def _encode(s, width):
+    src = np.zeros(width, dtype=np.uint32)
+    for i, ch in enumerate(s):
+        src[i] = ord(ch)
+    dst = np.zeros(4 * width + 1, dtype=np.uint8)
+    n = utf32_to_utf8(array_data_p(src), width, array_data_p(dst))
+    return bytes(dst[:n])
+
+
+def test_utf32_ascii():
+    assert _encode("abc", 6) == b"abc"
+
+
+def test_utf32_multibyte():
+    assert _encode("héllo", 6) == "héllo".encode("utf-8")
+
+
+def test_utf32_emoji_4byte():
+    assert _encode("a\U0001F600b", 6) == "a\U0001F600b".encode("utf-8")
+
+
+def test_utf32_stops_at_nul():
+    assert _encode("hi", 6) == b"hi"
+
+
+def test_utf32_keeps_interior_nul():
+    # trailing NUL pad is trimmed; an interior NUL code point is preserved
+    assert _encode("a\x00b", 6) == b"a\x00b"
+
+
+def test_utf32_invalid_codepoint_replacement():
+    src = np.array([0x41, 0xD800, 0x110000, 0], dtype=np.uint32)
+    dst = np.zeros(64, dtype=np.uint8)
+    n = utf32_to_utf8(array_data_p(src), 4, array_data_p(dst))
+    assert bytes(dst[:n]) == b"A" + b"\xef\xbf\xbd" + b"\xef\xbf\xbd"
+
+
+def test_nul_trimmed_len():
+    buf = np.frombuffer(b"hi\x00\x00\x00", dtype=np.uint8).copy()
+    assert _nul_trimmed_len(array_data_p(buf), 5) == 2
+
+
+def test_nul_trimmed_len_keeps_interior():
+    buf = np.frombuffer(b"a\x00b\x00\x00", dtype=np.uint8).copy()
+    assert _nul_trimmed_len(array_data_p(buf), 5) == 3
+
+
+def test_descriptor_2d_int64():
+    a = np.arange(6, dtype=np.int64).reshape(3, 2)
+    d = _build_descriptor(a, ["a", "b"], False)
+    assert (d.nrows, d.ncols, d.row_stride) == (3, 2, a.strides[0])
+    assert list(d.offsets) == [0, 8]
+    assert list(d.tags) == [_TAG_I64, _TAG_I64]
+    assert d.schema == b'CREATE TABLE x("a" INTEGER, "b" INTEGER)\x00'
+
+
+def test_descriptor_structured_mixed():
+    dt = np.dtype([("t", "U6"), ("q", "i8"), ("p", "f8")])
+    a = np.zeros(2, dtype=dt)
+    d = _build_descriptor(a, None, False)
+    assert d.ncols == 3
+    assert list(d.tags) == [_TAG_U, _TAG_I64, _TAG_F64]
+    assert list(d.offsets) == [dt.fields["t"][1], dt.fields["q"][1], dt.fields["p"][1]]
+    assert d.scratch_bytes == 6 * 4 + 1
+    assert d.schema == b'CREATE TABLE x("t" TEXT, "q" INTEGER, "p" REAL)\x00'
+
+
+def test_descriptor_rejects_bad_shapes():
+    import pytest
+    with pytest.raises((TypeError, ValueError)):
+        _build_descriptor(np.zeros((2, 2, 2), dtype=np.int64), ["a", "b"], False)
+    with pytest.raises((TypeError, ValueError)):
+        _build_descriptor(np.arange(4, dtype=np.int64), ["a"], False)
+    with pytest.raises((TypeError, ValueError)):
+        _build_descriptor(np.zeros((2, 3), dtype=np.int64), ["a", "b"], False)
+    with pytest.raises((TypeError, ValueError)):
+        _build_descriptor(np.empty((2, 2), dtype=object), ["a", "b"], False)
+    with pytest.raises((TypeError, ValueError)):
+        _build_descriptor(np.empty((3, 0), dtype=np.int64), [], False)
+
+
+def test_unicode_width_overflow_rejected():
+    # itemsize 4*536870906 = 2147483624; + 1 (scratch) + 24 (_CUR_SCRATCH) overflows int32
+    dt = np.dtype([("u", "U536870906")])
+    a = np.zeros(0, dtype=dt)
+    with pytest.raises(ValueError):
+        _build_descriptor(a, None, False)
+
+
+def test_descriptor_offsets_assertion_holds():
+    from numbox.core.bindings._sqlite_vtable import _NdarrayTableDescriptor
+    assert ctypes.sizeof(_NdarrayTableDescriptor) == 72
+
+
+_SQLITE_ROW = 100
+_T_INT, _T_FLOAT, _T_TEXT, _T_BLOB, _T_NULL = 1, 2, 3, 4, 5
+
+
+def _open_memory():
+    db_p = c_int64(0)
+    with c_string(":memory:") as name_p:
+        rc = sqlite3_open(name_p, addressof(db_p))
+    assert rc == 0, rc
+    return db_p.value
+
+
+def _fetchall(db, sql):
+    stmt_p = c_int64(0)
+    with c_string(sql) as sql_p:
+        rc = sqlite3_prepare_v2(db, sql_p, -1, addressof(stmt_p), 0)
+    assert rc == 0, (rc, sql)
+    stmt = stmt_p.value
+    rows = []
+    while sqlite3_step(stmt) == _SQLITE_ROW:
+        row = []
+        for i in range(sqlite3_column_count(stmt)):
+            t = sqlite3_column_type(stmt, i)
+            if t == _T_INT:
+                row.append(sqlite3_column_int64(stmt, i))
+            elif t == _T_FLOAT:
+                row.append(sqlite3_column_double(stmt, i))
+            elif t == _T_TEXT:
+                row.append(cast(sqlite3_column_text(stmt, i), c_char_p).value.decode("utf-8"))
+            elif t == _T_BLOB:
+                n = sqlite3_column_bytes(stmt, i)
+                row.append(string_at(sqlite3_column_blob(stmt, i), n) if n else b"")
+            else:
+                row.append(None)
+        rows.append(tuple(row))
+    sqlite3_finalize(stmt)
+    return rows
+
+
+def test_int64_table_select_where_order():
+    db = _open_memory()
+    a = np.array([[1, 10], [2, 20], [3, 30]], dtype=np.int64)
+    h = register_table(db, "points", a, columns=["a", "b"])  # noqa: F841
+    assert _fetchall(db, "SELECT a, b FROM points WHERE a >= 2 ORDER BY b DESC") == [(3, 30), (2, 20)]
+    sqlite3_close(db)
+
+
+def test_count_and_sum():
+    db = _open_memory()
+    a = np.array([[1, 10], [2, 20], [3, 30]], dtype=np.int64)
+    h = register_table(db, "t", a, columns=["a", "b"])  # noqa: F841
+    assert _fetchall(db, "SELECT COUNT(*), SUM(a) FROM t") == [(3, 6)]
+    sqlite3_close(db)
+
+
+def test_quoted_keyword_and_space_columns():
+    db = _open_memory()
+    a = np.array([[1, 2]], dtype=np.int64)
+    h = register_table(db, "t", a, columns=["order", "group by"])  # noqa: F841
+    assert _fetchall(db, 'SELECT "order", "group by" FROM t') == [(1, 2)]
+    sqlite3_close(db)
+
+
+@pytest.mark.parametrize("dt", [np.float64, np.float32, np.int32, np.int16, np.uint32, np.int8, np.uint8, np.uint16])
+def test_numeric_dtype_roundtrip(dt):
+    db = _open_memory()
+    a = (np.arange(6, dtype=dt).reshape(3, 2) + 1)
+    h = register_table(db, "t", a, columns=["a", "b"])  # noqa: F841
+    got = _fetchall(db, "SELECT a, b FROM t ORDER BY a")
+    exp = [tuple(row) for row in a.tolist()]
+    assert got == exp
+    sqlite3_close(db)
+
+
+def test_uint64_roundtrip_and_signed_wrap():
+    db = _open_memory()
+    a = np.array([[1], [2 ** 63], [2 ** 64 - 1]], dtype=np.uint64)
+    h = register_table(db, "t", a, columns=["a"])  # noqa: F841
+    # SQLite INTEGER is a signed int64; uint64 values >= 2**63 reinterpret as negative.
+    assert _fetchall(db, "SELECT a FROM t") == [(1,), (-(2 ** 63),), (-1,)]
+    sqlite3_close(db)
+
+
+def test_bool_dtype():
+    db = _open_memory()
+    a = np.array([[True, False], [False, True]], dtype=np.bool_)
+    h = register_table(db, "t", a, columns=["a", "b"])  # noqa: F841
+    assert _fetchall(db, "SELECT a, b FROM t") == [(1, 0), (0, 1)]
+    sqlite3_close(db)
+
+
+def test_structured_text_and_unicode():
+    db = _open_memory()
+    dt = np.dtype([("t", "U6"), ("q", "i4"), ("p", "f8"), ("s", "S4")])
+    a = np.array([("héllo", 3, 1.5, b"ab"), ("\U0001F600", 7, 2.0, b"cd")], dtype=dt)
+    h = register_table(db, "trades", a)  # noqa: F841
+    got = _fetchall(db, "SELECT t, q, p, s FROM trades")
+    assert got == [("héllo", 3, 1.5, "ab"), ("\U0001F600", 7, 2.0, "cd")]
+    sqlite3_close(db)
+
+
+def test_text_as_blob():
+    db = _open_memory()
+    dt = np.dtype([("s", "S3")])
+    a = np.array([(b"xy",)], dtype=dt)
+    h = register_table(db, "t", a, text_as_blob=True)  # noqa: F841
+    assert _fetchall(db, "SELECT s FROM t") == [(b"xy",)]
+    assert _fetchall(db, "SELECT typeof(s) FROM t") == [("blob",)]
+    sqlite3_close(db)
+
+
+def test_blob_preserves_interior_nul():
+    db = _open_memory()
+    dt = np.dtype([("s", "S5")])
+    a = np.array([(b"a\x00b",)], dtype=dt)  # numpy stores b"a\x00b\x00\x00"
+    h = register_table(db, "t", a, text_as_blob=True)  # noqa: F841
+    assert _fetchall(db, "SELECT s FROM t") == [(b"a\x00b",)]
+    sqlite3_close(db)
+
+
+def test_fortran_order_matches_c():
+    db = _open_memory()
+    a = np.asfortranarray(np.array([[1, 2], [3, 4], [5, 6]], dtype=np.int64))
+    h = register_table(db, "t", a, columns=["a", "b"])  # noqa: F841
+    assert _fetchall(db, "SELECT a, b FROM t ORDER BY a") == [(1, 2), (3, 4), (5, 6)]
+    sqlite3_close(db)
+
+
+def test_noncontiguous_slice():
+    db = _open_memory()
+    big = np.arange(40, dtype=np.int64).reshape(8, 5)
+    view = big[::2, 1:4]
+    h = register_table(db, "t", view, columns=["a", "b", "c"])  # noqa: F841
+    assert _fetchall(db, "SELECT a, b, c FROM t") == [tuple(r) for r in view.tolist()]
+    sqlite3_close(db)
+
+
+def test_reversed_rows():
+    db = _open_memory()
+    a = np.array([[1], [2], [3]], dtype=np.int64)[::-1]
+    h = register_table(db, "t", a, columns=["a"])  # noqa: F841
+    assert _fetchall(db, "SELECT a FROM t") == [(3,), (2,), (1,)]
+    sqlite3_close(db)
+
+
+def test_packed_unicode_odd_offset():
+    db = _open_memory()
+    dt = np.dtype([("a", "i1"), ("u", "U4")])
+    assert dt.fields["u"][1] == 1
+    a = np.array([(1, "wörd")], dtype=dt)
+    h = register_table(db, "t", a)  # noqa: F841
+    assert _fetchall(db, "SELECT a, u FROM t") == [(1, "wörd")]
+    sqlite3_close(db)
+
+
+def test_empty_table():
+    db = _open_memory()
+    a = np.empty((0, 2), dtype=np.int64)
+    h = register_table(db, "t", a, columns=["a", "b"])  # noqa: F841
+    assert _fetchall(db, "SELECT * FROM t") == []
+    assert _fetchall(db, "SELECT COUNT(*) FROM t") == [(0,)]
+    sqlite3_close(db)
+
+
+def test_rowid_is_zero_based():
+    db = _open_memory()
+    a = np.array([[10], [20], [30]], dtype=np.int64)
+    h = register_table(db, "t", a, columns=["a"])  # noqa: F841
+    assert _fetchall(db, "SELECT rowid, a FROM t") == [(0, 10), (1, 20), (2, 30)]
+    sqlite3_close(db)
+
+
+def test_join_two_tables():
+    db = _open_memory()
+    a = np.array([[1, 100], [2, 200]], dtype=np.int64)
+    b = np.array([[1, 7], [2, 9]], dtype=np.int64)
+    h1 = register_table(db, "lhs", a, columns=["id", "v"])  # noqa: F841
+    h2 = register_table(db, "rhs", b, columns=["id", "w"])  # noqa: F841
+    got = _fetchall(db, "SELECT lhs.v, rhs.w FROM lhs JOIN rhs ON lhs.id = rhs.id ORDER BY lhs.id")
+    assert got == [(100, 7), (200, 9)]
+    sqlite3_close(db)
+
+
+def test_handle_survives_gc():
+    db = _open_memory()
+    a = np.array([[5, 6]], dtype=np.int64)
+    h = register_table(db, "t", a, columns=["a", "b"])  # noqa: F841
+    gc.collect()
+    assert _fetchall(db, "SELECT a, b FROM t") == [(5, 6)]
+    sqlite3_close(db)
+
+
+def test_duplicate_name_replaces():
+    db = _open_memory()
+    a = np.array([[1]], dtype=np.int64)
+    b = np.array([[2]], dtype=np.int64)
+    h1 = register_table(db, "dup", a, columns=["x"])  # noqa: F841
+    h2 = register_table(db, "dup", b, columns=["x"])  # noqa: F841
+    assert _fetchall(db, "SELECT x FROM dup") == [(2,)]
+    sqlite3_close(db)
+
+
+# A self-contained driver: imports register_table, opens :memory:, registers a
+# 2-D int64 table, runs a SELECT, and prints the rows. Run twice in fresh
+# subprocesses to assert cold/warm cfunc cache reuse (no growth on the warm run).
+_DRIVER = textwrap.dedent('''
+    from ctypes import addressof, c_int64
+    import numpy as np
+    from numbox.core.bindings import (
+        sqlite3_open, sqlite3_prepare_v2, sqlite3_step,
+        sqlite3_column_int64, sqlite3_finalize)
+    from numbox.core.bindings._sqlite_vtable import register_table
+    from numbox.utils.cstrings import c_string
+
+    db_p = c_int64(0)
+    with c_string(":memory:") as n:
+        sqlite3_open(n, addressof(db_p))
+    db = db_p.value
+    a = np.array([[1, 10], [2, 20], [3, 30]], dtype=np.int64)
+    h = register_table(db, "t", a, columns=["a", "b"])
+    stmt_p = c_int64(0)
+    with c_string("SELECT a, b FROM t ORDER BY a") as sp:
+        sqlite3_prepare_v2(db, sp, -1, addressof(stmt_p), 0)
+    stmt = stmt_p.value
+    rows = []
+    while sqlite3_step(stmt) == 100:
+        rows.append((sqlite3_column_int64(stmt, 0), sqlite3_column_int64(stmt, 1)))
+    sqlite3_finalize(stmt)
+    assert rows == [(1, 10), (2, 20), (3, 30)], rows
+    print("RESULT", rows)
+''')
+
+
+def _run_vtable_driver(tmp_path, cache_dir):
+    script = tmp_path / "vtable_drv.py"
+    script.write_text(_DRIVER)
+    env = dict(os.environ, NUMBA_CACHE_DIR=str(cache_dir))
+    out = subprocess.run([sys.executable, str(script)], env=env,
+                         capture_output=True, text=True, timeout=600)
+    assert out.returncode == 0, out.stderr
+    line = [ln for ln in out.stdout.splitlines() if ln.startswith("RESULT")][0]
+    return line
+
+
+def _count_vtable_nbc(cache_dir):
+    # Scope to the vtable cfunc/njit caches only, so the no-growth assertion is
+    # immune to unrelated bindings whose compile timing differs across runs.
+    return sum(1 for _ in cache_dir.rglob("*_sqlite_vtable*.nbc"))
+
+
+def test_xprocess_cache_no_growth(tmp_path):
+    cache = tmp_path / "nbcache"
+    cache.mkdir()
+    line1 = _run_vtable_driver(tmp_path, cache)  # cold: compiles + writes cache
+    assert line1 == "RESULT [(1, 10), (2, 20), (3, 30)]"
+    n_cold = _count_vtable_nbc(cache)
+    assert n_cold > 0
+    line2 = _run_vtable_driver(tmp_path, cache)  # warm: must reuse, not append
+    assert line2 == "RESULT [(1, 10), (2, 20), (3, 30)]"
+    assert _count_vtable_nbc(cache) == n_cold, "warm run grew the cache (cache reuse failed)"

--- a/test/core/test_sqlite_vtable.py
+++ b/test/core/test_sqlite_vtable.py
@@ -107,12 +107,15 @@ def test_descriptor_rejects_bad_shapes():
         _build_descriptor(np.empty((3, 0), dtype=np.int64), [], False)
 
 
-def test_unicode_width_overflow_rejected():
-    # itemsize 4*536870906 = 2147483624; + 1 (scratch) + 24 (_CUR_HEADER) overflows int32
-    dt = np.dtype([("u", "U536870906")])
-    a = np.zeros(0, dtype=dt)
-    with pytest.raises(ValueError):
-        _build_descriptor(a, None, False)
+def test_widest_unicode_width_accepted():
+    # The per-cursor scratch buffer is its own int32-sized sqlite3_malloc, and
+    # numpy caps 'U' itemsize below 2**31, so even the widest constructible
+    # unicode column yields a scratch size that fits int32 -- no
+    # registration-time guard.
+    dt = np.dtype([("u", "U536870911")])
+    built = _build_descriptor(np.zeros(0, dtype=dt), None, False)
+    assert built.scratch_bytes == 4 * 536870911 + 1
+    assert built.scratch_bytes <= 2 ** 31 - 1
 
 
 def test_descriptor_dtype_itemsize():


### PR DESCRIPTION
Sync fork `main` with `upstream/main` following the merge of upstream [Goykhman/numbox#21](https://github.com/Goykhman/numbox/pull/21) (read-only, zero-copy numpy → SQLite virtual-table bindings, phase 4).

This is a **merge**, not a fast-forward: fork `main` carries fork-only extras (`CLAUDE.md`, the expanded [`numbox_ci.yml`](.github/workflows/numbox_ci.yml) matrix, doc-lint tooling, `docs/plans/`). The merge was conflict-free, and the merged package tree is byte-identical to the CI-green `upstream/main` (`d267294`).

Local gate (single env, numba 0.60.0, Python 3.12): `flake8 .` clean; **618 passed / 2 skipped**; `sphinx-build` exit 0; doc-codeblock-flake8 clean; lychee 30/30 OK.
