### PR TITLE
Sync upstream/main: preferred numpy.int64(...) casts (1c9fb24)

### DIFF
--- a/test/core/test_sqlite_udf.py
+++ b/test/core/test_sqlite_udf.py
@@ -121,7 +121,7 @@ def _sum_step_impl(ctx, argc, argv_pp):
     val = sqlite3_value_int64(args[0])
     slot = carray(_cast_int_to_void_p(agg_ptr), (1,), dtype=np.intp)
     if slot[0] == 0:
-        s = SumState(nb_types.int64(0))
+        s = SumState(np.int64(0))
         slot[0] = export_meminfo(s)
     state = borrow_structref(sum_state_type, slot[0])
     state.total += val
@@ -136,11 +136,11 @@ _sum_step_cb = cfunc(
 def _sum_final_impl(ctx):
     agg_ptr = sqlite3_aggregate_context(ctx, 0)
     if agg_ptr == 0:
-        sqlite3_result_int64(ctx, nb_types.int64(0))
+        sqlite3_result_int64(ctx, np.int64(0))
         return
     slot = carray(_cast_int_to_void_p(agg_ptr), (1,), dtype=np.intp)
     if slot[0] == 0:
-        sqlite3_result_int64(ctx, nb_types.int64(0))
+        sqlite3_result_int64(ctx, np.int64(0))
         return
     state = borrow_structref(sum_state_type, slot[0])
     sqlite3_result_int64(ctx, state.total)
@@ -211,11 +211,11 @@ _wsum_inverse_cb = cfunc(
 def _wsum_value_impl(ctx):
     agg_ptr = sqlite3_aggregate_context(ctx, 0)
     if agg_ptr == 0:
-        sqlite3_result_int64(ctx, nb_types.int64(0))
+        sqlite3_result_int64(ctx, np.int64(0))
         return
     slot = carray(_cast_int_to_void_p(agg_ptr), (_WSUM_SLOTS,), dtype=np.intp)
     if slot[0] == 0:
-        sqlite3_result_int64(ctx, nb_types.int64(0))
+        sqlite3_result_int64(ctx, np.int64(0))
         return
     state = carray(_cast_int_to_void_p(slot[1]), (1,), dtype=np.int64)
     sqlite3_result_int64(ctx, state[0])
@@ -228,11 +228,11 @@ _wsum_value_cb = cfunc(types.void(types.intp))(_wsum_value_impl)
 def _wsum_final_impl(ctx):
     agg_ptr = sqlite3_aggregate_context(ctx, 0)
     if agg_ptr == 0:
-        sqlite3_result_int64(ctx, nb_types.int64(0))
+        sqlite3_result_int64(ctx, np.int64(0))
         return
     slot = carray(_cast_int_to_void_p(agg_ptr), (_WSUM_SLOTS,), dtype=np.intp)
     if slot[0] == 0:
-        sqlite3_result_int64(ctx, nb_types.int64(0))
+        sqlite3_result_int64(ctx, np.int64(0))
         return
     state = carray(_cast_int_to_void_p(slot[1]), (1,), dtype=np.int64)
     sqlite3_result_int64(ctx, state[0])
@@ -251,7 +251,7 @@ def _user_data_probe_impl(ctx, argc, argv_pp):
     ud = sqlite3_user_data(ctx)
     args = carray(_cast_int_to_void_p(argv_pp), (argc,), dtype=np.intp)
     target_p = sqlite3_value_int64(args[0])
-    result = nb_types.int64(1) if ud == target_p else nb_types.int64(0)
+    result = np.int64(1) if ud == target_p else np.int64(0)
     sqlite3_result_int64(ctx, result)
 
 

--- a/test/core/test_sqlite_udf_helpers.py
+++ b/test/core/test_sqlite_udf_helpers.py
@@ -44,7 +44,7 @@ sum_state_type = SumStateType([("total", nb_types.int64)])
 
 @njit
 def sum_init():
-    return SumState(nb_types.int64(0))
+    return SumState(np.int64(0))
 
 
 @njit
@@ -163,7 +163,7 @@ _DRIVER = textwrap.dedent('''
 
     @njit
     def s_init():
-        return St(nb_types.int64(0))
+        return St(np.int64(0))
     @njit
     def s_step(state, ctx, argc, argv_pp):
         a = carray(_cast_int_to_void_p(argv_pp), (argc,), dtype=np.intp)
@@ -404,7 +404,7 @@ def test_plain_python_callbacks_accepted():
     _make_table(db, [1, 2, 3, 4, 5])
 
     def plain_init():
-        return SumState(nb_types.int64(0))
+        return SumState(np.int64(0))
 
     def plain_step(state, ctx, argc, argv_pp):
         args = carray(_cast_int_to_void_p(argv_pp), (argc,), dtype=np.intp)
@@ -447,7 +447,7 @@ pair_state_type = PairStateType([("sa", nb_types.int64), ("sb", nb_types.int64)]
 
 @njit
 def pair_init():
-    return PairState(nb_types.int64(0), nb_types.int64(0))
+    return PairState(np.int64(0), np.int64(0))
 
 
 @njit
@@ -640,7 +640,7 @@ def test_finalize_exception_empty_group_surfaces_error():
 
 @njit
 def init_raise():
-    s = SumState(nb_types.int64(0))
+    s = SumState(np.int64(0))
     if s.total >= 0:  # always true at runtime; keeps the St return type for typing
         raise ValueError("boom from init")
     return s

--- a/test/core/test_sqlite_value.py
+++ b/test/core/test_sqlite_value.py
@@ -69,7 +69,7 @@ def _cap_int_impl(ctx, argc, argv_pp):
     ud = sqlite3_user_data(ctx)
     out = carray(_cast_int_to_void_p(ud), (1,), dtype=np.int64)
     args = carray(_cast_int_to_void_p(argv_pp), (argc,), dtype=np.intp)
-    out[0] = nb_types.int64(sqlite3_value_int(args[0]))
+    out[0] = np.int64(sqlite3_value_int(args[0]))
     sqlite3_result_int(ctx, 0)
 
 
@@ -171,7 +171,7 @@ def _cap_types_impl(ctx, argc, argv_pp):
     ud = sqlite3_user_data(ctx)
     out = carray(_cast_int_to_void_p(ud), (6,), dtype=np.int64)
     args = carray(_cast_int_to_void_p(argv_pp), (argc,), dtype=np.intp)
-    out[0] = nb_types.int64(argc)
+    out[0] = np.int64(argc)
     for i in range(argc):
         out[1 + i] = nb_types.int64(sqlite3_value_type(args[i]))
     sqlite3_result_int(ctx, 0)


### PR DESCRIPTION
Routine fork-main sync. Merges `upstream/main` (Goykhman/numbox @ `1c9fb24`, "preferred numpy.int64(...) casts") into fork `main`.

Upstream's change converts bare `int64(...)` value-casts to `numpy.int64(...)` in three phase-2/3 test files only — no library code:
- `test/core/test_sqlite_udf.py`
- `test/core/test_sqlite_udf_helpers.py`
- `test/core/test_sqlite_value.py`

Clean merge (no conflicts). Local gate green: 618 passed, 2 skipped; flake8 clean at the repo config (max-line-length=127).
