### PR TITLE
docs(CLAUDE): local venv numba is 0.65.1, not 0.60.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ numbox — a toolbox of low-level utilities for working with numba. Provides typ
 - Lint: `flake8` (config in `.flake8`: max-line-length=127, default rules, per-file F403/F405 ignore for `test/core/test_bindings.py`)
 - Docs: `cd docs && make html` (Sphinx)
 - Python: >=3.10 (CI tests 3.10–3.14; local venv pinned to 3.12)
-- Key dependency: `numba>=0.60.0,<0.66.0` (matches `pyproject.toml`; use `numba==0.60.0` locally)
+- Key dependency: `numba>=0.60.0,<0.66.0` (matches `pyproject.toml`; local venv has `numba==0.65.1`)
 
 ## Architecture
 


### PR DESCRIPTION
Doc-only fix: the local venv has numba 0.65.1, but the CLAUDE.md line said 0.60.0. CI still tests the full 0.60.0-0.65.1 matrix; this just matches the line to reality.