### PR TITLE
Sync fork main with upstream/main (fa0b010): align index_info struct + simplify bindings imports

### DIFF
--- a/numbox/core/bindings/_sqlite_udf_helpers.py
+++ b/numbox/core/bindings/_sqlite_udf_helpers.py
@@ -47,13 +47,13 @@ from numba import cfunc, types
 from numba.core.types import StructRef
 from numba.extending import is_jitted
 
-from numbox.core.bindings._sqlite_conn import sqlite3_errmsg
-from numbox.core.bindings._sqlite_constants import (
+from numbox.core.bindings import sqlite3_errmsg
+from numbox.core.bindings import (
     SQLITE_DETERMINISTIC,
     SQLITE_OK,
     SQLITE_UTF8,
 )
-from numbox.core.bindings._sqlite_udf import (
+from numbox.core.bindings import (
     sqlite3_create_function_v2,
     sqlite3_create_window_function,
 )
@@ -70,8 +70,8 @@ from numbox.utils.preprocessing import (
 import numpy as np  # noqa: F401
 from numba import carray, njit  # noqa: F401
 from numbox.core.configurations import jit_options  # noqa: F401
-from numbox.core.bindings._sqlite_result import sqlite3_result_error  # noqa: F401
-from numbox.core.bindings._sqlite_udf import sqlite3_aggregate_context  # noqa: F401
+from numbox.core.bindings import sqlite3_result_error  # noqa: F401
+from numbox.core.bindings import sqlite3_aggregate_context  # noqa: F401
 from numbox.utils.lowlevel import _cast_int_to_void_p, get_unicode_data_p  # noqa: F401
 from numbox.utils.meminfo import (  # noqa: F401
     borrow_structref,

--- a/numbox/core/bindings/_sqlite_vtable.py
+++ b/numbox/core/bindings/_sqlite_vtable.py
@@ -20,7 +20,7 @@ from numba.core.types import (
     float32, float64,
 )
 
-from numbox.core.bindings._sqlite_constants import (
+from numbox.core.bindings import (
     SQLITE_OK, SQLITE_TRANSIENT, SQLITE_ERROR, SQLITE_NOMEM,
 )
 from numbox.core.bindings import (
@@ -84,13 +84,11 @@ _CUR_SIZE = _CUR_DTYPE.itemsize
 # estimatedRows (idxFlags 3.9.0, colUsed 3.10.0) are omitted -- never addressed;
 # estimatedRows needs SQLite 3.8.2+, met by the >=3.34 support floor.
 _IDX_INFO_DTYPE = np.dtype([
-    ("nConstraint", "i4"), ("_pad0", "i4"), ("aConstraint", "i8"),
-    ("nOrderBy", "i4"), ("_pad1", "i4"), ("aOrderBy", "i8"),
-    ("aConstraintUsage", "i8"),
-    ("idxNum", "i4"), ("_pad2", "i4"), ("idxStr", "i8"),
-    ("needToFreeIdxStr", "i4"), ("orderByConsumed", "i4"),
+    ("nConstraint", "i4"), ("aConstraint", "i8"), ("nOrderBy", "i4"),
+    ("aOrderBy", "i8"), ("aConstraintUsage", "i8"), ("idxNum", "i4"),
+    ("idxStr", "i8"), ("needToFreeIdxStr", "i4"), ("orderByConsumed", "i4"),
     ("estimatedCost", "f8"), ("estimatedRows", "i8"),
-])
+], align=True)
 assert _IDX_INFO_DTYPE.fields["estimatedCost"][1] == 64
 assert _IDX_INFO_DTYPE.fields["estimatedRows"][1] == 72
 


### PR DESCRIPTION
Sync fork `main` with `upstream/main` ([`fa0b010`](https://github.com/Goykhman/numbox/commit/fa0b010611c9ad59e5c9e3a96539d254e37805f7)).

Brings in Goykhman's post-phase-4 cleanup:
- `sqlite3_index_info` modelled with `align=True` instead of explicit `_pad` fields (byte-identical layout; the offset asserts are unchanged).
- Remaining bindings imports in [`_sqlite_vtable.py`](numbox/core/bindings/_sqlite_vtable.py) and [`_sqlite_udf_helpers.py`](numbox/core/bindings/_sqlite_udf_helpers.py) consolidated onto the `numbox.core.bindings` package namespace.

Lightweight merge — no fork-only files touched. Restores `upstream/main` as an ancestor of fork `main` so future syncs stay clean.
