### PR TITLE
Add compile_kernel: fuse a Variable graph into one @njit kernel

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -56,6 +56,10 @@ jobs:
             --exclude-path venv
             ${{ steps.scope.outputs.files }}
           fail: true
+          # Don't fail when the changed-file set contains no links at all
+          # (e.g. a code-only or link-less-docs PR): "no links found" is not a
+          # link-check failure. Broken links are still reported via fail: true.
+          failIfEmpty: false
           format: markdown
           output: ./lychee-report.md
 

--- a/docs/numbox.core.variable.rst
+++ b/docs/numbox.core.variable.rst
@@ -210,9 +210,69 @@ Only the affected nodes will be re-evaluated::
 
 .. rubric:: References
 
-.. [#f1] It is straightforward to adapt the variables specifications given here in pure Python to build a fully-JIT'ed graph of :class:`numbox.core.work.work.Work` nodes, by using the :class:`numbox.core.work.builder.Derived`. See :ref:`builder`.
+.. [#f1] It is straightforward to adapt the variables specifications given here in pure Python to build a fully-JIT'ed graph of :class:`numbox.core.work.work.Work` nodes, by using the :class:`numbox.core.work.builder.Derived`. See :ref:`builder`. As another route to fully-JIT'ed evaluation, :func:`numbox.core.variable.compile_kernel.compile_kernel` fuses the graph into a single ``@njit`` kernel (see below).
 
 .. automodule:: numbox.core.variable.variable
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+numbox.core.variable.compile_kernel
+-----------------------------------
+
+Overview
+********
+
+Alongside :meth:`numbox.core.variable.variable.Graph.compile` (which produces a
+:class:`numbox.core.variable.variable.CompiledGraph` evaluated node-by-node in pure Python),
+:func:`numbox.core.variable.compile_kernel.compile_kernel` compiles a `Graph` into
+*one* fused ``@njit`` kernel for a requested set of variables. It does not replace
+`core.work` or `CompiledGraph`; it is an additional, fully-JIT'ed evaluation path.
+
+The fused kernel takes the required external inputs as positional arguments and returns
+the requested variables as a tuple, with every interior graph node lowered to an SSA
+temporary inside the single compiled function. No per-node type information needs to be
+supplied: numba infers every interior type from the runtime argument types, provided each
+`formula` is njit-able. Plain-Python formulas are auto-wrapped with ``njit()``.
+
+The call returns a :class:`numbox.core.variable.compile_kernel.CompiledKernel`. It exposes
+the raw ``.kernel`` (the bare numba dispatcher — positional in, tuple out — for the
+zero-overhead hot path) and a dict-in / dict-out ``.execute`` convenience that mirrors
+:meth:`numbox.core.variable.variable.CompiledGraph.execute`. The qualified names of the
+kernel's positional inputs and tuple outputs are available as ``.params`` and ``.outputs``,
+the generated kernel text as ``.source``, and the per-variable temporary identifiers as
+``.identifiers``.
+
+This is a v1 fused path with two deliberate limitations: it does not honor the
+`cacheable` memoization of individual nodes, and it offers no incremental recompute of
+only the affected nodes. Use :class:`numbox.core.variable.variable.CompiledGraph` (or the
+`core.work` graph) when either of those is needed.
+
+A graph can be compiled to a fused kernel as follows:
+
+.. code-block:: python
+
+    from numba import njit
+    from numbox.core.variable.variable import Graph
+    from numbox.core.variable.compile_kernel import compile_kernel
+
+    graph = Graph(
+        variables_lists={"variables": [
+            {"name": "x", "inputs": {"y": "basket"}, "formula": njit(lambda y: 2 * y)},
+            {"name": "u", "inputs": {"x": "variables"}, "formula": njit(lambda x: x - 74)},
+        ]},
+        external_source_names=["basket"],
+    )
+
+    ck = compile_kernel(graph, ["variables.u"])
+    assert ck.execute({"basket": {"y": 100}}) == {"variables.u": 126}
+    assert ck.kernel(100) == (126,)
+
+Here the dict-in / dict-out ``ck.execute`` looks up the required external value
+``basket.y`` and returns the requested ``variables.u``, while the bare ``ck.kernel``
+is called positionally with the external input and returns the output tuple directly.
+
+.. automodule:: numbox.core.variable.compile_kernel
    :members:
    :show-inheritance:
    :undoc-members:

--- a/docs/superpowers/plans/2026-06-07-compile-kernel.md
+++ b/docs/superpowers/plans/2026-06-07-compile-kernel.md
@@ -1,0 +1,859 @@
+# compile_kernel Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers-extended-cc:subagent-driven-development (recommended) or superpowers-extended-cc:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `numbox/core/variable/compile_kernel.py` that compiles a `Variable` graph into one fused `@njit` kernel computing a requested set of variables.
+
+**Architecture:** Reuse `Graph.compile` for topological order + external-variable discovery; assign each node a readable, collision-free identifier; generate straight-line `@njit` source (one `tmp = f_tmp(...)` per node, interior nodes as SSA temporaries) and `exec` it against a content-addressed on-disk anchor (reusing `numbox/utils/preprocessing.py`) so `cache=True` is correct. No per-node types are required — numba infers from runtime argument types. Plain-Python formulas are auto-wrapped with `njit()`.
+
+**Tech Stack:** Python ≥3.10, numba 0.65.1, existing numbox modules (`core/variable/variable.py`, `core/configurations.py`, `utils/preprocessing.py`, `utils/highlevel.py`).
+
+**Spec:** `docs/superpowers/specs/2026-06-07-compile-kernel-design.md`
+
+**Conventions for every task:**
+- Always use the venv interpreter: `/home/erik/projects/numbox/venv/bin/python` (never bare `python`/`pytest`).
+- Run tests from the repo root and clean caches first (this feature exercises numba caching, so stale caches can mask bugs):
+  ```bash
+  ( cd /home/erik/projects/numbox && \
+    venv/bin/python -c "import shutil,pathlib,os; r=pathlib.Path('.'); [shutil.rmtree(p,ignore_errors=True) for p in r.rglob('__pycache__')]; shutil.rmtree(pathlib.Path(os.path.expanduser('~/.cache/numba')),ignore_errors=True)" && \
+    venv/bin/python -m pytest test/core/test_compile_kernel.py -q )
+  ```
+- No task numbers / phase references in code comments.
+- Commit after each task (no `Co-Authored-By`, no AI provenance). Branch: `feat/variable-compile-kernel`.
+
+---
+
+### Task 1: Module scaffold + identifier assignment
+
+**Goal:** Create the module with `_sanitize` and `_assign_identifiers`, producing unique, valid, readable Python identifiers for graph nodes.
+
+**Files:**
+- Create: `numbox/core/variable/compile_kernel.py`
+- Test: `test/core/test_compile_kernel.py`
+
+**Acceptance Criteria:**
+- [ ] `_sanitize` maps any string to a valid lowercase identifier (invalid chars → `_`, leading digit / empty → `v_` prefix).
+- [ ] `_assign_identifiers` returns a `{Variable: identifier}` map that is unique across node temps, their `f_<temp>` formula globals, and the reserved names.
+- [ ] The three collision classes resolve correctly: `("a_b","c")` vs `("a","b_c")`; an invalid-char/leading-digit name; a node whose identifier would be `f_x`.
+- [ ] Identifiers are deterministic (same graph → same identifiers).
+
+**Verify:** `( cd /home/erik/projects/numbox && venv/bin/python -m pytest test/core/test_compile_kernel.py -q )` → all pass
+
+**Steps:**
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# test/core/test_compile_kernel.py
+from numbox.core.variable.compile_kernel import _sanitize, _assign_identifiers
+from numbox.core.variable.variable import Variable
+
+
+def test_sanitize_basic():
+    assert _sanitize("variables.a") == "variables_a"
+    assert _sanitize("first-name") == "first_name"
+    assert _sanitize("3m") == "v_3m"
+    assert _sanitize("a..b") == "a_b"
+    assert _sanitize("") == "v_"
+
+
+def test_assign_identifiers_unique_and_valid():
+    v1 = Variable(name="c", source="a_b")     # qual a_b.c -> base a_b_c
+    v2 = Variable(name="b_c", source="a")     # qual a.b_c -> base a_b_c (collision)
+    idents = _assign_identifiers([v1, v2])
+    assert idents[v1] != idents[v2]
+    assert all(s.isidentifier() for s in idents.values())
+
+
+def test_assign_identifiers_formula_prefix_collision():
+    node = Variable(name="x", source="variables")        # base variables_x
+    clash = Variable(name="variables_x", source="f")     # base f_variables_x == f_<node temp>
+    idents = _assign_identifiers([node, clash])
+    temps = set(idents.values())
+    fgs = {"f_" + t for t in temps}
+    assert temps.isdisjoint(fgs)                          # no temp equals any formula global
+
+
+def test_assign_identifiers_deterministic():
+    v1 = Variable(name="c", source="a_b")
+    v2 = Variable(name="b_c", source="a")
+    assert _assign_identifiers([v1, v2]) == _assign_identifiers([v1, v2])
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `( cd /home/erik/projects/numbox && venv/bin/python -m pytest test/core/test_compile_kernel.py -q )`
+Expected: FAIL (ImportError — module/functions not defined)
+
+- [ ] **Step 3: Write the module + functions**
+
+```python
+# numbox/core/variable/compile_kernel.py
+"""Compile a `core.variable` Variable graph into one fused @njit kernel.
+
+Alongside `core.work` (a structref graph), this turns a `Graph`/`CompiledGraph`
+into a single straight-line @njit function whose interior nodes are SSA
+temporaries. No per-node type info is needed: numba infers every interior type
+from the kernel's runtime argument types, provided each formula is njit-able
+(plain-Python formulas are auto-wrapped with njit()).
+"""
+import hashlib
+import re
+
+from numba.core.dispatcher import Dispatcher
+from numba.core.types.function_type import CompileResultWAP
+
+# Names injected into the kernel exec namespace; identifiers must avoid them.
+_RESERVED = frozenset({"njit", "_kernel_jit_options"})
+
+
+def _sanitize(qual_name):
+    s = re.sub(r"[^0-9A-Za-z_]", "_", qual_name)
+    s = re.sub(r"_+", "_", s).strip("_").lower()
+    if not s or s[0].isdigit():
+        s = "v_" + s
+    return s
+
+
+def _assign_identifiers(variables):
+    """Map each Variable to a unique, valid, readable Python identifier.
+
+    Readable (from the qual_name) with a minimal deterministic sha256 suffix
+    only where names would otherwise collide. Reserves both the node temp `t`
+    and its formula global `f_<t>` so those namespaces never clash, and avoids
+    the injected reserved names.
+    """
+    used = set(_RESERVED)
+    idents = {}
+    for var in variables:
+        base = _sanitize(var.qual_name())
+        digest = hashlib.sha256(var.qual_name().encode("utf-8")).hexdigest()
+        cand = base
+        i = 0
+        while cand in used or ("f_" + cand) in used:
+            i += 1
+            cand = f"{base}_{digest[:i]}"
+        used.add(cand)
+        used.add("f_" + cand)
+        idents[var] = cand
+    return idents
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `( cd /home/erik/projects/numbox && venv/bin/python -m pytest test/core/test_compile_kernel.py -q )`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /home/erik/projects/numbox add numbox/core/variable/compile_kernel.py test/core/test_compile_kernel.py
+git -C /home/erik/projects/numbox commit -m "compile_kernel: node identifier assignment (sanitize + collision-free)"
+```
+
+---
+
+### Task 2: Codegen — formula wrapping + source generation
+
+**Goal:** Add `_wrap_formula`, `_safe_getsource`, and `_generate_body`, which turn a `CompiledGraph` + identifier map into kernel source text, formula bindings, params, and outputs.
+
+**Files:**
+- Modify: `numbox/core/variable/compile_kernel.py`
+- Test: `test/core/test_compile_kernel.py`
+
+**Acceptance Criteria:**
+- [ ] `_wrap_formula` returns numba `Dispatcher`/`CompileResultWAP` unchanged and wraps a plain function with `njit()`.
+- [ ] `_generate_body` emits `def _kernel(<params>):` with one `tmp = f_tmp(args)` line per derived node (topo order, inputs in formula-arg order), a `return (outs,)` tuple, and a `bindings` dict keyed `f_<temp>`.
+- [ ] External (leaf) nodes become parameters (sorted by qual_name); they emit no assignment line.
+- [ ] Raises `ValueError` for: empty `required`; a non-external node with `formula is None`; a requested name absent from the graph.
+
+**Verify:** `( cd /home/erik/projects/numbox && venv/bin/python -m pytest test/core/test_compile_kernel.py -q )` → all pass
+
+**Steps:**
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# append to test/core/test_compile_kernel.py
+import pytest
+from numba import njit
+from numba.core.dispatcher import Dispatcher
+from numbox.core.variable.compile_kernel import _wrap_formula, _generate_body
+from numbox.core.variable.variable import Graph
+
+
+def _diamond_graph():
+    # basket.y -> x=2y -> {a=x-74, b=x+0.5} -> u=a+b
+    return Graph(
+        variables_lists={"variables": [
+            {"name": "x", "inputs": {"y": "basket"}, "formula": njit(lambda y: 2 * y)},
+            {"name": "a", "inputs": {"x": "variables"}, "formula": njit(lambda x: x - 74)},
+            {"name": "b", "inputs": {"x": "variables"}, "formula": njit(lambda x: x + 0.5)},
+            {"name": "u", "inputs": {"a": "variables", "b": "variables"},
+             "formula": njit(lambda a, b: a + b)},
+        ]},
+        external_source_names=["basket"],
+    )
+
+
+def test_wrap_formula_passthrough_and_wrap():
+    d = njit(lambda x: x)
+    assert _wrap_formula(d) is d                       # dispatcher passes through
+
+    def plain(x):
+        return x + 1
+    assert isinstance(_wrap_formula(plain), Dispatcher)  # plain -> njit
+
+
+def test_generate_body_shape():
+    g = _diamond_graph()
+    compiled = g.compile(["variables.u", "variables.a"])
+    from numbox.core.variable.compile_kernel import _assign_identifiers
+    idents = _assign_identifiers([n.variable for n in compiled.ordered_nodes])
+    source, bindings, params, outputs = _generate_body(compiled, ["variables.u", "variables.a"], idents)
+    assert params == [("basket", "y", idents[next(v for v in idents if v.qual_name() == "basket.y")])]
+    assert outputs == ["variables.u", "variables.a"]
+    assert source.startswith("def _kernel(")
+    assert source.rstrip().endswith(",)")
+    assert set(bindings) == {"f_" + idents[v] for v in idents if v.qual_name() != "basket.y"}
+
+
+def test_generate_body_errors():
+    g = _diamond_graph()
+    compiled = g.compile(["variables.u"])
+    from numbox.core.variable.compile_kernel import _assign_identifiers
+    idents = _assign_identifiers([n.variable for n in compiled.ordered_nodes])
+    with pytest.raises(ValueError):
+        _generate_body(compiled, [], idents)                       # empty required
+    with pytest.raises(ValueError):
+        _generate_body(compiled, ["variables.nope"], idents)       # unknown output
+
+    gph = Graph(
+        variables_lists={"variables": [
+            {"name": "x", "inputs": {"y": "basket"}, "formula": njit(lambda y: 2 * y)},
+            {"name": "broken", "inputs": {"x": "variables"}, "formula": None},
+        ]},
+        external_source_names=["basket"],
+    )
+    c2 = gph.compile(["variables.broken"])
+    id2 = _assign_identifiers([n.variable for n in c2.ordered_nodes])
+    with pytest.raises(ValueError):
+        _generate_body(c2, ["variables.broken"], id2)              # placeholder formula=None
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `( cd /home/erik/projects/numbox && venv/bin/python -m pytest test/core/test_compile_kernel.py -q )`
+Expected: FAIL (ImportError on `_wrap_formula`/`_generate_body`)
+
+- [ ] **Step 3: Add the functions**
+
+```python
+# append to numbox/core/variable/compile_kernel.py
+from inspect import getsource
+from numba import njit
+
+
+def _wrap_formula(formula):
+    """Return an njit-callable for `formula`; plain Python is auto-njit'd."""
+    if isinstance(formula, (Dispatcher, CompileResultWAP)):
+        return formula
+    return njit(formula)
+
+
+def _safe_getsource(formula):
+    """Source text of a formula for cache hashing; falls back to repr."""
+    target = getattr(formula, "py_func", formula)
+    try:
+        return getsource(target)
+    except (OSError, TypeError):
+        return repr(formula)
+
+
+def _generate_body(compiled, required, idents):
+    """Generate `def _kernel(...): ...` source (no decorator) + bindings.
+
+    Returns (source, bindings, params, outputs):
+      source   - the kernel def as text (function name is the literal _kernel)
+      bindings - {formula_global_name: njit-callable}
+      params   - [(source_name, var_name, identifier)] in kernel-arg order
+      outputs  - [requested_qual_name] in return-tuple order
+    """
+    if not required:
+        raise ValueError("compile_kernel requires at least one requested variable")
+
+    external = set()
+    for vars_ in compiled.required_external_variables.values():
+        external.update(vars_.values())
+
+    ext_sorted = sorted(external, key=lambda v: v.qual_name())
+    params = [(v.source, v.name, idents[v]) for v in ext_sorted]
+
+    bindings = {}
+    lines = []
+    for node in compiled.ordered_nodes:
+        var = node.variable
+        if var in external:
+            continue
+        if var.formula is None:
+            raise ValueError(
+                f"{var.qual_name()!r} has graph placement but no formula; a fused "
+                f"kernel cannot compile it. Provide a formula, or use CompiledGraph."
+            )
+        temp = idents[var]
+        fg = "f_" + temp
+        bindings[fg] = _wrap_formula(var.formula)
+        arg_ids = ", ".join(idents[inp] for inp in node.inputs)
+        in_names = ", ".join(inp.qual_name() for inp in node.inputs)
+        lines.append(f"    {temp} = {fg}({arg_ids})  # {var.qual_name()} = f({in_names})")
+
+    by_qual = {n.variable.qual_name(): n.variable for n in compiled.ordered_nodes}
+    outputs, out_ids = [], []
+    for q in required:
+        var = by_qual.get(q)
+        if var is None:
+            raise ValueError(f"Requested variable {q!r} is not in the compiled graph")
+        outputs.append(q)
+        out_ids.append(idents[var])
+
+    sig = ", ".join(ident for _, _, ident in params)
+    body = "\n".join(lines) if lines else "    pass"
+    ret = f"    return ({', '.join(out_ids)},)"
+    source = f"def _kernel({sig}):\n{body}\n{ret}\n"
+    return source, bindings, params, outputs
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `( cd /home/erik/projects/numbox && venv/bin/python -m pytest test/core/test_compile_kernel.py -q )`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /home/erik/projects/numbox add numbox/core/variable/compile_kernel.py test/core/test_compile_kernel.py
+git -C /home/erik/projects/numbox commit -m "compile_kernel: formula wrapping + straight-line source generation"
+```
+
+---
+
+### Task 3: Compile with content-addressed cache
+
+**Goal:** Add `_compile`, which hashes the kernel source + formula sources, materializes an on-disk anchor, and `exec`s the `@njit(cache=...)` kernel.
+
+**Files:**
+- Modify: `numbox/core/variable/compile_kernel.py`
+- Test: `test/core/test_compile_kernel.py`
+
+**Acceptance Criteria:**
+- [ ] `_compile(source, bindings, jit_options, cache)` returns a numba dispatcher that computes correctly.
+- [ ] A content-addressed anchor file is created under numba's cache dir, subdir `numbox-compile-kernel`.
+- [ ] The anchor path is deterministic for identical (source, formula-sources) and differs when a formula's source differs (collision safety).
+
+**Verify:** `( cd /home/erik/projects/numbox && venv/bin/python -m pytest test/core/test_compile_kernel.py -q )` → all pass
+
+**Steps:**
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# append to test/core/test_compile_kernel.py
+from numbox.core.variable.compile_kernel import _compile, _ANCHOR_SUBDIR
+from numbox.utils.preprocessing import _anchor_root
+
+
+def test_compile_runs():
+    src = "def _kernel(y):\n    x = f_x(y)\n    return (x,)\n"
+    bindings = {"f_x": njit(lambda y: 2 * y)}
+    kernel = _compile(src, bindings, None, True)
+    assert kernel(10) == (20,)
+
+
+def test_compile_anchor_is_content_addressed():
+    root = _anchor_root(_ANCHOR_SUBDIR)
+    src = "def _kernel(y):\n    x = f_x(y)\n    return (x,)\n"
+    _compile(src, {"f_x": njit(lambda y: 2 * y)}, None, True)
+    anchors = sorted(p.name for p in root.glob("_kernel_*.py"))
+    assert anchors, "expected at least one anchor file"
+    # different formula source -> different anchor digest
+    before = set(root.glob("_kernel_*.py"))
+    _compile(src, {"f_x": njit(lambda y: 3 * y)}, None, True)
+    after = set(root.glob("_kernel_*.py"))
+    assert after - before, "different formula must produce a new anchor"
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `( cd /home/erik/projects/numbox && venv/bin/python -m pytest test/core/test_compile_kernel.py -q )`
+Expected: FAIL (ImportError on `_compile`/`_ANCHOR_SUBDIR`)
+
+- [ ] **Step 3: Add `_compile` + anchor setup**
+
+```python
+# add near the top imports of numbox/core/variable/compile_kernel.py
+from numbox.core.configurations import jit_options as _default_jit_options
+from numbox.utils.preprocessing import (
+    _anchor_path, _materialize_anchor, _orphan_anchor_sweep,
+)
+
+_ANCHOR_SUBDIR = "numbox-compile-kernel"
+_orphan_anchor_sweep(_ANCHOR_SUBDIR)
+```
+
+```python
+# append to numbox/core/variable/compile_kernel.py
+def _compile(source, bindings, jit_options, cache):
+    """Content-addressed compile of the kernel source into an @njit dispatcher."""
+    formula_src = "\n".join(_safe_getsource(f) for f in bindings.values())
+    hash_text = source + "\n# formulas:\n" + formula_src
+    digest = hashlib.sha256(hash_text.encode("utf-8")).hexdigest()[:16]
+    name = f"_kernel_{digest}"
+    opts = {**_default_jit_options, **(jit_options or {}), "cache": cache}
+    final_src = "@njit(**_kernel_jit_options)\n" + source.replace(
+        "def _kernel(", f"def {name}(", 1
+    )
+    anchor = _anchor_path(_ANCHOR_SUBDIR, name, hash_text)
+    _materialize_anchor(anchor, final_src)
+    code = compile(final_src, str(anchor), "exec")
+    ns = {**bindings, "njit": njit, "_kernel_jit_options": opts}
+    exec(code, ns)  # nosec B102 - JIT codegen of internal source
+    return ns[name]
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `( cd /home/erik/projects/numbox && venv/bin/python -m pytest test/core/test_compile_kernel.py -q )`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /home/erik/projects/numbox add numbox/core/variable/compile_kernel.py test/core/test_compile_kernel.py
+git -C /home/erik/projects/numbox commit -m "compile_kernel: content-addressed anchor + cached @njit compile"
+```
+
+---
+
+### Task 4: Public API — `CompiledKernel` + `compile_kernel`
+
+**Goal:** Tie the pieces together into the public `compile_kernel(graph, required)` returning a `CompiledKernel` with `.kernel`, `.execute`, `.params`, `.outputs`, `.source`, `.identifiers`.
+
+**Files:**
+- Modify: `numbox/core/variable/compile_kernel.py`
+- Test: `test/core/test_compile_kernel.py`
+
+**Acceptance Criteria:**
+- [ ] `compile_kernel(graph, required)` returns a `CompiledKernel`; `required` accepts `str | list[str]`.
+- [ ] `ck.kernel(*ext)` and `ck.execute({src:{name:val}})` both equal `CompiledGraph.execute` for chain, diamond, mixed-type, multi-output, and single-output graphs.
+- [ ] `ck.execute` raises `KeyError` (naming the qualified variable) when an external value is missing.
+- [ ] Auto-specialization: the same `ck.kernel` works for int then float external input.
+
+**Verify:** `( cd /home/erik/projects/numbox && venv/bin/python -m pytest test/core/test_compile_kernel.py -q )` → all pass
+
+**Steps:**
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# append to test/core/test_compile_kernel.py
+from numbox.core.variable.compile_kernel import compile_kernel, CompiledKernel
+from numbox.core.variable.variable import Values
+
+
+def _pure(graph, required, external_values):
+    compiled = graph.compile(required)
+    values = Values()
+    compiled.execute(external_values, values)
+    by_qual = {n.variable.qual_name(): n.variable for n in compiled.ordered_nodes}
+    return {q: values.get(by_qual[q]).value for q in required}
+
+
+def test_compile_kernel_matches_pure_python_diamond():
+    g = _diamond_graph()
+    req = ["variables.u", "variables.a"]
+    ck = compile_kernel(g, req)
+    assert isinstance(ck, CompiledKernel)
+    ext = {"basket": {"y": 100}}
+    assert ck.execute(ext) == _pure(g, req, ext)
+    # raw kernel: positional in ck.params order, tuple in ck.outputs order
+    assert ck.params == ["basket.y"]
+    assert ck.outputs == req
+    assert tuple(ck.kernel(100)) == tuple(_pure(g, req, ext)[q] for q in req)
+
+
+def test_compile_kernel_single_output_and_str_required():
+    g = _diamond_graph()
+    ck = compile_kernel(g, "variables.u")          # str accepted
+    assert ck.outputs == ["variables.u"]
+    assert ck.execute({"basket": {"y": 100}}) == {"variables.u": 326.5}
+
+
+def test_compile_kernel_auto_specialization():
+    g = _diamond_graph()
+    ck = compile_kernel(g, ["variables.u"])
+    assert ck.execute({"basket": {"y": 100}})["variables.u"] == 326.5
+    assert ck.execute({"basket": {"y": 100.0}})["variables.u"] == 326.5
+
+
+def test_compile_kernel_missing_external_raises():
+    g = _diamond_graph()
+    ck = compile_kernel(g, ["variables.u"])
+    with pytest.raises(KeyError):
+        ck.execute({"basket": {}})
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `( cd /home/erik/projects/numbox && venv/bin/python -m pytest test/core/test_compile_kernel.py -q )`
+Expected: FAIL (ImportError on `compile_kernel`/`CompiledKernel`)
+
+- [ ] **Step 3: Add the wrapper + entry point**
+
+```python
+# add to imports of numbox/core/variable/compile_kernel.py
+from numbox.core.variable.variable import make_qual_name
+```
+
+```python
+# append to numbox/core/variable/compile_kernel.py
+class CompiledKernel:
+    """A fused @njit kernel compiled from a Variable graph.
+
+    Attributes:
+      kernel      - bare numba dispatcher; positional external args (in `params`
+                    order) -> tuple (in `outputs` order). Zero-overhead hot path.
+      params      - external input qual_names, kernel-argument order.
+      outputs     - requested variable qual_names, return-tuple order.
+      source      - generated kernel source text.
+      identifiers - {qual_name: temp identifier} for inspection.
+    """
+
+    def __init__(self, kernel, params, outputs, source, identifiers):
+        self.kernel = kernel
+        self._param_keys = [(src, name) for src, name, _ in params]
+        self.params = [make_qual_name(src, name) for src, name, _ in params]
+        self.outputs = list(outputs)
+        self.source = source
+        self.identifiers = identifiers
+
+    def execute(self, external_values):
+        """Dict-in / dict-out convenience, symmetric with CompiledGraph.execute."""
+        args = []
+        for src, name in self._param_keys:
+            try:
+                args.append(external_values[src][name])
+            except KeyError as e:
+                raise KeyError(
+                    f"Missing external value for {make_qual_name(src, name)!r}"
+                ) from e
+        result = self.kernel(*args)
+        return dict(zip(self.outputs, result))
+
+
+def compile_kernel(graph, required, *, jit_options=None, cache=True):
+    """Compile `graph` into a fused @njit kernel for the `required` variables."""
+    if isinstance(required, str):
+        required = [required]
+    required = list(required)
+    compiled = graph.compile(required)
+    idents = _assign_identifiers([n.variable for n in compiled.ordered_nodes])
+    source, bindings, params, outputs = _generate_body(compiled, required, idents)
+    kernel = _compile(source, bindings, jit_options, cache)
+    identifiers = {v.qual_name(): ident for v, ident in idents.items()}
+    return CompiledKernel(kernel, params, outputs, source, identifiers)
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `( cd /home/erik/projects/numbox && venv/bin/python -m pytest test/core/test_compile_kernel.py -q )`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /home/erik/projects/numbox add numbox/core/variable/compile_kernel.py test/core/test_compile_kernel.py
+git -C /home/erik/projects/numbox commit -m "compile_kernel: CompiledKernel wrapper + public compile_kernel entry point"
+```
+
+---
+
+### Task 5: Robustness — identifier collisions, formula variety, error taxonomy (integration)
+
+**Goal:** Prove the end-to-end pipeline survives adversarial names and formula kinds, and that lazy/eager errors behave as specified.
+
+**Files:**
+- Test: `test/core/test_compile_kernel.py`
+
+**Acceptance Criteria:**
+- [ ] A graph using the `("a_b","c")` vs `("a","b_c")` collision pair compiles and computes both outputs correctly.
+- [ ] A graph with an invalid-char / leading-digit external name compiles and runs.
+- [ ] `cres`-compiled and `@njit` formulas are both callable from the kernel (or — if a `cres` `CompileResultWAP` global is not callable by name — the test documents that and the implementation requires `@njit`; see Spec §14.1).
+- [ ] An auto-wrapped plain-Python formula works; a constant (no-input) formula works; an array-returning formula works.
+- [ ] A non-jittable formula surfaces a numba error at first call (lazy), not at `compile_kernel()` time.
+
+**Verify:** `( cd /home/erik/projects/numbox && venv/bin/python -m pytest test/core/test_compile_kernel.py -q )` → all pass
+
+**Steps:**
+
+- [ ] **Step 1: Write the tests**
+
+```python
+# append to test/core/test_compile_kernel.py
+import numpy as np
+from numba.core.errors import TypingError
+from numbox.utils.highlevel import cres
+from numba.core.types import float64
+
+
+def test_identifier_collision_graph_runs():
+    # two sources whose qual_names sanitize to the same base: a_b.c and a.b_c
+    g = Graph(
+        variables_lists={
+            "a_b": [{"name": "c", "inputs": {"y": "ext"}, "formula": njit(lambda y: y + 1)}],
+            "a": [{"name": "b_c", "inputs": {"y": "ext"}, "formula": njit(lambda y: y + 2)}],
+        },
+        external_source_names=["ext"],
+    )
+    ck = compile_kernel(g, ["a_b.c", "a.b_c"])
+    assert ck.execute({"ext": {"y": 10}}) == {"a_b.c": 11, "a.b_c": 12}
+
+
+def test_invalid_char_external_name_runs():
+    g = Graph(
+        variables_lists={"variables": [
+            {"name": "out", "inputs": {"first-name": "ext"}, "formula": njit(lambda v: v * 2)},
+        ]},
+        external_source_names=["ext"],
+    )
+    ck = compile_kernel(g, ["variables.out"])
+    assert ck.execute({"ext": {"first-name": 5}}) == {"variables.out": 10}
+
+
+def test_cres_and_constant_and_array_formulas():
+    add = cres(float64(float64, float64))(lambda a, b: a + b)
+    g = Graph(
+        variables_lists={"variables": [
+            {"name": "k", "inputs": {}, "formula": njit(lambda: 7.0)},     # constant
+            {"name": "u", "inputs": {"k": "variables", "y": "ext"}, "formula": add},
+            {"name": "arr", "inputs": {"y": "ext"}, "formula": njit(lambda y: np.arange(y))},
+        ]},
+        external_source_names=["ext"],
+    )
+    ck = compile_kernel(g, ["variables.u", "variables.arr"])
+    out = ck.execute({"ext": {"y": 3.0}})
+    assert out["variables.u"] == 10.0
+    assert list(out["variables.arr"]) == [0, 1, 2]
+
+
+def test_non_jittable_formula_fails_at_first_call_not_compile():
+    def bad(x):
+        return open("/tmp/_ck_nope.txt", "w")     # unsupported in nopython
+    g = Graph(
+        variables_lists={"variables": [
+            {"name": "b", "inputs": {"y": "ext"}, "formula": bad},
+        ]},
+        external_source_names=["ext"],
+    )
+    ck = compile_kernel(g, ["variables.b"])        # compiles (lazy) — no raise here
+    with pytest.raises((TypingError, Exception)):
+        ck.execute({"ext": {"y": 1}})              # error surfaces at first call
+```
+
+- [ ] **Step 2: Run; if the `cres` assertion fails (CompileResultWAP not callable by global name)**, change `_wrap_formula` to also `njit`-wrap `CompileResultWAP` inputs OR document `cres` as unsupported (require `@njit`); update the test and Spec §14.1 to match the verified behavior. Re-run.
+
+Run: `( cd /home/erik/projects/numbox && venv/bin/python -m pytest test/core/test_compile_kernel.py -q )`
+Expected: PASS (after reconciling the `cres` finding)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /home/erik/projects/numbox add test/core/test_compile_kernel.py numbox/core/variable/compile_kernel.py
+git -C /home/erik/projects/numbox commit -m "compile_kernel: robustness + formula-variety + error-taxonomy tests"
+```
+
+---
+
+### Task 6: Cross-process cache-collision regression
+
+**Goal:** Prove that two kernels with identical straight-line skeletons but different formulas do not collide in numba's on-disk cache across fresh processes (the verified footgun the content-addressed anchor fixes).
+
+**Files:**
+- Test: `test/core/test_compile_kernel.py`
+
+**Acceptance Criteria:**
+- [ ] In a fresh subprocess, compiling two same-skeleton/different-formula kernels with `cache=True` yields each kernel's own correct result (no cross-load).
+- [ ] Mirrors the existing pattern in `test/core/test_builder.py::test_make_graph_cache_key_content_independent`.
+
+**Verify:** `( cd /home/erik/projects/numbox && venv/bin/python -m pytest test/core/test_compile_kernel.py::test_cache_no_skeleton_collision -q )` → pass
+
+**Steps:**
+
+- [ ] **Step 1: Read the existing pattern**
+
+Read `test/core/test_builder.py::test_make_graph_cache_key_content_independent` to match the subprocess harness style used in this repo.
+
+- [ ] **Step 2: Write the test**
+
+```python
+# append to test/core/test_compile_kernel.py
+import subprocess
+import sys
+import textwrap
+
+
+def test_cache_no_skeleton_collision(tmp_path):
+    # Two kernels: identical skeleton (one leaf -> one formula -> return),
+    # different formulas (x*10 vs x*1000). With cache=True they must NOT
+    # load each other's cached binary.
+    script = textwrap.dedent('''
+        from numba import njit
+        from numbox.core.variable.variable import Graph
+        from numbox.core.variable.compile_kernel import compile_kernel
+
+        def build(mult):
+            g = Graph(
+                variables_lists={"v": [
+                    {"name": "o", "inputs": {"y": "e"}, "formula": njit(lambda y: y * mult)},
+                ]},
+                external_source_names=["e"],
+            )
+            return compile_kernel(g, ["v.o"], cache=True)
+
+        a = build(10)
+        b = build(1000)
+        ra = a.execute({"e": {"y": 1}})["v.o"]
+        rb = b.execute({"e": {"y": 1}})["v.o"]
+        assert ra == 10, ra
+        assert rb == 1000, rb
+        print("OK", ra, rb)
+    ''')
+    f = tmp_path / "ck_cache_probe.py"
+    f.write_text(script)
+    # run twice in fresh interpreters so the second run reads the on-disk cache
+    for _ in range(2):
+        p = subprocess.run([sys.executable, str(f)], capture_output=True, text=True)
+        assert p.returncode == 0, p.stdout + p.stderr
+        assert "OK 10 1000" in p.stdout, p.stdout + p.stderr
+```
+
+- [ ] **Step 3: Run to verify pass**
+
+Run: `( cd /home/erik/projects/numbox && venv/bin/python -m pytest test/core/test_compile_kernel.py::test_cache_no_skeleton_collision -q )`
+Expected: PASS. If it fails (cross-load), the anchor hash in `_compile` is not capturing formula identity — fix `hash_text` to include every formula's source and re-run.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C /home/erik/projects/numbox add test/core/test_compile_kernel.py
+git -C /home/erik/projects/numbox commit -m "compile_kernel: cross-process cache-collision regression test"
+```
+
+---
+
+### Task 7: Documentation
+
+**Goal:** Document `compile_kernel` in the Sphinx docs and confirm the doc build + doc-codeblock lint are clean.
+
+**Files:**
+- Modify: `docs/numbox.core.variable.rst`
+
+**Acceptance Criteria:**
+- [ ] A `compile_kernel` section with prose, a worked example, and `automodule:: numbox.core.variable.compile_kernel`.
+- [ ] `sphinx-build` exits 0 (warning count stable).
+- [ ] `extract_codeblocks.py` reports the new `.rst` python blocks clean at max-line-length 120.
+
+**Verify:**
+```bash
+( cd /home/erik/projects/numbox && venv/bin/sphinx-build -b html docs docs/_build/html ) && \
+( cd /home/erik/projects/numbox && venv/bin/python .github/scripts/extract_codeblocks.py docs --flake8 venv/bin/flake8 )
+```
+→ sphinx exit 0; extract_codeblocks exit 0
+
+**Steps:**
+
+- [ ] **Step 1: Read the current doc** to match heading/automodule style: `docs/numbox.core.variable.rst` (the `[#f1]` footnote already points at the fully-JIT'ed path — cross-reference it).
+
+- [ ] **Step 2: Append a section** to `docs/numbox.core.variable.rst` (keep code-block lines ≤ 120 chars):
+
+```rst
+Compiling a graph to a fused JIT kernel
++++++++++++++++++++++++++++++++++++++++
+
+:func:`numbox.core.variable.compile_kernel.compile_kernel` compiles a graph into
+a single fused ``@njit`` kernel for a requested set of variables. Unlike
+:class:`numbox.core.work.work.Work`, it needs no per-node type information —
+numba infers every interior type from the kernel's runtime arguments — provided
+every ``formula`` is njit-able (plain-Python formulas are auto-wrapped)::
+
+    from numba import njit
+    from numbox.core.variable.variable import Graph
+    from numbox.core.variable.compile_kernel import compile_kernel
+
+    graph = Graph(
+        variables_lists={"variables": [
+            {"name": "x", "inputs": {"y": "basket"}, "formula": njit(lambda y: 2 * y)},
+            {"name": "u", "inputs": {"x": "variables"}, "formula": njit(lambda x: x - 74)},
+        ]},
+        external_source_names=["basket"],
+    )
+
+    ck = compile_kernel(graph, ["variables.u"])
+    assert ck.execute({"basket": {"y": 100}}) == {"variables.u": 126}
+    assert ck.kernel(100) == (126,)
+
+.. automodule:: numbox.core.variable.compile_kernel
+   :members:
+   :show-inheritance:
+```
+
+- [ ] **Step 3: Build + lint docs**
+
+Run the **Verify** commands above. Fix any sphinx warning the new section introduces and any flake8 finding in the `.rst` python block.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C /home/erik/projects/numbox add docs/numbox.core.variable.rst
+git -C /home/erik/projects/numbox commit -m "docs(variable): document compile_kernel (Variable graph -> fused @njit kernel)"
+```
+
+---
+
+### Task 8: Full local CI gate + push readiness
+
+**Goal:** Run every CI check locally (caches cleaned), confirm green, and ready the branch for the fork PR.
+
+**Files:** none (verification only)
+
+**Acceptance Criteria:**
+- [ ] Full pytest suite passes (existing + new), caches cleaned first.
+- [ ] `flake8` clean at the repo config (run from repo root).
+- [ ] `doc-codeblock-flake8` (extract_codeblocks over `docs`) clean.
+- [ ] `lychee` over changed docs clean (the new `.rst` has links, so the empty-diff failIfEmpty case does not apply).
+- [ ] Branch ready; do NOT open the fork PR until the user approves (per workflow rules); upstream PR only on explicit per-PR approval.
+
+**Verify:**
+```bash
+# clean caches
+( cd /home/erik/projects/numbox && venv/bin/python -c "import shutil,pathlib,os; r=pathlib.Path('.'); [shutil.rmtree(p,ignore_errors=True) for p in r.rglob('__pycache__')]; shutil.rmtree(pathlib.Path(os.path.expanduser('~/.cache/numba')),ignore_errors=True)" )
+# full suite
+( cd /home/erik/projects/numbox && venv/bin/python -m pytest -q --durations=20 )
+# lint (repo root for correct .flake8 discovery)
+( cd /home/erik/projects/numbox && venv/bin/flake8 . --count --show-source --statistics )
+# doc code blocks
+( cd /home/erik/projects/numbox && venv/bin/python .github/scripts/extract_codeblocks.py docs --flake8 venv/bin/flake8 )
+```
+→ all green
+
+**Steps:**
+
+- [ ] **Step 1: Run the full gate** (Verify block). Fix anything red.
+- [ ] **Step 2: Report** the test count + lint status to the user. Stop. Await approval before opening the fork PR (then upstream only on explicit approval; exclude `CLAUDE.md` and `docs/superpowers/**` from any upstream PR).
+
+---
+
+## Out of scope (v1 — documented, not bugs)
+
+`cacheable` memoization, incremental `recompute`, `None`-as-value formulas,
+node-identity `load`/`combine`/`harvest`, and a `Variable`→`Work` bridge. Use
+`CompiledGraph` or `Work` for those (Spec §2, §7).

--- a/docs/superpowers/plans/2026-06-07-compile-kernel.md.tasks.json
+++ b/docs/superpowers/plans/2026-06-07-compile-kernel.md.tasks.json
@@ -4,20 +4,20 @@
     {
       "id": 1,
       "subject": "Task 1: Module scaffold + identifier assignment",
-      "status": "pending",
+      "status": "completed",
       "description": "**Goal:** Create `numbox/core/variable/compile_kernel.py` with `_sanitize` and `_assign_identifiers` (unique, valid, readable identifiers; minimal deterministic sha256 suffix only on collision; reserves temp + `f_<temp>`).\n\n**Verify:** `( cd /home/erik/projects/numbox && venv/bin/python -m pytest test/core/test_compile_kernel.py -q )`\n\n```json:metadata\n{\"model\": \"opus\", \"files\": [\"numbox/core/variable/compile_kernel.py\", \"test/core/test_compile_kernel.py\"], \"verifyCommand\": \"( cd /home/erik/projects/numbox && venv/bin/python -m pytest test/core/test_compile_kernel.py -q )\", \"acceptanceCriteria\": [\"_sanitize handles invalid chars/leading digit/empty\", \"_assign_identifiers unique across temps + f_<temp> + reserved\", \"three collision classes resolve\", \"deterministic\"]}\n```"
     },
     {
       "id": 2,
       "subject": "Task 2: Codegen — formula wrapping + source generation",
-      "status": "pending",
+      "status": "completed",
       "blockedBy": [1],
       "description": "**Goal:** Add `_wrap_formula`, `_safe_getsource`, `_generate_body` (CompiledGraph + idents -> source, bindings, params=[(source,name,ident)], outputs). External nodes -> params; ValueError on empty required / non-external formula=None / unknown output.\n\n**Verify:** `( cd /home/erik/projects/numbox && venv/bin/python -m pytest test/core/test_compile_kernel.py -q )`\n\n```json:metadata\n{\"model\": \"opus\", \"files\": [\"numbox/core/variable/compile_kernel.py\", \"test/core/test_compile_kernel.py\"], \"verifyCommand\": \"( cd /home/erik/projects/numbox && venv/bin/python -m pytest test/core/test_compile_kernel.py -q )\", \"acceptanceCriteria\": [\"_wrap_formula passthrough + njit-wrap\", \"_generate_body straight-line source + bindings + params + outputs\", \"external nodes -> params\", \"ValueError on empty/placeholder/unknown-output\"]}\n```"
     },
     {
       "id": 3,
       "subject": "Task 3: Compile with content-addressed cache",
-      "status": "pending",
+      "status": "completed",
       "blockedBy": [2],
       "description": "**Goal:** Add `_compile` (hash source + every formula getsource -> content-addressed anchor via preprocessing `_anchor_path`/`_materialize_anchor`; `@njit(cache=...)` in-source; exec against real anchor). Subdir `numbox-compile-kernel`; `_orphan_anchor_sweep` at import.\n\n**Verify:** `( cd /home/erik/projects/numbox && venv/bin/python -m pytest test/core/test_compile_kernel.py -q )`\n\n```json:metadata\n{\"model\": \"opus\", \"files\": [\"numbox/core/variable/compile_kernel.py\", \"test/core/test_compile_kernel.py\"], \"verifyCommand\": \"( cd /home/erik/projects/numbox && venv/bin/python -m pytest test/core/test_compile_kernel.py -q )\", \"acceptanceCriteria\": [\"_compile returns working dispatcher\", \"content-addressed anchor created\", \"anchor differs when formula source differs\"]}\n```"
     },
@@ -57,5 +57,5 @@
       "description": "**Goal:** Caches cleaned; full pytest --durations=20 green; flake8 . clean (repo root); extract_codeblocks docs clean; lychee on changed docs clean. Report counts; STOP and await user approval before opening fork PR (upstream only on explicit per-PR approval; exclude CLAUDE.md + docs/superpowers/** from upstream).\n\n**Verify:** `( cd /home/erik/projects/numbox && venv/bin/python -m pytest -q --durations=20 ) && ( cd /home/erik/projects/numbox && venv/bin/flake8 . --count --show-source --statistics ) && ( cd /home/erik/projects/numbox && venv/bin/python .github/scripts/extract_codeblocks.py docs --flake8 venv/bin/flake8 )`\n\n```json:metadata\n{\"model\": \"opus\", \"files\": [], \"verifyCommand\": \"( cd /home/erik/projects/numbox && venv/bin/python -m pytest -q --durations=20 ) && ( cd /home/erik/projects/numbox && venv/bin/flake8 . --count --show-source --statistics ) && ( cd /home/erik/projects/numbox && venv/bin/python .github/scripts/extract_codeblocks.py docs --flake8 venv/bin/flake8 )\", \"acceptanceCriteria\": [\"full pytest green caches-cleaned\", \"flake8 clean repo config\", \"doc-codeblock clean\", \"branch ready; no fork PR without approval\"]}\n```"
     }
   ],
-  "lastUpdated": "2026-06-07T22:45:00Z"
+  "lastUpdated": "2026-06-08T00:10:00Z"
 }

--- a/docs/superpowers/plans/2026-06-07-compile-kernel.md.tasks.json
+++ b/docs/superpowers/plans/2026-06-07-compile-kernel.md.tasks.json
@@ -52,10 +52,10 @@
     {
       "id": 8,
       "subject": "Task 8: Full local CI gate + push readiness",
-      "status": "pending",
+      "status": "completed",
       "blockedBy": [5, 6, 7],
       "description": "**Goal:** Caches cleaned; full pytest --durations=20 green; flake8 . clean (repo root); extract_codeblocks docs clean; lychee on changed docs clean. Report counts; STOP and await user approval before opening fork PR (upstream only on explicit per-PR approval; exclude CLAUDE.md + docs/superpowers/** from upstream).\n\n**Verify:** `( cd /home/erik/projects/numbox && venv/bin/python -m pytest -q --durations=20 ) && ( cd /home/erik/projects/numbox && venv/bin/flake8 . --count --show-source --statistics ) && ( cd /home/erik/projects/numbox && venv/bin/python .github/scripts/extract_codeblocks.py docs --flake8 venv/bin/flake8 )`\n\n```json:metadata\n{\"model\": \"opus\", \"files\": [], \"verifyCommand\": \"( cd /home/erik/projects/numbox && venv/bin/python -m pytest -q --durations=20 ) && ( cd /home/erik/projects/numbox && venv/bin/flake8 . --count --show-source --statistics ) && ( cd /home/erik/projects/numbox && venv/bin/python .github/scripts/extract_codeblocks.py docs --flake8 venv/bin/flake8 )\", \"acceptanceCriteria\": [\"full pytest green caches-cleaned\", \"flake8 clean repo config\", \"doc-codeblock clean\", \"branch ready; no fork PR without approval\"]}\n```"
     }
   ],
-  "lastUpdated": "2026-06-08T02:00:00Z"
+  "lastUpdated": "2026-06-08T02:20:00Z"
 }

--- a/docs/superpowers/plans/2026-06-07-compile-kernel.md.tasks.json
+++ b/docs/superpowers/plans/2026-06-07-compile-kernel.md.tasks.json
@@ -38,14 +38,14 @@
     {
       "id": 6,
       "subject": "Task 6: Cross-process cache-collision regression",
-      "status": "pending",
+      "status": "completed",
       "blockedBy": [4],
       "description": "**Goal:** Subprocess test (run twice so 2nd reads on-disk cache): two same-skeleton/different-formula cache=True kernels each return their own result. Mirror test_builder.py::test_make_graph_cache_key_content_independent.\n\n**Verify:** `( cd /home/erik/projects/numbox && venv/bin/python -m pytest test/core/test_compile_kernel.py::test_cache_no_skeleton_collision -q )`\n\n```json:metadata\n{\"model\": \"opus\", \"files\": [\"test/core/test_compile_kernel.py\"], \"verifyCommand\": \"( cd /home/erik/projects/numbox && venv/bin/python -m pytest test/core/test_compile_kernel.py::test_cache_no_skeleton_collision -q )\", \"acceptanceCriteria\": [\"fresh-subprocess same-skeleton/different-formula kernels do not cross-load\", \"mirrors builder cache-independence test\"]}\n```"
     },
     {
       "id": 7,
       "subject": "Task 7: Documentation",
-      "status": "pending",
+      "status": "completed",
       "blockedBy": [4],
       "description": "**Goal:** Add a `compile_kernel` section + worked example + `automodule` to `docs/numbox.core.variable.rst`; sphinx-build exit 0; doc python blocks flake8-clean at max-line-length 120.\n\n**Verify:** `( cd /home/erik/projects/numbox && venv/bin/sphinx-build -b html docs docs/_build/html ) && ( cd /home/erik/projects/numbox && venv/bin/python .github/scripts/extract_codeblocks.py docs --flake8 venv/bin/flake8 )`\n\n```json:metadata\n{\"model\": \"opus\", \"files\": [\"docs/numbox.core.variable.rst\"], \"verifyCommand\": \"( cd /home/erik/projects/numbox && venv/bin/sphinx-build -b html docs docs/_build/html ) && ( cd /home/erik/projects/numbox && venv/bin/python .github/scripts/extract_codeblocks.py docs --flake8 venv/bin/flake8 )\", \"acceptanceCriteria\": [\"compile_kernel rst section + automodule\", \"sphinx-build exit 0\", \"doc python blocks flake8-clean at 120\"]}\n```"
     },
@@ -57,5 +57,5 @@
       "description": "**Goal:** Caches cleaned; full pytest --durations=20 green; flake8 . clean (repo root); extract_codeblocks docs clean; lychee on changed docs clean. Report counts; STOP and await user approval before opening fork PR (upstream only on explicit per-PR approval; exclude CLAUDE.md + docs/superpowers/** from upstream).\n\n**Verify:** `( cd /home/erik/projects/numbox && venv/bin/python -m pytest -q --durations=20 ) && ( cd /home/erik/projects/numbox && venv/bin/flake8 . --count --show-source --statistics ) && ( cd /home/erik/projects/numbox && venv/bin/python .github/scripts/extract_codeblocks.py docs --flake8 venv/bin/flake8 )`\n\n```json:metadata\n{\"model\": \"opus\", \"files\": [], \"verifyCommand\": \"( cd /home/erik/projects/numbox && venv/bin/python -m pytest -q --durations=20 ) && ( cd /home/erik/projects/numbox && venv/bin/flake8 . --count --show-source --statistics ) && ( cd /home/erik/projects/numbox && venv/bin/python .github/scripts/extract_codeblocks.py docs --flake8 venv/bin/flake8 )\", \"acceptanceCriteria\": [\"full pytest green caches-cleaned\", \"flake8 clean repo config\", \"doc-codeblock clean\", \"branch ready; no fork PR without approval\"]}\n```"
     }
   ],
-  "lastUpdated": "2026-06-08T01:05:00Z"
+  "lastUpdated": "2026-06-08T02:00:00Z"
 }

--- a/docs/superpowers/plans/2026-06-07-compile-kernel.md.tasks.json
+++ b/docs/superpowers/plans/2026-06-07-compile-kernel.md.tasks.json
@@ -1,0 +1,61 @@
+{
+  "planPath": "docs/superpowers/plans/2026-06-07-compile-kernel.md",
+  "tasks": [
+    {
+      "id": 1,
+      "subject": "Task 1: Module scaffold + identifier assignment",
+      "status": "pending",
+      "description": "**Goal:** Create `numbox/core/variable/compile_kernel.py` with `_sanitize` and `_assign_identifiers` (unique, valid, readable identifiers; minimal deterministic sha256 suffix only on collision; reserves temp + `f_<temp>`).\n\n**Verify:** `( cd /home/erik/projects/numbox && venv/bin/python -m pytest test/core/test_compile_kernel.py -q )`\n\n```json:metadata\n{\"model\": \"opus\", \"files\": [\"numbox/core/variable/compile_kernel.py\", \"test/core/test_compile_kernel.py\"], \"verifyCommand\": \"( cd /home/erik/projects/numbox && venv/bin/python -m pytest test/core/test_compile_kernel.py -q )\", \"acceptanceCriteria\": [\"_sanitize handles invalid chars/leading digit/empty\", \"_assign_identifiers unique across temps + f_<temp> + reserved\", \"three collision classes resolve\", \"deterministic\"]}\n```"
+    },
+    {
+      "id": 2,
+      "subject": "Task 2: Codegen — formula wrapping + source generation",
+      "status": "pending",
+      "blockedBy": [1],
+      "description": "**Goal:** Add `_wrap_formula`, `_safe_getsource`, `_generate_body` (CompiledGraph + idents -> source, bindings, params=[(source,name,ident)], outputs). External nodes -> params; ValueError on empty required / non-external formula=None / unknown output.\n\n**Verify:** `( cd /home/erik/projects/numbox && venv/bin/python -m pytest test/core/test_compile_kernel.py -q )`\n\n```json:metadata\n{\"model\": \"opus\", \"files\": [\"numbox/core/variable/compile_kernel.py\", \"test/core/test_compile_kernel.py\"], \"verifyCommand\": \"( cd /home/erik/projects/numbox && venv/bin/python -m pytest test/core/test_compile_kernel.py -q )\", \"acceptanceCriteria\": [\"_wrap_formula passthrough + njit-wrap\", \"_generate_body straight-line source + bindings + params + outputs\", \"external nodes -> params\", \"ValueError on empty/placeholder/unknown-output\"]}\n```"
+    },
+    {
+      "id": 3,
+      "subject": "Task 3: Compile with content-addressed cache",
+      "status": "pending",
+      "blockedBy": [2],
+      "description": "**Goal:** Add `_compile` (hash source + every formula getsource -> content-addressed anchor via preprocessing `_anchor_path`/`_materialize_anchor`; `@njit(cache=...)` in-source; exec against real anchor). Subdir `numbox-compile-kernel`; `_orphan_anchor_sweep` at import.\n\n**Verify:** `( cd /home/erik/projects/numbox && venv/bin/python -m pytest test/core/test_compile_kernel.py -q )`\n\n```json:metadata\n{\"model\": \"opus\", \"files\": [\"numbox/core/variable/compile_kernel.py\", \"test/core/test_compile_kernel.py\"], \"verifyCommand\": \"( cd /home/erik/projects/numbox && venv/bin/python -m pytest test/core/test_compile_kernel.py -q )\", \"acceptanceCriteria\": [\"_compile returns working dispatcher\", \"content-addressed anchor created\", \"anchor differs when formula source differs\"]}\n```"
+    },
+    {
+      "id": 4,
+      "subject": "Task 4: Public API — CompiledKernel + compile_kernel",
+      "status": "pending",
+      "blockedBy": [3],
+      "description": "**Goal:** `compile_kernel(graph, required, *, jit_options=None, cache=True)` -> `CompiledKernel` (.kernel, .execute dict-in/dict-out, .params, .outputs, .source, .identifiers). Equivalent to CompiledGraph.execute; missing external -> KeyError; auto-specialization.\n\n**Verify:** `( cd /home/erik/projects/numbox && venv/bin/python -m pytest test/core/test_compile_kernel.py -q )`\n\n```json:metadata\n{\"model\": \"opus\", \"files\": [\"numbox/core/variable/compile_kernel.py\", \"test/core/test_compile_kernel.py\"], \"verifyCommand\": \"( cd /home/erik/projects/numbox && venv/bin/python -m pytest test/core/test_compile_kernel.py -q )\", \"acceptanceCriteria\": [\"compile_kernel returns CompiledKernel; str|list required\", \"kernel + execute match CompiledGraph.execute\", \"missing external -> KeyError\", \"auto-specialization int then float\"]}\n```"
+    },
+    {
+      "id": 5,
+      "subject": "Task 5: Robustness — identifier collisions, formula variety, error taxonomy",
+      "status": "pending",
+      "blockedBy": [4],
+      "description": "**Goal:** Integration tests: a_b.c vs a.b_c collision-pair graph runs; invalid-char/leading-digit external name runs; cres + njit formulas reconciled to verified behavior (Spec §14.1); auto-wrap/constant/array formulas; non-jittable -> error at first call (lazy).\n\n**Verify:** `( cd /home/erik/projects/numbox && venv/bin/python -m pytest test/core/test_compile_kernel.py -q )`\n\n```json:metadata\n{\"model\": \"opus\", \"files\": [\"test/core/test_compile_kernel.py\", \"numbox/core/variable/compile_kernel.py\"], \"verifyCommand\": \"( cd /home/erik/projects/numbox && venv/bin/python -m pytest test/core/test_compile_kernel.py -q )\", \"acceptanceCriteria\": [\"collision-pair graph runs\", \"invalid-char name runs\", \"cres+njit reconciled to verified behavior\", \"auto-wrap/constant/array formulas work\", \"non-jittable fails at first call\"]}\n```"
+    },
+    {
+      "id": 6,
+      "subject": "Task 6: Cross-process cache-collision regression",
+      "status": "pending",
+      "blockedBy": [4],
+      "description": "**Goal:** Subprocess test (run twice so 2nd reads on-disk cache): two same-skeleton/different-formula cache=True kernels each return their own result. Mirror test_builder.py::test_make_graph_cache_key_content_independent.\n\n**Verify:** `( cd /home/erik/projects/numbox && venv/bin/python -m pytest test/core/test_compile_kernel.py::test_cache_no_skeleton_collision -q )`\n\n```json:metadata\n{\"model\": \"opus\", \"files\": [\"test/core/test_compile_kernel.py\"], \"verifyCommand\": \"( cd /home/erik/projects/numbox && venv/bin/python -m pytest test/core/test_compile_kernel.py::test_cache_no_skeleton_collision -q )\", \"acceptanceCriteria\": [\"fresh-subprocess same-skeleton/different-formula kernels do not cross-load\", \"mirrors builder cache-independence test\"]}\n```"
+    },
+    {
+      "id": 7,
+      "subject": "Task 7: Documentation",
+      "status": "pending",
+      "blockedBy": [4],
+      "description": "**Goal:** Add a `compile_kernel` section + worked example + `automodule` to `docs/numbox.core.variable.rst`; sphinx-build exit 0; doc python blocks flake8-clean at max-line-length 120.\n\n**Verify:** `( cd /home/erik/projects/numbox && venv/bin/sphinx-build -b html docs docs/_build/html ) && ( cd /home/erik/projects/numbox && venv/bin/python .github/scripts/extract_codeblocks.py docs --flake8 venv/bin/flake8 )`\n\n```json:metadata\n{\"model\": \"opus\", \"files\": [\"docs/numbox.core.variable.rst\"], \"verifyCommand\": \"( cd /home/erik/projects/numbox && venv/bin/sphinx-build -b html docs docs/_build/html ) && ( cd /home/erik/projects/numbox && venv/bin/python .github/scripts/extract_codeblocks.py docs --flake8 venv/bin/flake8 )\", \"acceptanceCriteria\": [\"compile_kernel rst section + automodule\", \"sphinx-build exit 0\", \"doc python blocks flake8-clean at 120\"]}\n```"
+    },
+    {
+      "id": 8,
+      "subject": "Task 8: Full local CI gate + push readiness",
+      "status": "pending",
+      "blockedBy": [5, 6, 7],
+      "description": "**Goal:** Caches cleaned; full pytest --durations=20 green; flake8 . clean (repo root); extract_codeblocks docs clean; lychee on changed docs clean. Report counts; STOP and await user approval before opening fork PR (upstream only on explicit per-PR approval; exclude CLAUDE.md + docs/superpowers/** from upstream).\n\n**Verify:** `( cd /home/erik/projects/numbox && venv/bin/python -m pytest -q --durations=20 ) && ( cd /home/erik/projects/numbox && venv/bin/flake8 . --count --show-source --statistics ) && ( cd /home/erik/projects/numbox && venv/bin/python .github/scripts/extract_codeblocks.py docs --flake8 venv/bin/flake8 )`\n\n```json:metadata\n{\"model\": \"opus\", \"files\": [], \"verifyCommand\": \"( cd /home/erik/projects/numbox && venv/bin/python -m pytest -q --durations=20 ) && ( cd /home/erik/projects/numbox && venv/bin/flake8 . --count --show-source --statistics ) && ( cd /home/erik/projects/numbox && venv/bin/python .github/scripts/extract_codeblocks.py docs --flake8 venv/bin/flake8 )\", \"acceptanceCriteria\": [\"full pytest green caches-cleaned\", \"flake8 clean repo config\", \"doc-codeblock clean\", \"branch ready; no fork PR without approval\"]}\n```"
+    }
+  ],
+  "lastUpdated": "2026-06-07T22:45:00Z"
+}

--- a/docs/superpowers/plans/2026-06-07-compile-kernel.md.tasks.json
+++ b/docs/superpowers/plans/2026-06-07-compile-kernel.md.tasks.json
@@ -24,14 +24,14 @@
     {
       "id": 4,
       "subject": "Task 4: Public API — CompiledKernel + compile_kernel",
-      "status": "pending",
+      "status": "completed",
       "blockedBy": [3],
       "description": "**Goal:** `compile_kernel(graph, required, *, jit_options=None, cache=True)` -> `CompiledKernel` (.kernel, .execute dict-in/dict-out, .params, .outputs, .source, .identifiers). Equivalent to CompiledGraph.execute; missing external -> KeyError; auto-specialization.\n\n**Verify:** `( cd /home/erik/projects/numbox && venv/bin/python -m pytest test/core/test_compile_kernel.py -q )`\n\n```json:metadata\n{\"model\": \"opus\", \"files\": [\"numbox/core/variable/compile_kernel.py\", \"test/core/test_compile_kernel.py\"], \"verifyCommand\": \"( cd /home/erik/projects/numbox && venv/bin/python -m pytest test/core/test_compile_kernel.py -q )\", \"acceptanceCriteria\": [\"compile_kernel returns CompiledKernel; str|list required\", \"kernel + execute match CompiledGraph.execute\", \"missing external -> KeyError\", \"auto-specialization int then float\"]}\n```"
     },
     {
       "id": 5,
       "subject": "Task 5: Robustness — identifier collisions, formula variety, error taxonomy",
-      "status": "pending",
+      "status": "completed",
       "blockedBy": [4],
       "description": "**Goal:** Integration tests: a_b.c vs a.b_c collision-pair graph runs; invalid-char/leading-digit external name runs; cres + njit formulas reconciled to verified behavior (Spec §14.1); auto-wrap/constant/array formulas; non-jittable -> error at first call (lazy).\n\n**Verify:** `( cd /home/erik/projects/numbox && venv/bin/python -m pytest test/core/test_compile_kernel.py -q )`\n\n```json:metadata\n{\"model\": \"opus\", \"files\": [\"test/core/test_compile_kernel.py\", \"numbox/core/variable/compile_kernel.py\"], \"verifyCommand\": \"( cd /home/erik/projects/numbox && venv/bin/python -m pytest test/core/test_compile_kernel.py -q )\", \"acceptanceCriteria\": [\"collision-pair graph runs\", \"invalid-char name runs\", \"cres+njit reconciled to verified behavior\", \"auto-wrap/constant/array formulas work\", \"non-jittable fails at first call\"]}\n```"
     },
@@ -57,5 +57,5 @@
       "description": "**Goal:** Caches cleaned; full pytest --durations=20 green; flake8 . clean (repo root); extract_codeblocks docs clean; lychee on changed docs clean. Report counts; STOP and await user approval before opening fork PR (upstream only on explicit per-PR approval; exclude CLAUDE.md + docs/superpowers/** from upstream).\n\n**Verify:** `( cd /home/erik/projects/numbox && venv/bin/python -m pytest -q --durations=20 ) && ( cd /home/erik/projects/numbox && venv/bin/flake8 . --count --show-source --statistics ) && ( cd /home/erik/projects/numbox && venv/bin/python .github/scripts/extract_codeblocks.py docs --flake8 venv/bin/flake8 )`\n\n```json:metadata\n{\"model\": \"opus\", \"files\": [], \"verifyCommand\": \"( cd /home/erik/projects/numbox && venv/bin/python -m pytest -q --durations=20 ) && ( cd /home/erik/projects/numbox && venv/bin/flake8 . --count --show-source --statistics ) && ( cd /home/erik/projects/numbox && venv/bin/python .github/scripts/extract_codeblocks.py docs --flake8 venv/bin/flake8 )\", \"acceptanceCriteria\": [\"full pytest green caches-cleaned\", \"flake8 clean repo config\", \"doc-codeblock clean\", \"branch ready; no fork PR without approval\"]}\n```"
     }
   ],
-  "lastUpdated": "2026-06-08T00:10:00Z"
+  "lastUpdated": "2026-06-08T01:05:00Z"
 }

--- a/docs/superpowers/specs/2026-06-07-compile-kernel-design.md
+++ b/docs/superpowers/specs/2026-06-07-compile-kernel-design.md
@@ -187,6 +187,14 @@ Caveat: `lambda` formulas work functionally but their `getsource` is unreliable
 for the cache hash (multiple lambdas can share a source line) — documented, not
 blocked; callers wanting cache stability should use named functions.
 
+Note: `cres`/`CompileResultWAP` formulas and source-less lambdas (defined
+outside any source file) have no recoverable `getsource`, so the cache hash
+falls back to `repr(formula)` (per the `_safe_getsource` docstring); this is
+correctness-safe (repr is unique per object, never a hash collision) but, being
+per-process, gets no cross-process cache reuse. (A `cres` formula additionally
+disables caching of the whole kernel via numba's dynamic-globals rule — see
+§14.1.)
+
 ## 8. Caching (content-addressed)
 
 Reuse `numbox.utils.preprocessing`:
@@ -280,12 +288,17 @@ Code blocks in the `.rst` must be flake8-clean (doc-codeblock-flake8).
 
 ## 14. Open risks / verification items
 
-1. **`cres`-by-global-name callability.** The PoC verified `@njit`
-   (`CPUDispatcher`) globals are callable by name inside the kernel; `cres`
-   returns a `CompileResultWAP` (first-class function value). Whether that is
-   callable by global name inside the kernel must be verified in tests; if not,
-   wrap such formulas (or document `cres` formulas as unsupported, requiring
-   `@njit`).
+1. **`cres`-by-global-name callability. — VERIFIED: works as-is.** The PoC
+   verified `@njit` (`CPUDispatcher`) globals are callable by name inside the
+   kernel; `cres` returns a `CompileResultWAP` (first-class function value).
+   Confirmed by `test_compile_kernel.py::test_cres_formula`: a
+   `CompileResultWAP` bound as a kernel global is callable by name and produces
+   the correct result, with no wrapping needed (no Option A re-`njit`, no Option
+   B fail-fast). Only side effect: numba emits a `NumbaWarning` and disables
+   on-disk caching for that kernel ("uses dynamic globals"), because a
+   `CompileResultWAP` is treated as a dynamic global; the result is still
+   correct, the kernel just recompiles each fresh process. `cres` formulas are
+   therefore supported but not cache-eligible.
 2. **Cache correctness across processes** — covered by the subprocess test, but
    it is the highest-risk area; treat a green subprocess collision test as the
    gate for shipping `cache=True` as the default.

--- a/docs/superpowers/specs/2026-06-07-compile-kernel-design.md
+++ b/docs/superpowers/specs/2026-06-07-compile-kernel-design.md
@@ -193,7 +193,7 @@ falls back to `repr(formula)` (per the `_safe_getsource` docstring); this is
 correctness-safe (repr is unique per object, never a hash collision) but, being
 per-process, gets no cross-process cache reuse. (A `cres` formula additionally
 disables caching of the whole kernel via numba's dynamic-globals rule — see
-§14.1.)
+§14 item 1.)
 
 ## 8. Caching (content-addressed)
 

--- a/docs/superpowers/specs/2026-06-07-compile-kernel-design.md
+++ b/docs/superpowers/specs/2026-06-07-compile-kernel-design.md
@@ -1,0 +1,295 @@
+# Design: `compile_kernel` — fuse a `Variable` graph into one `@njit` kernel
+
+- **Date:** 2026-06-07
+- **Status:** Draft (awaiting review)
+- **Module:** `numbox/core/variable/compile_kernel.py` (new)
+- **Relates to:** `numbox/core/variable/variable.py` (`Graph`/`CompiledGraph`),
+  `numbox/core/work/` (`Work`/`builder.make_graph`),
+  `numbox/utils/preprocessing.py` (anchor machinery),
+  `numbox/utils/highlevel.py` (`cres`).
+
+## 1. Motivation
+
+`core/variable` builds a pure-Python DAG: `Graph.compile(required)` returns a
+`CompiledGraph` that runs each node's `formula` in the Python interpreter
+(`CompiledGraph._calculate`). The formulas *may* be JIT-compiled, but the
+traversal and the value passing between nodes are Python, so every node crossing
+pays interpreter + boxing overhead.
+
+`core/work` already proves that a graph can be turned into JIT-compiled code:
+`builder.make_graph` generates Python source for an `@njit` function, `exec`s it,
+and returns a graph of `Work` structref nodes; `Work.calculate()` walks that
+graph in nopython mode. But `Work` is a *structref graph* — per-node nodes,
+dynamic dispatch through a function pointer, and it **requires per-node numba
+types** (`builder.get_ty = spec.ty or typeof(spec.init_value)`), which a
+`Variable` does not carry.
+
+This module adds a **different compiled target, alongside `Work`**: compile a
+`Variable` graph into a **single fused `@njit` kernel** — straight-line code,
+interior nodes become SSA temporaries, LLVM can inline and fuse arithmetic
+across formulas, and **no per-node type declarations are needed** because numba
+infers every interior type from the kernel's runtime argument types.
+
+A proof-of-concept (run against numba 0.65.1) confirmed the approach end to end:
+a real `Variable` graph compiled to a fused `@njit` kernel produced results
+identical to `CompiledGraph.execute`, auto-specialized on a second input dtype
+with zero annotations, and rejected the boundary cases (non-jitted formula,
+`formula=None` placeholder) as expected.
+
+## 2. Goals / Non-goals
+
+**Goals**
+- `compile_kernel(graph, required)` → a `CompiledKernel` that computes the
+  requested variables as one fused `@njit` function.
+- Reuse, not reimplement: topological order + external-variable discovery come
+  from `Graph.compile`; the content-addressed cache anchor comes from
+  `utils/preprocessing.py`.
+- Correct under the full range of `Variable` name strings (no identifier
+  collisions, no invalid identifiers).
+- Cross-process caching that is *correct* (no skeleton-collision reuse).
+
+**Non-goals (v1) — documented limitations, not bugs**
+- `cacheable` per-node memoization (a `CompiledGraph`-only feature).
+- Incremental `recompute` (a monolithic kernel recomputes everything).
+- Formulas that return Python `None` as a value (no nopython representation).
+- Node-identity `load`/`combine`/`harvest` (Work-only APIs).
+- A `Variable` → `Work`/`Derived` bridge (separate, harder, type-requiring;
+  out of scope here).
+
+For any of those, callers keep using `CompiledGraph` or `Work`.
+
+## 3. Public API
+
+```
+from numbox.core.variable.compile_kernel import compile_kernel
+
+ck = compile_kernel(graph, ["variables.u", "variables.a"],
+                    jit_options=None, cache=True)
+
+# Hot path: bare @njit kernel, positional external args (in ck.params order),
+# returns a tuple (in ck.outputs order). Zero Python overhead.
+u, a = ck.kernel(100)
+
+# Convenience: dict-in / dict-out, symmetric with CompiledGraph.execute.
+out = ck.execute({"basket": {"y": 100}})      # -> {"variables.u": 326.5, "variables.a": 126}
+
+ck.params      # ["basket.y"]                  external inputs, kernel-arg order
+ck.outputs     # ["variables.u", "variables.a"]  requested vars, return-tuple order
+ck.source      # generated kernel source text (with per-line comments)
+ck.identifiers # {qual_name: temp_identifier}  for debugging
+```
+
+- `compile_kernel(graph, required, *, jit_options=None, cache=True)` is a free
+  function (no method added to `Graph`, keeping the capability self-contained
+  and the frozen `Variable` dataclass untouched).
+- `graph` is a `core.variable.variable.Graph`; `required` is `str | list[str]`
+  (same shape `Graph.compile` accepts). Internally calls `graph.compile(required)`.
+- Returns a `CompiledKernel`.
+
+`CompiledKernel` is a small wrapper holding: the compiled `@njit` dispatcher
+(`.kernel`), `.params`, `.outputs`, `.source`, `.identifiers`, and `.execute()`.
+
+## 4. Architecture & data flow
+
+```
+Graph ──compile(required)──▶ CompiledGraph
+                              │  ordered_nodes (topo)            assemble identifiers
+                              │  required_external_variables ──▶ + generate source ──▶ exec ──▶ @njit kernel
+                              ▼                                  (content-addressed anchor + cache)
+                            (reused as-is)                              │
+                                                                       ▼
+                                                              CompiledKernel(.kernel/.execute/...)
+```
+
+`compile_kernel` is one module with internal helpers; the only public symbols
+are `compile_kernel` and `CompiledKernel`.
+
+## 5. Identifier scheme (and why the naive one is unsound)
+
+Node temporaries and formula globals in the generated source need identifiers.
+`qual_name().replace(".", "_")` is **not safe**, because `source`/`name` are
+arbitrary strings (`External.__getitem__` mints a `Variable` for any requested
+name; `VarSpec["name"]` is unvalidated):
+
+1. **Underscore ambiguity** — `.` and `_` both collapse to `_`, so distinct
+   variables alias: `("a_b","c")` → `a_b_c` and `("a","b_c")` → `a_b_c`.
+2. **Invalid identifiers** — `"first-name"`, `"3m"`, spaces, unicode → a
+   `SyntaxError` at `exec` (or a valid-but-wrong identifier).
+3. **Prefix-namespace collision** — a node whose identifier is `f_x` collides
+   with another node `x`'s formula global `f_x`; likewise with injected names
+   (`njit`).
+
+**Chosen scheme: readable name + minimal deterministic suffix.**
+
+- `base = sanitize(qual_name)`: replace every char not in `[A-Za-z0-9_]` with
+  `_`, collapse runs of `_`, strip leading/trailing `_`, lowercase, and prefix
+  `v_` if empty or if it starts with a digit.
+- Assemble all symbols that must be unique **as one namespace**: every node's
+  temp, every formula global (`f_<temp>`), and the injected helper names
+  (`njit`, and any others bound into the exec namespace).
+- Detect collisions at assembly time (we hold all nodes up front). When two
+  symbols would collide, append `_<suffix>`, where `<suffix>` is the shortest
+  prefix of `sha256(true_qual_name).hexdigest()` (lowercase base-16) that makes
+  the whole symbol set unique. Grow the suffix length until unique.
+
+Properties: the common case is clean and readable (`variables_a`); suffixes
+appear only on genuine clashes (`a_b_c_4f`, `a_b_c_9q`); the scheme is
+**deterministic** (suffix seeded from the qual_name, not an RNG), so the
+generated source is byte-stable across runs — which the content-addressed cache
+(§7) depends on. Names never need to be valid Python identifiers; they survive
+only as dict keys in `.execute`/`.params`/`.outputs`.
+
+## 6. Codegen algorithm
+
+Inputs: `compiled.ordered_nodes` (topo order), `compiled.required_external_variables`,
+`required` (the requested qual_names).
+
+1. Build `external_set` = the set of `Variable`s in
+   `required_external_variables` (these become kernel parameters).
+2. Assign each node in `ordered_nodes` an identifier per §5; build
+   `var → identifier` and the formula-global names. Collision resolution runs
+   over the union of all temps + formula globals + injected names.
+3. Parameters: the external nodes, **sorted by qual_name** (deterministic
+   signature); record `params` (qual_names) and the matching identifiers.
+4. For each node in topo order:
+   - external (`variable in external_set`) → it is a parameter; emit nothing.
+   - `formula is None` and **not** external → **raise `ValueError`** (a
+     derived placeholder cannot be compiled).
+   - otherwise → emit `tmp = f_tmp(input_tmps...)` in `variable.inputs` order
+     (the 1:1 input↔formula-arg correspondence the variable docs make
+     load-bearing), with a trailing comment `# <qual_name> = formula(<inputs>)`.
+     Bind the (possibly auto-wrapped, §7) formula as global `f_tmp`.
+5. Outputs: map each requested qual_name to its node's identifier; **raise
+   `ValueError`** if a requested name is absent or never computed. Emit
+   `return (out_tmps,)` (trailing comma → always a tuple, including the
+   single-output case).
+6. Empty `required` → `ValueError`.
+
+The generated function signature is `def kernel(<param tmps>):` decorated with
+`@njit(cache=<cache>, **jit_options)`.
+
+## 7. Formula handling (auto-wrap)
+
+Per derived node's `formula`:
+- plain Python function (`types.FunctionType`, not a numba `Dispatcher`) →
+  wrap with `njit()` (lazy, no signature) and bind the dispatcher.
+- already a numba `Dispatcher` (`@njit`) or a `cres` `CompileResultWAP` → bind
+  as-is.
+- anything else → bind as-is and let numba decide at compile time.
+
+Genuinely non-jittable bodies surface as a numba `TypingError` pointing at the
+formula. Because the kernel is lazily `@njit`-compiled, **that occurs on the
+first `ck.kernel(...)` / `ck.execute(...)` call**, not at `compile_kernel()`
+time (no argument types are known earlier). Structural errors (§6) raise
+eagerly. This eager/lazy split is documented in the API docstring.
+
+Caveat: `lambda` formulas work functionally but their `getsource` is unreliable
+for the cache hash (multiple lambdas can share a source line) — documented, not
+blocked; callers wanting cache stability should use named functions.
+
+## 8. Caching (content-addressed)
+
+Reuse `numbox.utils.preprocessing`:
+- `hash_text` = generated kernel source **+** `getsource()` of every formula in
+  node order. Including formula sources is mandatory: two graphs with identical
+  straight-line skeletons but different formulas must not share a cache entry
+  (a verified failure mode — without it, `cache=True` silently loads the wrong
+  binary).
+- `anchor = _anchor_path("numbox-compile-kernel", "kernel", hash_text)`;
+  `_materialize_anchor(anchor, source)`; `compile(source, str(anchor), "exec")`;
+  fold the digest into the kernel function name too (belt-and-suspenders, as
+  `builder.make_graph` does).
+- `@njit(cache=cache, **jit_options)` over that real on-disk anchor. Compiling
+  exec'd source under `<string>` with `cache=True` raises `RuntimeError`; the
+  anchor file is mandatory whenever caching is on.
+- Call `_orphan_anchor_sweep("numbox-compile-kernel")` at module import.
+
+`jit_options` defaults to `numbox.core.configurations.jit_options` merged with
+the caller's overrides; `cache` defaults to `True`.
+
+## 9. Execution & marshalling
+
+- `ck.kernel(*args)` — the bare dispatcher. Args are the external inputs in
+  `ck.params` order; returns a tuple in `ck.outputs` order. This is the
+  zero-overhead hot path.
+- `ck.execute(external_values)` — accepts the `CompiledGraph.execute` dict shape
+  `{source: {name: value}}`, looks up each param's `(source, name)`, builds the
+  positional args, calls `ck.kernel(*args)`, and zips the returned tuple back to
+  `{qual_name: value}` using `ck.outputs`. A missing external raises a `KeyError`
+  with the qualified name (mirroring `CompiledGraph._assign_external_values`).
+
+## 10. Error taxonomy
+
+| Condition | When | Error |
+|---|---|---|
+| `formula is None` on a non-external node | `compile_kernel()` | `ValueError` |
+| requested name absent / never computed | `compile_kernel()` | `ValueError` |
+| empty `required` | `compile_kernel()` | `ValueError` |
+| cycle in the graph | `graph.compile()` (reused) | `RuntimeError` |
+| missing external value | `ck.execute()` | `KeyError` |
+| non-jittable formula | first `ck.kernel()`/`ck.execute()` | numba `TypingError` |
+
+## 11. Testing (`test/core/test_compile_kernel.py`)
+
+Equivalence vs `CompiledGraph.execute`:
+- chain; diamond (merge point); mixed int/float; constant formula (no inputs);
+  array-returning formula; multi-output `required`; single-output (1-tuple).
+
+Numba behavior:
+- auto-specialization (same kernel, int then float input);
+- `cres` formula and `@njit` formula both callable from the kernel (verify
+  `cres`/`CompileResultWAP`-by-global-name works; if not, document and fall back
+  to plain `@njit` wrapping);
+- auto-wrap of a plain-Python formula.
+
+Identifier safety (regression for §5):
+- the `("a_b","c")` vs `("a","b_c")` alias pair compiles to distinct temps and
+  computes both correctly;
+- a name with invalid chars / leading digit (`"first-name"`, `"3m"`) compiles;
+- the `f_x`-prefix collision case.
+
+Marshalling & errors:
+- `.execute` round-trip; missing-external `KeyError`;
+- `formula=None` placeholder → `ValueError`; unknown/uncomputed output →
+  `ValueError`; empty `required` → `ValueError`.
+
+Caching:
+- two kernels with identical skeleton but different formulas, exercised in a
+  **fresh subprocess**, must not collide (the regression test for the
+  skeleton-collision footgun) — mirror the existing
+  `test_builder.py::test_make_graph_cache_key_content_independent` pattern.
+
+Run via `venv/bin/python -m pytest` from the repo root, caches cleaned first.
+
+## 12. Docs
+
+Extend `docs/numbox.core.variable.rst` with a `compile_kernel` section
+(prose + `automodule:: numbox.core.variable.compile_kernel`) and a short
+worked example. Run `sphinx-build` and confirm exit 0 (warning count stable).
+Code blocks in the `.rst` must be flake8-clean (doc-codeblock-flake8).
+
+## 13. Branch / PR workflow
+
+- Branch: `feat/variable-compile-kernel`, based on the current-upstream synced
+  tip (includes `1c9fb24`).
+- Full local CI gate before push (pytest `--durations=20`, flake8 at the repo
+  config, doc-codeblock-flake8, lychee), caches cleaned first.
+- Fork PR first (bot review). Upstream PR only on explicit per-PR approval.
+- Exclude `CLAUDE.md` and `docs/superpowers/**` (incl. this spec) from any
+  upstream PR.
+
+## 14. Open risks / verification items
+
+1. **`cres`-by-global-name callability.** The PoC verified `@njit`
+   (`CPUDispatcher`) globals are callable by name inside the kernel; `cres`
+   returns a `CompileResultWAP` (first-class function value). Whether that is
+   callable by global name inside the kernel must be verified in tests; if not,
+   wrap such formulas (or document `cres` formulas as unsupported, requiring
+   `@njit`).
+2. **Cache correctness across processes** — covered by the subprocess test, but
+   it is the highest-risk area; treat a green subprocess collision test as the
+   gate for shipping `cache=True` as the default.
+3. **Eager vs lazy errors** — accepted: non-jittable formulas fail at first
+   call. If eager validation is later wanted, add an optional
+   `signature=` / `sample_values=` parameter to force compilation; out of scope
+   for v1.

--- a/docs/superpowers/specs/2026-06-07-compile-kernel-design.md
+++ b/docs/superpowers/specs/2026-06-07-compile-kernel-design.md
@@ -1,7 +1,7 @@
 # Design: `compile_kernel` — fuse a `Variable` graph into one `@njit` kernel
 
 - **Date:** 2026-06-07
-- **Status:** Draft (awaiting review)
+- **Status:** Implemented on `feat/variable-compile-kernel` (8/8 tasks; full local gate green)
 - **Module:** `numbox/core/variable/compile_kernel.py` (new)
 - **Relates to:** `numbox/core/variable/variable.py` (`Graph`/`CompiledGraph`),
   `numbox/core/work/` (`Work`/`builder.make_graph`),
@@ -175,7 +175,9 @@ Per derived node's `formula`:
   wrap with `njit()` (lazy, no signature) and bind the dispatcher.
 - already a numba `Dispatcher` (`@njit`) or a `cres` `CompileResultWAP` → bind
   as-is.
-- anything else → bind as-is and let numba decide at compile time.
+- anything else (any other callable) → `njit`-wrapped like a plain function;
+  a non-njit-able callable then fails eagerly at `compile_kernel()` time when
+  `njit()` is applied, rather than lazily at first call.
 
 Genuinely non-jittable bodies surface as a numba `TypingError` pointing at the
 formula. Because the kernel is lazily `@njit`-compiled, **that occurs on the

--- a/docs/superpowers/specs/2026-06-07-compile-kernel-design.md
+++ b/docs/superpowers/specs/2026-06-07-compile-kernel-design.md
@@ -202,7 +202,10 @@ Reuse `numbox.utils.preprocessing`:
   node order. Including formula sources is mandatory: two graphs with identical
   straight-line skeletons but different formulas must not share a cache entry
   (a verified failure mode — without it, `cache=True` silently loads the wrong
-  binary).
+  binary). The content hash includes each formula's source text **and its
+  closed-over constants** (the formula's closure cell values), so two formulas
+  built by the same closure factory — identical source text, different captured
+  values — get distinct cache entries instead of colliding.
 - `anchor = _anchor_path("numbox-compile-kernel", "kernel", hash_text)`;
   `_materialize_anchor(anchor, source)`; `compile(source, str(anchor), "exec")`;
   fold the digest into the kernel function name too (belt-and-suspenders, as

--- a/numbox/core/variable/compile_kernel.py
+++ b/numbox/core/variable/compile_kernel.py
@@ -82,23 +82,24 @@ def _safe_getsource(formula):
     signature, which would let different bodies collide.
 
     When no source is recoverable (a cres/CompileResultWAP formula, or a lambda
-    defined outside a source file), we fall back to ``repr(formula)``. repr is
-    unique per object, so it never causes a hash *collision* (results stay
-    correct); it is just not stable across processes, so such a formula does
-    not get cross-process cache reuse. The same downgrade applies if a closure
-    cell value has no process-stable ``repr``.
+    defined outside a source file), we fall back to ``repr(formula)`` plus
+    ``id(formula)`` as a per-object discriminator, so the fallback is unique per
+    object even when ``__repr__`` is non-unique -- it never causes a hash
+    *collision* (results stay correct); it is just not stable across processes,
+    so such a formula does not get cross-process cache reuse. The same downgrade
+    applies if a closure cell value has no process-stable ``repr``.
     """
     target = getattr(formula, "py_func", formula)
     try:
         src = getsource(target)
     except (OSError, TypeError):
-        return repr(formula)
+        return f"{repr(formula)} @{id(formula)}"
     closure = getattr(target, "__closure__", None)
     if closure:
         try:
             src += "\n# closure: " + repr([c.cell_contents for c in closure])
         except Exception:  # noqa: BLE001 - unrepr-able cell -> per-object fallback
-            return repr(formula)
+            return f"{repr(formula)} @{id(formula)}"
     return src
 
 

--- a/numbox/core/variable/compile_kernel.py
+++ b/numbox/core/variable/compile_kernel.py
@@ -199,9 +199,7 @@ class CompiledKernel:
 
 def compile_kernel(graph, required, *, jit_options=None, cache=True):
     """Compile `graph` into a fused @njit kernel for the `required` variables."""
-    if isinstance(required, str):
-        required = [required]
-    required = list(required)
+    required = [required] if isinstance(required, str) else list(required)
     compiled = graph.compile(required)
     idents = _assign_identifiers([n.variable for n in compiled.ordered_nodes])
     source, bindings, params, outputs = _generate_body(compiled, required, idents)

--- a/numbox/core/variable/compile_kernel.py
+++ b/numbox/core/variable/compile_kernel.py
@@ -214,6 +214,7 @@ class CompiledKernel:
 def compile_kernel(graph, required, *, jit_options=None, cache=True):
     """Compile `graph` into a fused @njit kernel for the `required` variables."""
     required = [required] if isinstance(required, str) else list(required)
+    required = list(dict.fromkeys(required))  # dedupe, preserve first-seen order
     compiled = graph.compile(required)
     idents = _assign_identifiers([n.variable for n in compiled.ordered_nodes])
     source, bindings, params, outputs = _generate_body(compiled, required, idents)

--- a/numbox/core/variable/compile_kernel.py
+++ b/numbox/core/variable/compile_kernel.py
@@ -14,8 +14,16 @@ from numba import njit
 from numba.core.dispatcher import Dispatcher
 from numba.core.types.function_type import CompileResultWAP
 
+from numbox.core.configurations import jit_options as _default_jit_options
+from numbox.utils.preprocessing import (
+    _anchor_path, _materialize_anchor, _orphan_anchor_sweep,
+)
+
 # Names injected into the kernel exec namespace; identifiers must avoid them.
 _RESERVED = frozenset({"njit", "_kernel_jit_options"})
+
+_ANCHOR_SUBDIR = "numbox-compile-kernel"
+_orphan_anchor_sweep(_ANCHOR_SUBDIR)
 
 
 def _sanitize(qual_name):
@@ -131,3 +139,21 @@ def _generate_body(compiled, required, idents):
     body = ("\n".join(lines) + "\n") if lines else ""
     source = f"def _kernel({sig}):\n{body}{ret}\n"
     return source, bindings, params, outputs
+
+
+def _compile(source, bindings, jit_options, cache):
+    """Content-addressed compile of the kernel source into an @njit dispatcher."""
+    formula_src = "\n".join(_safe_getsource(f) for f in bindings.values())
+    hash_text = source + "\n# formulas:\n" + formula_src
+    digest = hashlib.sha256(hash_text.encode("utf-8")).hexdigest()[:16]
+    name = f"_kernel_{digest}"
+    opts = {**_default_jit_options, **(jit_options or {}), "cache": cache}
+    final_src = "@njit(**_kernel_jit_options)\n" + source.replace(
+        "def _kernel(", f"def {name}(", 1
+    )
+    anchor = _anchor_path(_ANCHOR_SUBDIR, name, hash_text)
+    _materialize_anchor(anchor, final_src)
+    code = compile(final_src, str(anchor), "exec")
+    ns = {**bindings, "njit": njit, "_kernel_jit_options": opts}
+    exec(code, ns)  # nosec B102 - JIT codegen of internal source
+    return ns[name]

--- a/numbox/core/variable/compile_kernel.py
+++ b/numbox/core/variable/compile_kernel.py
@@ -151,7 +151,7 @@ def _compile(source, bindings, jit_options, cache):
     final_src = "@njit(**_kernel_jit_options)\n" + source.replace(
         "def _kernel(", f"def {name}(", 1
     )
-    anchor = _anchor_path(_ANCHOR_SUBDIR, name, hash_text)
+    anchor = _anchor_path(_ANCHOR_SUBDIR, "_kernel", hash_text)
     _materialize_anchor(anchor, final_src)
     code = compile(final_src, str(anchor), "exec")
     # __name__ must be an importable module so numba can rebuild the cached

--- a/numbox/core/variable/compile_kernel.py
+++ b/numbox/core/variable/compile_kernel.py
@@ -1,0 +1,45 @@
+"""Compile a `core.variable` Variable graph into one fused @njit kernel.
+
+Alongside `core.work` (a structref graph), this turns a `Graph`/`CompiledGraph`
+into a single straight-line @njit function whose interior nodes are SSA
+temporaries. No per-node type info is needed: numba infers every interior type
+from the kernel's runtime argument types, provided each formula is njit-able
+(plain-Python formulas are auto-wrapped with njit()).
+"""
+import hashlib
+import re
+
+# Names injected into the kernel exec namespace; identifiers must avoid them.
+_RESERVED = frozenset({"njit", "_kernel_jit_options"})
+
+
+def _sanitize(qual_name):
+    s = re.sub(r"[^0-9A-Za-z_]", "_", qual_name)
+    s = re.sub(r"_+", "_", s).strip("_").lower()
+    if not s or s[0].isdigit():
+        s = "v_" + s
+    return s
+
+
+def _assign_identifiers(variables):
+    """Map each Variable to a unique, valid, readable Python identifier.
+
+    Readable (from the qual_name) with a minimal deterministic sha256 suffix
+    only where names would otherwise collide. Reserves both the node temp `t`
+    and its formula global `f_<t>` so those namespaces never clash, and avoids
+    the injected reserved names.
+    """
+    used = set(_RESERVED)
+    idents = {}
+    for var in variables:
+        base = _sanitize(var.qual_name())
+        digest = hashlib.sha256(var.qual_name().encode("utf-8")).hexdigest()
+        cand = base
+        i = 0
+        while cand in used or ("f_" + cand) in used:
+            i += 1
+            cand = f"{base}_{digest[:i]}"
+        used.add(cand)
+        used.add("f_" + cand)
+        idents[var] = cand
+    return idents

--- a/numbox/core/variable/compile_kernel.py
+++ b/numbox/core/variable/compile_kernel.py
@@ -96,8 +96,8 @@ def _safe_getsource(formula):
     if closure:
         try:
             src += "\n# closure: " + repr([c.cell_contents for c in closure])
-        except Exception:  # noqa: BLE001 - any unrepr-able cell -> conservative tag
-            src += "\n# closure: <unrepr>"
+        except Exception:  # noqa: BLE001 - unrepr-able cell -> per-object fallback
+            return repr(formula)
     return src
 
 

--- a/numbox/core/variable/compile_kernel.py
+++ b/numbox/core/variable/compile_kernel.py
@@ -56,14 +56,23 @@ def _assign_identifiers(variables):
 
 
 def _wrap_formula(formula):
-    """Return an njit-callable for `formula`; plain Python is auto-njit'd."""
+    """Return an njit-callable for `formula`; non-Dispatcher/CompileResultWAP callables are njit-wrapped."""
     if isinstance(formula, (Dispatcher, CompileResultWAP)):
         return formula
     return njit(formula)
 
 
 def _safe_getsource(formula):
-    """Source text of a formula for cache hashing; falls back to repr."""
+    """Source text of a formula, for the content-addressed cache hash.
+
+    Content-sensitive on purpose: two formulas with the same signature but
+    different bodies must hash differently, so we never substitute the
+    signature here. When no source is recoverable (e.g. a cres/CompileResultWAP
+    formula, or a lambda defined outside a source file), we fall back to
+    ``repr(formula)``. repr is unique per object, so it never causes a hash
+    *collision* (results stay correct); it is just not stable across processes,
+    so such a formula does not get cross-process cache reuse.
+    """
     target = getattr(formula, "py_func", formula)
     try:
         return getsource(target)
@@ -118,7 +127,7 @@ def _generate_body(compiled, required, idents):
         out_ids.append(idents[var])
 
     sig = ", ".join(ident for _, _, ident in params)
-    body = "\n".join(lines) if lines else "    pass"
     ret = f"    return ({', '.join(out_ids)},)"
-    source = f"def _kernel({sig}):\n{body}\n{ret}\n"
+    body = ("\n".join(lines) + "\n") if lines else ""
+    source = f"def _kernel({sig}):\n{body}{ret}\n"
     return source, bindings, params, outputs

--- a/numbox/core/variable/compile_kernel.py
+++ b/numbox/core/variable/compile_kernel.py
@@ -74,19 +74,31 @@ def _wrap_formula(formula):
 def _safe_getsource(formula):
     """Source text of a formula, for the content-addressed cache hash.
 
-    Content-sensitive on purpose: two formulas with the same signature but
-    different bodies must hash differently, so we never substitute the
-    signature here. When no source is recoverable (e.g. a cres/CompileResultWAP
-    formula, or a lambda defined outside a source file), we fall back to
-    ``repr(formula)``. repr is unique per object, so it never causes a hash
-    *collision* (results stay correct); it is just not stable across processes,
-    so such a formula does not get cross-process cache reuse.
+    Content-sensitive on purpose: two formulas that differ in body OR in
+    closed-over values must hash differently, so we append the closure cell
+    contents to the recovered source (the source text alone is identical for
+    two lambdas built by the same closure factory). We never substitute the
+    signature, which would let different bodies collide.
+
+    When no source is recoverable (a cres/CompileResultWAP formula, or a lambda
+    defined outside a source file), we fall back to ``repr(formula)``. repr is
+    unique per object, so it never causes a hash *collision* (results stay
+    correct); it is just not stable across processes, so such a formula does
+    not get cross-process cache reuse. The same downgrade applies if a closure
+    cell value has no process-stable ``repr``.
     """
     target = getattr(formula, "py_func", formula)
     try:
-        return getsource(target)
+        src = getsource(target)
     except (OSError, TypeError):
         return repr(formula)
+    closure = getattr(target, "__closure__", None)
+    if closure:
+        try:
+            src += "\n# closure: " + repr([c.cell_contents for c in closure])
+        except Exception:  # noqa: BLE001 - any unrepr-able cell -> conservative tag
+            src += "\n# closure: <unrepr>"
+    return src
 
 
 def _generate_body(compiled, required, idents):

--- a/numbox/core/variable/compile_kernel.py
+++ b/numbox/core/variable/compile_kernel.py
@@ -178,7 +178,8 @@ def _compile(source, bindings, jit_options, cache):
 class CompiledKernel:
     """A fused @njit kernel compiled from a Variable graph.
 
-    Attributes:
+    Attributes::
+
       kernel      - bare numba dispatcher; positional external args (in `params`
                     order) -> tuple (in `outputs` order). Zero-overhead hot path.
       params      - external input qual_names, kernel-argument order.

--- a/numbox/core/variable/compile_kernel.py
+++ b/numbox/core/variable/compile_kernel.py
@@ -38,6 +38,11 @@ def _assign_identifiers(variables):
         i = 0
         while cand in used or ("f_" + cand) in used:
             i += 1
+            if i > len(digest):
+                raise RuntimeError(
+                    f"Cannot assign a unique identifier for {var.qual_name()!r}; "
+                    f"all sha256 prefixes exhausted"
+                )
             cand = f"{base}_{digest[:i]}"
         used.add(cand)
         used.add("f_" + cand)

--- a/numbox/core/variable/compile_kernel.py
+++ b/numbox/core/variable/compile_kernel.py
@@ -7,6 +7,7 @@ from the kernel's runtime argument types, provided each formula is njit-able
 (plain-Python formulas are auto-wrapped with njit()).
 """
 import hashlib
+import keyword
 import re
 
 from inspect import getsource
@@ -50,7 +51,7 @@ def _assign_identifiers(variables):
         digest = hashlib.sha256(var.qual_name().encode("utf-8")).hexdigest()
         cand = base
         i = 0
-        while cand in used or ("f_" + cand) in used:
+        while cand in used or ("f_" + cand) in used or keyword.iskeyword(cand):
             i += 1
             if i > len(digest):
                 raise RuntimeError(
@@ -135,8 +136,8 @@ def _generate_body(compiled, required, idents):
         fg = "f_" + temp
         bindings[fg] = _wrap_formula(var.formula)
         arg_ids = ", ".join(idents[inp] for inp in node.inputs)
-        in_names = ", ".join(inp.qual_name() for inp in node.inputs)
-        lines.append(f"    {temp} = {fg}({arg_ids})  # {var.qual_name()} = f({in_names})")
+        in_names = ", ".join(repr(inp.qual_name()) for inp in node.inputs)
+        lines.append(f"    {temp} = {fg}({arg_ids})  # {var.qual_name()!r} = f({in_names})")
 
     by_qual = {n.variable.qual_name(): n.variable for n in compiled.ordered_nodes}
     outputs, out_ids = [], []

--- a/numbox/core/variable/compile_kernel.py
+++ b/numbox/core/variable/compile_kernel.py
@@ -15,6 +15,7 @@ from numba.core.dispatcher import Dispatcher
 from numba.core.types.function_type import CompileResultWAP
 
 from numbox.core.configurations import jit_options as _default_jit_options
+from numbox.core.variable.variable import make_qual_name
 from numbox.utils.preprocessing import (
     _anchor_path, _materialize_anchor, _orphan_anchor_sweep,
 )
@@ -160,3 +161,50 @@ def _compile(source, bindings, jit_options, cache):
     ns = {**bindings, "njit": njit, "_kernel_jit_options": opts, "__name__": __name__}
     exec(code, ns)  # nosec B102 - JIT codegen of internal source
     return ns[name]
+
+
+class CompiledKernel:
+    """A fused @njit kernel compiled from a Variable graph.
+
+    Attributes:
+      kernel      - bare numba dispatcher; positional external args (in `params`
+                    order) -> tuple (in `outputs` order). Zero-overhead hot path.
+      params      - external input qual_names, kernel-argument order.
+      outputs     - requested variable qual_names, return-tuple order.
+      source      - generated kernel source text.
+      identifiers - {qual_name: temp identifier} for inspection.
+    """
+
+    def __init__(self, kernel, params, outputs, source, identifiers):
+        self.kernel = kernel
+        self._param_keys = [(src, name) for src, name, _ in params]
+        self.params = [make_qual_name(src, name) for src, name, _ in params]
+        self.outputs = list(outputs)
+        self.source = source
+        self.identifiers = identifiers
+
+    def execute(self, external_values):
+        """Dict-in / dict-out convenience, symmetric with CompiledGraph.execute."""
+        args = []
+        for src, name in self._param_keys:
+            try:
+                args.append(external_values[src][name])
+            except KeyError as e:
+                raise KeyError(
+                    f"Missing external value for {make_qual_name(src, name)!r}"
+                ) from e
+        result = self.kernel(*args)
+        return dict(zip(self.outputs, result))
+
+
+def compile_kernel(graph, required, *, jit_options=None, cache=True):
+    """Compile `graph` into a fused @njit kernel for the `required` variables."""
+    if isinstance(required, str):
+        required = [required]
+    required = list(required)
+    compiled = graph.compile(required)
+    idents = _assign_identifiers([n.variable for n in compiled.ordered_nodes])
+    source, bindings, params, outputs = _generate_body(compiled, required, idents)
+    kernel = _compile(source, bindings, jit_options, cache)
+    identifiers = {v.qual_name(): ident for v, ident in idents.items()}
+    return CompiledKernel(kernel, params, outputs, source, identifiers)

--- a/numbox/core/variable/compile_kernel.py
+++ b/numbox/core/variable/compile_kernel.py
@@ -154,6 +154,9 @@ def _compile(source, bindings, jit_options, cache):
     anchor = _anchor_path(_ANCHOR_SUBDIR, name, hash_text)
     _materialize_anchor(anchor, final_src)
     code = compile(final_src, str(anchor), "exec")
-    ns = {**bindings, "njit": njit, "_kernel_jit_options": opts}
+    # __name__ must be an importable module so numba can rebuild the cached
+    # overload's environment in another process (importlib.import_module needs
+    # a real name, not None); mirrors make_graph / make_structref.
+    ns = {**bindings, "njit": njit, "_kernel_jit_options": opts, "__name__": __name__}
     exec(code, ns)  # nosec B102 - JIT codegen of internal source
     return ns[name]

--- a/numbox/core/variable/compile_kernel.py
+++ b/numbox/core/variable/compile_kernel.py
@@ -9,6 +9,11 @@ from the kernel's runtime argument types, provided each formula is njit-able
 import hashlib
 import re
 
+from inspect import getsource
+from numba import njit
+from numba.core.dispatcher import Dispatcher
+from numba.core.types.function_type import CompileResultWAP
+
 # Names injected into the kernel exec namespace; identifiers must avoid them.
 _RESERVED = frozenset({"njit", "_kernel_jit_options"})
 
@@ -48,3 +53,72 @@ def _assign_identifiers(variables):
         used.add("f_" + cand)
         idents[var] = cand
     return idents
+
+
+def _wrap_formula(formula):
+    """Return an njit-callable for `formula`; plain Python is auto-njit'd."""
+    if isinstance(formula, (Dispatcher, CompileResultWAP)):
+        return formula
+    return njit(formula)
+
+
+def _safe_getsource(formula):
+    """Source text of a formula for cache hashing; falls back to repr."""
+    target = getattr(formula, "py_func", formula)
+    try:
+        return getsource(target)
+    except (OSError, TypeError):
+        return repr(formula)
+
+
+def _generate_body(compiled, required, idents):
+    """Generate `def _kernel(...): ...` source (no decorator) + bindings.
+
+    Returns (source, bindings, params, outputs):
+      source   - the kernel def as text (function name is the literal _kernel)
+      bindings - {formula_global_name: njit-callable}
+      params   - [(source_name, var_name, identifier)] in kernel-arg order
+      outputs  - [requested_qual_name] in return-tuple order
+    """
+    if not required:
+        raise ValueError("compile_kernel requires at least one requested variable")
+
+    external = set()
+    for vars_ in compiled.required_external_variables.values():
+        external.update(vars_.values())
+
+    ext_sorted = sorted(external, key=lambda v: v.qual_name())
+    params = [(v.source, v.name, idents[v]) for v in ext_sorted]
+
+    bindings = {}
+    lines = []
+    for node in compiled.ordered_nodes:
+        var = node.variable
+        if var in external:
+            continue
+        if var.formula is None:
+            raise ValueError(
+                f"{var.qual_name()!r} has graph placement but no formula; a fused "
+                f"kernel cannot compile it. Provide a formula, or use CompiledGraph."
+            )
+        temp = idents[var]
+        fg = "f_" + temp
+        bindings[fg] = _wrap_formula(var.formula)
+        arg_ids = ", ".join(idents[inp] for inp in node.inputs)
+        in_names = ", ".join(inp.qual_name() for inp in node.inputs)
+        lines.append(f"    {temp} = {fg}({arg_ids})  # {var.qual_name()} = f({in_names})")
+
+    by_qual = {n.variable.qual_name(): n.variable for n in compiled.ordered_nodes}
+    outputs, out_ids = [], []
+    for q in required:
+        var = by_qual.get(q)
+        if var is None:
+            raise ValueError(f"Requested variable {q!r} is not in the compiled graph")
+        outputs.append(q)
+        out_ids.append(idents[var])
+
+    sig = ", ".join(ident for _, _, ident in params)
+    body = "\n".join(lines) if lines else "    pass"
+    ret = f"    return ({', '.join(out_ids)},)"
+    source = f"def _kernel({sig}):\n{body}\n{ret}\n"
+    return source, bindings, params, outputs

--- a/test/compile_kernel_benchmark.py
+++ b/test/compile_kernel_benchmark.py
@@ -1,0 +1,388 @@
+"""Benchmark: a fused ``compile_kernel`` kernel vs ``CompiledGraph`` execution.
+
+Answers the two questions raised in review of the ``compile_kernel`` PR:
+
+1. How much faster is the single fused ``@njit`` kernel than iterating a
+   ``CompiledGraph`` whose formulas are themselves jitted -- i.e. how much comes
+   from jitting the *iteration over the topologically ordered nodes*, separate
+   from jitting the individual formulas?
+2. With the per-node bindings being ``CPUDispatcher`` objects, how big does the
+   fused kernel's numba cache get and how long does it take to compile for a
+   large graph -- and does lowering the bindings through ``proxy`` (an external
+   call per node instead of an inlined body) help?
+
+The graph under test is a chain of ``N`` distinct arithmetic nodes over 1-d
+float64 arrays (``v_i = f_i(v_{i-1}, b)``), "already ordered", which stresses
+exactly the node iteration. Every node has its own generated formula -- a mix of
+cheap affine ops and (~1/3 of nodes) more expensive transcendentals (sin / cos /
+tanh / exp / sqrt) -- so the graph is genuinely heterogeneous and each node is a
+distinct numba compile, not one of a few ops repeated.
+
+Run it (from the repo root, with numbox installed)::
+
+    python -m test.compile_kernel_benchmark                       # perf, N=200, mixed
+    python -m test.compile_kernel_benchmark --nodes 1000 --size 10000
+    python -m test.compile_kernel_benchmark --profile cheap       # dispatch-bound regime
+    python -m test.compile_kernel_benchmark --compile-report      # + cache/compile
+    python test/compile_kernel_benchmark.py --help
+
+``--profile {cheap,mixed,expensive}`` selects the per-node cost mix, so every
+claim below is reproducible from this one file: ``cheap`` reproduces the
+dispatch-bound regime (large fusion win), ``mixed`` (default) the heterogeneous
+numbers reported here, ``expensive`` the compute-bound extreme.
+
+``--nodes`` drives a linear (depth-N) chain, so it is bounded by Python's
+recursion limit inside ``Graph.compile`` (a recursive topological sort); tested
+to 1000. The fused kernel compile is intentionally slow on a cold cache -- both
+the perf path and the compile report print a heads-up before compiling.
+
+----------------------------------------------------------------------------
+Sample results (AMD Ryzen 5 7640HS, Linux x86-64, CPython 3.12, numba 0.65.1;
+default --profile mixed; your numbers will vary). Hot path, microseconds/call,
+best of 30:
+
+    N=1000, S=1000    fused 3311   cg_execute 6192 (1.9x)   iter-only 5689 (1.7x)   numpy 4829 (1.5x)
+    N=1000, S=10000   fused 32737  cg_execute 62589 (1.9x)  iter-only 38155 (1.2x)  numpy 31135 (0.95x)
+
+The fused kernel is ~1.9x faster than CompiledGraph's public execute here -- far
+less than the >10x it reaches with --profile cheap, because ~1/3 of the nodes do
+transcendental work, so per-node compute now dominates the per-node Python
+dispatch that fusion removes. Isolating the iteration (iter-only) shows the same
+thing: a 1.7x win at S=1000 collapses to 1.2x at S=10000, where fusion roughly
+matches numpy (0.95x). So the jitted-iteration win is large for cheap,
+dispatch-bound graphs and small for compute-bound ones (run --profile cheap vs
+--profile expensive to see both ends).
+
+Compile / cache (--compile-report) at N=1000, cold then warm restart. ``total``
+is the apples-to-apples cold cost (njit formulas compile lazily inside
+kernel_compile, proxy formulas eagerly inside build):
+
+    bindings        total cold   warm restart   on-disk cache
+    CPUDispatcher   ~155 s       ~0.8 s         ~23 MiB   (1 kernel file)
+    proxy           ~168 s       ~114 s (*)     ~1.2 MiB  (kernel only)
+    proxy (cached)  ~172 s       ~3.8 s         ~57 MiB   (~4000 files)
+
+The CPUDispatcher kernel inlines all N distinct bodies -> one ~23 MiB cache,
+~155 s cold compile, fast ~0.8 s warm restart. proxy lowers each node to an
+external call, shrinking the *kernel* cache ~20x to ~1.2 MiB -- but (*) with
+uncached formulas every process recompiles all N (warm restart ~114 s, worse than
+njit). Making the proxy formulas cache=True fixes warm (~3.8 s), but with N
+genuinely-distinct formulas each caches separately, so the *total* footprint
+balloons to ~57 MiB across ~4000 files -- larger than the monolithic njit cache.
+So "proxy = smaller cache" holds for the kernel, but reverses for the whole
+on-disk footprint once the formulas are distinct and made cacheable. proxy also
+needs an explicit signature + a named, source-resolvable function per formula.
+----------------------------------------------------------------------------
+"""
+import argparse
+import importlib.util
+import os
+import pathlib
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+import warnings
+
+import numba
+import numpy
+from numba import njit, float64
+
+from numbox.core.variable.variable import Graph, Values
+from numbox.core.variable.compile_kernel import compile_kernel
+from numbox.core.proxy.proxy import proxy
+
+SIG = float64[:](float64[:], float64[:])
+
+
+# --- formula generation ------------------------------------------------------
+# Each node's formula takes (a, b) -> 1-d float64 array, where `a` is the
+# previous node's value (fed in 1000x deep) and `b` is a fixed external. For the
+# chain to stay finite, the `a`-dependence must be NON-AMPLIFYING: a bounded
+# transcendental of `a`, or an affine `ca*a` with |ca| < 1 (contractive). `b` is
+# constant down the chain, so any O(1) function of `b` is safe. Roughly a third
+# of the nodes use an expensive transcendental (which doubles as the stabilizer).
+#
+# To make every node a genuinely DISTINCT numba compile (not 4 ops cycled), the N
+# functions are emitted into a real importable module, one per source line:
+# numba keys its on-disk cache on (file, lineno), so distinct lines => distinct
+# compiles even where two bodies are structurally similar. A real module file
+# also keeps inspect.getsource/getmodule working, which proxy lowering and
+# compile_kernel's content-addressed cache both require.
+
+def _body(i, profile):
+    """Deterministic, value-bounded, distinct formula body for node ``i``.
+
+    ``profile`` sets the per-node cost mix: 'cheap' (affine only -> dispatch-
+    bound), 'expensive' (transcendental only -> compute-bound), or 'mixed'
+    (~1/3 expensive). Every form is non-amplifying in ``a`` so the chain stays
+    finite; ``b`` is the fixed external, so any O(1) function of it is safe.
+    """
+    ca = round(0.30 + (i % 13) * 0.05, 3)   # 0.30..0.90  (|ca| < 1 -> contractive)
+    cb = round(0.10 + (i % 7) * 0.05, 3)    # 0.10..0.40
+    cc = round(-0.5 + (i % 11) * 0.1, 3)    # small offset
+    cheap_a = [f"{ca}*a", f"-{ca}*a + {cc}", f"{ca}*a - {cb}*b"]
+    exp_a = [
+        f"numpy.sin({ca}*a)",
+        f"numpy.tanh(a - {cb}*b)",
+        f"numpy.cos(a)*{ca}",
+        f"numpy.exp(-numpy.abs({ca}*a))",
+        f"numpy.sqrt(numpy.abs(a))*{ca}",
+    ]
+    cheap_b = [f"{cb}*b", f"{cb}*b*b", f"-{cb}*b"]
+    exp_b = [f"{cb}*numpy.sin(b)", f"{cb}*numpy.abs(b)", f"{cb}*numpy.cos(b)"]
+    if profile == "cheap":
+        a_forms, b_forms = cheap_a, cheap_b
+    elif profile == "expensive":
+        a_forms, b_forms = exp_a, exp_b
+    elif i % 3 == 0:                         # mixed: ~1/3 expensive
+        a_forms, b_forms = exp_a, exp_b
+    else:
+        a_forms, b_forms = cheap_a, cheap_b
+    return f"{a_forms[i % len(a_forms)]} + {b_forms[i % len(b_forms)]}"
+
+
+_FORMULAS_CACHE = {}
+
+
+def _atomic_write(path, text):
+    fd, tmp = tempfile.mkstemp(dir=str(path.parent), prefix=path.name + ".tmp-")
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write(text)
+        os.replace(tmp, path)
+    finally:
+        if os.path.exists(tmp):
+            os.remove(tmp)
+
+
+def load_formulas(n_nodes, profile):
+    """Return ``[f0 .. f{n-1}]``: N genuinely-distinct arithmetic formulas.
+
+    Generated into a real importable module (one function per source line, so
+    each is a distinct numba compile and inspect can recover its source). The
+    module path is content-addressed by ``(profile, n_nodes)`` so subprocess
+    workers in the compile report regenerate an identical module -> stable
+    cross-process cache.
+    """
+    cached = _FORMULAS_CACHE.get((profile, n_nodes))
+    if cached is not None:
+        return cached
+    lines = ["import numpy", "", ""]
+    for i in range(n_nodes):
+        lines += [f"def f{i}(a, b):", f"    return {_body(i, profile)}", "", ""]
+    text = "\n".join(lines)
+    mod_name = f"_ck_bench_formulas_{profile}_{n_nodes}"
+    path = pathlib.Path(tempfile.gettempdir()) / f"{mod_name}.py"
+    # Only (re)write when content actually changes: rewriting bumps the file's
+    # mtime, which invalidates numba's source-stamp and defeats the cross-process
+    # formula cache (the warm proxy_cached restart would recompile every body).
+    if not path.exists() or path.read_text() != text:
+        _atomic_write(path, text)
+    spec = importlib.util.spec_from_file_location(mod_name, path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[mod_name] = module
+    spec.loader.exec_module(module)
+    funcs = [getattr(module, f"f{i}") for i in range(n_nodes)]
+    _FORMULAS_CACHE[(profile, n_nodes)] = funcs
+    return funcs
+
+
+def make_formula(fn, kind):
+    if kind == "njit":
+        return njit(fn)                                      # CPUDispatcher binding
+    if kind == "proxy":
+        return proxy(SIG)(fn)                                # external-call binding
+    if kind == "proxy_cached":
+        return proxy(SIG, jit_options={"cache": True})(fn)   # + cacheable formula
+    raise ValueError(kind)
+
+
+def build_graph(n_nodes, kind, formulas):
+    """Chain of ``n_nodes`` distinct nodes; returns ``(graph, required_qual)``."""
+    specs = [{
+        "name": "v0",
+        "inputs": {"a": "ext", "b": "ext"},
+        "formula": make_formula(formulas[0], kind),
+    }]
+    for i in range(1, n_nodes):
+        specs.append({
+            "name": f"v{i}",
+            "inputs": {f"v{i - 1}": "vars", "b": "ext"},
+            "formula": make_formula(formulas[i], kind),
+        })
+    graph = Graph({"vars": specs}, external_source_names=["ext"])
+    return graph, f"vars.v{n_nodes - 1}"
+
+
+def make_externals(size, seed=0):
+    rng = numpy.random.default_rng(seed)
+    return rng.standard_normal(size), rng.standard_normal(size)
+
+
+def reference_numpy(formulas, a, b):
+    """Pure-numpy evaluation of the same chain (correctness + vectorized baseline)."""
+    v = formulas[0](a, b)
+    for f in formulas[1:]:
+        v = f(v, b)
+    return v
+
+
+def best_median(fn, repeats):
+    """Warm once, then return (best, median) per-call nanoseconds over ``repeats``."""
+    fn()
+    samples = [_timed(fn) for _ in range(repeats)]
+    samples.sort()
+    return samples[0], samples[len(samples) // 2]
+
+
+def _timed(fn):
+    t0 = time.perf_counter_ns()
+    fn()
+    return time.perf_counter_ns() - t0
+
+
+def run_perf(n_nodes, size, repeats, profile):
+    formulas = load_formulas(n_nodes, profile)
+    a, b = make_externals(size)
+    ref = reference_numpy(formulas, a, b)
+    assert numpy.all(numpy.isfinite(ref)), "chain diverged -- a formula is amplifying"
+
+    graph, required = build_graph(n_nodes, "njit", formulas)
+
+    print(f"compiling fused kernel for N={n_nodes} nodes (cold cache is slow)...",
+          flush=True)
+    t0 = time.perf_counter_ns()
+    ck = compile_kernel(graph, required)
+    ck.kernel(a, b)
+    print(f"  fused kernel ready in {(time.perf_counter_ns() - t0) / 1e9:.1f}s",
+          flush=True)
+
+    compiled = graph.compile([required])
+    last_var = {n.variable.qual_name(): n.variable
+                for n in compiled.ordered_nodes}[required]
+
+    # Correctness: fused kernel and CompiledGraph must match pure numpy.
+    fused_out = ck.kernel(a, b)[0]
+    vs0 = Values()
+    compiled.execute({"ext": {"a": a, "b": b}}, vs0)
+    assert numpy.max(numpy.abs(fused_out - ref)) < 1e-9, "fused kernel mismatch"
+    assert numpy.max(numpy.abs(vs0.get(last_var).value - ref)) < 1e-9, "CompiledGraph mismatch"
+
+    # Iteration-only: pre-load externals once (private call -- no public entry
+    # point assigns externals without also iterating), so the timing isolates the
+    # node loop. best_median's warmup primes vs_iter's Value objects, so all timed
+    # reps measure pure iteration + formula dispatch without dict-insertion churn.
+    vs_iter = Values()
+    compiled._assign_external_values({"ext": {"a": a, "b": b}}, vs_iter)
+
+    rows = [
+        ("fused kernel", best_median(lambda: ck.kernel(a, b), repeats)),
+        ("cg_execute", best_median(
+            lambda: compiled.execute({"ext": {"a": a, "b": b}}, Values()), repeats)),
+        ("cg_calculate (iter only)", best_median(
+            lambda: compiled._calculate(compiled.ordered_nodes, vs_iter), repeats)),
+        ("numpy", best_median(lambda: reference_numpy(formulas, a, b), repeats)),
+    ]
+    fused_best = rows[0][1][0]
+
+    print(f"\nhot path, profile={profile}, N={n_nodes} nodes, array size S={size}, "
+          f"best of {repeats} (microseconds/call):")
+    print(f"  {'path':<26}{'best':>10}{'median':>10}{'vs fused':>10}")
+    for name, (best, med) in rows:
+        print(f"  {name:<26}{best / 1e3:10.2f}{med / 1e3:10.2f}{best / fused_best:9.2f}x")
+
+
+# --- compile / cache report (his CPUDispatcher-vs-proxy question) ------------
+# Each measurement runs in a fresh subprocess with an isolated NUMBA_CACHE_DIR so
+# the cache is clean and measurable; the same process re-runs warm to show the
+# cross-process ("post-cache") reload cost.
+
+def _cache_size(cache_dir):
+    files = [p for p in pathlib.Path(cache_dir).rglob("*") if p.suffix in (".nbi", ".nbc")]
+    return sum(p.stat().st_size for p in files), len(files)
+
+
+def _compile_worker(n_nodes, kind, profile):
+    cache_dir = os.environ["NUMBA_CACHE_DIR"]
+    formulas = load_formulas(n_nodes, profile)
+    a, b = make_externals(64)
+    ref = reference_numpy(formulas, a, b)
+
+    t0 = time.perf_counter_ns()
+    graph, required = build_graph(n_nodes, kind, formulas)
+    build_ms = (time.perf_counter_ns() - t0) / 1e6
+
+    cannot_cache = False
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        t1 = time.perf_counter_ns()
+        ck = compile_kernel(graph, required)
+        out = ck.kernel(a, b)[0]
+        kernel_ms = (time.perf_counter_ns() - t1) / 1e6
+        cannot_cache = any(
+            issubclass(w.category, numba.NumbaWarning)
+            and "cannot cache" in str(w.message).lower()
+            for w in caught)
+
+    assert numpy.max(numpy.abs(out - ref)) < 1e-9, "correctness mismatch"
+    size, nfiles = _cache_size(cache_dir)
+    print(f"  {kind:<13} build={build_ms:9.1f}ms  kernel_compile={kernel_ms:10.1f}ms  "
+          f"total={build_ms + kernel_ms:10.1f}ms  cache={size / 1024:9.1f}KiB "
+          f"({nfiles} files)  cacheable={'NO' if cannot_cache else 'yes'}")
+
+
+def run_compile_report(n_nodes, profile):
+    repo_root = pathlib.Path(__file__).resolve().parent.parent
+    print(f"\ncompile / cache report, profile={profile}, N={n_nodes} nodes (COLD "
+          f"writes cache, WARM is a fresh process reusing it; cold compile can "
+          f"take minutes per binding kind -- see docstring):", flush=True)
+    print("  ('total' is the apples-to-apples cost: njit formulas compile inside "
+          "kernel_compile, proxy formulas inside build)", flush=True)
+    for kind in ("njit", "proxy", "proxy_cached"):
+        cache_dir = tempfile.mkdtemp(prefix=f"ck_bench_{kind}_")
+        env = {**os.environ, "NUMBA_CACHE_DIR": cache_dir}
+        try:
+            for label in ("COLD", "WARM"):
+                print(f"{label} ", end="", flush=True)
+                # cwd=repo_root so `-m test.compile_kernel_benchmark` resolves
+                # regardless of where the parent was launched from.
+                subprocess.run(
+                    [sys.executable, "-m", "test.compile_kernel_benchmark",
+                     "--_worker", kind, "--nodes", str(n_nodes),
+                     "--profile", profile],
+                    cwd=repo_root, env=env, check=True)
+        finally:
+            shutil.rmtree(cache_dir, ignore_errors=True)
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument("--nodes", type=int, default=200, help="chain length (default 200)")
+    p.add_argument("--size", type=int, default=1000, help="array length (default 1000)")
+    p.add_argument("--repeats", type=int, default=30, help="timed reps (default 30)")
+    p.add_argument("--profile", choices=("cheap", "mixed", "expensive"), default="mixed",
+                   help="per-node cost mix (default mixed: ~1/3 expensive). 'cheap' "
+                        "is dispatch-bound (big fusion win); 'expensive' compute-bound")
+    p.add_argument("--compile-report", action="store_true",
+                   help="also run the CPUDispatcher-vs-proxy compile/cache comparison")
+    p.add_argument("--_worker", help=argparse.SUPPRESS)  # internal: one compile measurement
+    args = p.parse_args()
+
+    # Graph.compile's topological sort is a recursive DFS; a depth-N chain needs
+    # headroom over the default ~1000 limit. Set here (not at import) so merely
+    # importing this module never perturbs the process-wide recursion limit.
+    sys.setrecursionlimit(20000)
+
+    if args._worker:
+        _compile_worker(args.nodes, args._worker, args.profile)
+        return
+
+    run_perf(args.nodes, args.size, args.repeats, args.profile)
+    if args.compile_report:
+        run_compile_report(args.nodes, args.profile)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/core/test_compile_kernel.py
+++ b/test/core/test_compile_kernel.py
@@ -383,3 +383,20 @@ def test_compile_kernel_duplicate_required_deduped():
     assert ck.outputs == ["variables.u"]
     assert ck.execute({"basket": {"y": 100}}) == {"variables.u": 326.5}
     assert ck.kernel(100) == (326.5,)
+
+
+def test_safe_getsource_repr_fallback_is_per_object():
+    # A callable whose source can't be recovered and whose __repr__ is
+    # non-unique must still hash distinctly per object (via the id() suffix),
+    # so two such formulas never collide in the content-addressed cache.
+    from numbox.core.variable.compile_kernel import _safe_getsource
+
+    class _Konst:
+        def __repr__(self):
+            return "<konst>"
+
+        def __call__(self, x):
+            return x
+
+    a, b = _Konst(), _Konst()
+    assert _safe_getsource(a) != _safe_getsource(b)

--- a/test/core/test_compile_kernel.py
+++ b/test/core/test_compile_kernel.py
@@ -3,14 +3,17 @@ import subprocess
 import sys
 import textwrap
 
+import numpy as np
 import pytest
 from numba import njit
 from numba.core.dispatcher import Dispatcher
+from numba.core.types import float64
 from numbox.core.variable.compile_kernel import (
     _sanitize, _assign_identifiers, _wrap_formula, _generate_body, _compile,
     compile_kernel, CompiledKernel,
 )
 from numbox.core.variable.variable import Variable, Graph, Values
+from numbox.utils.highlevel import cres
 
 
 def test_sanitize_basic():
@@ -223,3 +226,80 @@ def test_compile_kernel_missing_external_source_raises():
     with pytest.raises(KeyError) as exc:
         ck.execute({})                      # entire 'basket' source absent
     assert "basket.y" in str(exc.value)
+
+
+def test_identifier_collision_graph_runs():
+    g = Graph(
+        variables_lists={
+            "a_b": [{"name": "c", "inputs": {"y": "ext"}, "formula": njit(lambda y: y + 1)}],
+            "a": [{"name": "b_c", "inputs": {"y": "ext"}, "formula": njit(lambda y: y + 2)}],
+        },
+        external_source_names=["ext"],
+    )
+    ck = compile_kernel(g, ["a_b.c", "a.b_c"])
+    assert ck.execute({"ext": {"y": 10}}) == {"a_b.c": 11, "a.b_c": 12}
+
+
+def test_invalid_char_external_name_runs():
+    g = Graph(
+        variables_lists={"variables": [
+            {"name": "out", "inputs": {"first-name": "ext"}, "formula": njit(lambda v: v * 2)},
+        ]},
+        external_source_names=["ext"],
+    )
+    ck = compile_kernel(g, ["variables.out"])
+    assert ck.execute({"ext": {"first-name": 5}}) == {"variables.out": 10}
+
+
+def test_constant_and_array_formulas():
+    g = Graph(
+        variables_lists={"variables": [
+            {"name": "k", "inputs": {}, "formula": njit(lambda: 7.0)},
+            {"name": "u", "inputs": {"k": "variables", "y": "ext"}, "formula": njit(lambda k, y: k + y)},
+            {"name": "arr", "inputs": {"y": "ext"}, "formula": njit(lambda y: np.arange(y))},
+        ]},
+        external_source_names=["ext"],
+    )
+    ck = compile_kernel(g, ["variables.u", "variables.arr"])
+    out = ck.execute({"ext": {"y": 3}})
+    assert out["variables.u"] == 10.0
+    assert list(out["variables.arr"]) == [0, 1, 2]
+
+
+def test_autowrap_plain_python_formula():
+    def plain(y):
+        return y * 3
+    g = Graph(
+        variables_lists={"variables": [
+            {"name": "o", "inputs": {"y": "ext"}, "formula": plain},
+        ]},
+        external_source_names=["ext"],
+    )
+    ck = compile_kernel(g, ["variables.o"])
+    assert ck.execute({"ext": {"y": 4}}) == {"variables.o": 12}
+
+
+def test_cres_formula():
+    add = cres(float64(float64, float64))(lambda a, b: a + b)
+    g = Graph(
+        variables_lists={"variables": [
+            {"name": "u", "inputs": {"p": "ext", "q": "ext"}, "formula": add},
+        ]},
+        external_source_names=["ext"],
+    )
+    ck = compile_kernel(g, ["variables.u"])
+    assert ck.execute({"ext": {"p": 1.5, "q": 2.0}}) == {"variables.u": 3.5}
+
+
+def test_non_jittable_formula_fails_at_first_call_not_compile():
+    def bad(y):
+        return open("/tmp/_ck_nope.txt", "w")
+    g = Graph(
+        variables_lists={"variables": [
+            {"name": "b", "inputs": {"y": "ext"}, "formula": bad},
+        ]},
+        external_source_names=["ext"],
+    )
+    ck = compile_kernel(g, ["variables.b"])     # must NOT raise here (lazy)
+    with pytest.raises(Exception):
+        ck.execute({"ext": {"y": 1}})           # error surfaces at first call

--- a/test/core/test_compile_kernel.py
+++ b/test/core/test_compile_kernel.py
@@ -7,6 +7,7 @@ import numpy as np
 import pytest
 from numba import njit
 from numba.core.dispatcher import Dispatcher
+from numba.core.errors import TypingError
 from numba.core.types import float64
 from numbox.core.variable.compile_kernel import (
     _sanitize, _assign_identifiers, _wrap_formula, _generate_body, _compile,
@@ -128,8 +129,6 @@ def test_generate_body_external_as_only_output():
 
 def test_safe_getsource_named_function_and_cres():
     from numbox.core.variable.compile_kernel import _safe_getsource
-    from numbox.utils.highlevel import cres
-    from numba.core.types import float64
 
     @njit
     def named(x):
@@ -280,15 +279,15 @@ def test_autowrap_plain_python_formula():
 
 
 def test_cres_formula():
-    add = cres(float64(float64, float64))(lambda a, b: a + b)
+    sub = cres(float64(float64, float64))(lambda a, b: a - b)
     g = Graph(
         variables_lists={"variables": [
-            {"name": "u", "inputs": {"p": "ext", "q": "ext"}, "formula": add},
+            {"name": "u", "inputs": {"p": "ext", "q": "ext"}, "formula": sub},
         ]},
         external_source_names=["ext"],
     )
     ck = compile_kernel(g, ["variables.u"])
-    assert ck.execute({"ext": {"p": 1.5, "q": 2.0}}) == {"variables.u": 3.5}
+    assert ck.execute({"ext": {"p": 1.5, "q": 2.0}}) == {"variables.u": -0.5}
 
 
 def test_non_jittable_formula_fails_at_first_call_not_compile():
@@ -301,5 +300,5 @@ def test_non_jittable_formula_fails_at_first_call_not_compile():
         external_source_names=["ext"],
     )
     ck = compile_kernel(g, ["variables.b"])     # must NOT raise here (lazy)
-    with pytest.raises(Exception):
+    with pytest.raises(TypingError):
         ck.execute({"ext": {"y": 1}})           # error surfaces at first call

--- a/test/core/test_compile_kernel.py
+++ b/test/core/test_compile_kernel.py
@@ -78,7 +78,9 @@ def test_generate_body_shape():
     assert outputs == ["variables.u", "variables.a"]
     assert source.startswith("def _kernel(")
     assert source.rstrip().endswith(",)")
-    assert set(bindings) == {"f_" + idents[v] for v in idents if v.qual_name() != "basket.y"}
+    external = {v for vs in compiled.required_external_variables.values() for v in vs.values()}
+    expected = {"f_" + idents[n.variable] for n in compiled.ordered_nodes if n.variable not in external}
+    assert set(bindings) == expected
 
 
 def test_generate_body_errors():
@@ -101,3 +103,31 @@ def test_generate_body_errors():
     id2 = _assign_identifiers([n.variable for n in c2.ordered_nodes])
     with pytest.raises(ValueError):
         _generate_body(c2, ["variables.broken"], id2)
+
+
+def test_generate_body_external_as_only_output():
+    g = _diamond_graph()
+    compiled = g.compile(["basket.y"])
+    idents = _assign_identifiers([n.variable for n in compiled.ordered_nodes])
+    source, bindings, params, outputs = _generate_body(compiled, ["basket.y"], idents)
+    assert bindings == {}
+    assert outputs == ["basket.y"]
+    assert "pass" not in source
+    y_ident = params[0][2]
+    assert source == f"def _kernel({y_ident}):\n    return ({y_ident},)\n"
+
+
+def test_safe_getsource_named_function_and_cres():
+    from numbox.core.variable.compile_kernel import _safe_getsource
+    from numbox.utils.highlevel import cres
+    from numba.core.types import float64
+
+    @njit
+    def named(x):
+        return x + 41
+    src = _safe_getsource(named)
+    assert "return x + 41" in src
+
+    wap = cres(float64(float64))(lambda x: x * 2.0)
+    s = _safe_getsource(wap)             # must not raise
+    assert isinstance(s, str) and s      # non-empty (repr fallback is acceptable)

--- a/test/core/test_compile_kernel.py
+++ b/test/core/test_compile_kernel.py
@@ -371,5 +371,15 @@ def test_compile_kernel_newline_in_name_is_safe():
         external_source_names=["e"],
     )
     ck = compile_kernel(g, ["v.o"])
-    assert "\n" not in ck.source.split("# ")[-1].splitlines()[0] or True  # comment stays single-logical-line
+    # the raw newline from the name must not appear unescaped in the generated
+    # source (that would split the trailing comment into an executable line)
+    assert "e.a\nx" not in ck.source
     assert ck.execute({"e": {"a\nx": 10}}) == {"v.o": 11}
+
+
+def test_compile_kernel_duplicate_required_deduped():
+    g = _diamond_graph()
+    ck = compile_kernel(g, ["variables.u", "variables.u"])
+    assert ck.outputs == ["variables.u"]
+    assert ck.execute({"basket": {"y": 100}}) == {"variables.u": 326.5}
+    assert ck.kernel(100) == (326.5,)

--- a/test/core/test_compile_kernel.py
+++ b/test/core/test_compile_kernel.py
@@ -7,9 +7,10 @@ import pytest
 from numba import njit
 from numba.core.dispatcher import Dispatcher
 from numbox.core.variable.compile_kernel import (
-    _sanitize, _assign_identifiers, _wrap_formula, _generate_body, _compile, _ANCHOR_SUBDIR
+    _sanitize, _assign_identifiers, _wrap_formula, _generate_body, _compile, _ANCHOR_SUBDIR,
+    compile_kernel, CompiledKernel,
 )
-from numbox.core.variable.variable import Variable, Graph
+from numbox.core.variable.variable import Variable, Graph, Values
 from numbox.utils.preprocessing import _anchor_root
 
 
@@ -173,3 +174,44 @@ def test_compile_cache_survives_fresh_process(tmp_path):
         p = subprocess.run([sys.executable, str(f)], capture_output=True, text=True, env=env)
         assert p.returncode == 0, p.stdout + p.stderr
         assert "RESULT 20" in p.stdout, p.stdout + p.stderr
+
+
+def _pure(graph, required, external_values):
+    compiled = graph.compile(required)
+    values = Values()
+    compiled.execute(external_values, values)
+    by_qual = {n.variable.qual_name(): n.variable for n in compiled.ordered_nodes}
+    return {q: values.get(by_qual[q]).value for q in required}
+
+
+def test_compile_kernel_matches_pure_python_diamond():
+    g = _diamond_graph()
+    req = ["variables.u", "variables.a"]
+    ck = compile_kernel(g, req)
+    assert isinstance(ck, CompiledKernel)
+    ext = {"basket": {"y": 100}}
+    assert ck.execute(ext) == _pure(g, req, ext)
+    assert ck.params == ["basket.y"]
+    assert ck.outputs == req
+    assert tuple(ck.kernel(100)) == tuple(_pure(g, req, ext)[q] for q in req)
+
+
+def test_compile_kernel_single_output_and_str_required():
+    g = _diamond_graph()
+    ck = compile_kernel(g, "variables.u")
+    assert ck.outputs == ["variables.u"]
+    assert ck.execute({"basket": {"y": 100}}) == {"variables.u": 326.5}
+
+
+def test_compile_kernel_auto_specialization():
+    g = _diamond_graph()
+    ck = compile_kernel(g, ["variables.u"])
+    assert ck.execute({"basket": {"y": 100}})["variables.u"] == 326.5
+    assert ck.execute({"basket": {"y": 100.0}})["variables.u"] == 326.5
+
+
+def test_compile_kernel_missing_external_raises():
+    g = _diamond_graph()
+    ck = compile_kernel(g, ["variables.u"])
+    with pytest.raises(KeyError):
+        ck.execute({"basket": {}})

--- a/test/core/test_compile_kernel.py
+++ b/test/core/test_compile_kernel.py
@@ -2,9 +2,10 @@ import pytest
 from numba import njit
 from numba.core.dispatcher import Dispatcher
 from numbox.core.variable.compile_kernel import (
-    _sanitize, _assign_identifiers, _wrap_formula, _generate_body
+    _sanitize, _assign_identifiers, _wrap_formula, _generate_body, _compile, _ANCHOR_SUBDIR
 )
 from numbox.core.variable.variable import Variable, Graph
+from numbox.utils.preprocessing import _anchor_root
 
 
 def test_sanitize_basic():
@@ -131,3 +132,22 @@ def test_safe_getsource_named_function_and_cres():
     wap = cres(float64(float64))(lambda x: x * 2.0)
     s = _safe_getsource(wap)             # must not raise
     assert isinstance(s, str) and s      # non-empty (repr fallback is acceptable)
+
+
+def test_compile_runs():
+    src = "def _kernel(y):\n    x = f_x(y)\n    return (x,)\n"
+    bindings = {"f_x": njit(lambda y: 2 * y)}
+    kernel = _compile(src, bindings, None, True)
+    assert kernel(10) == (20,)
+
+
+def test_compile_anchor_is_content_addressed():
+    root = _anchor_root(_ANCHOR_SUBDIR)
+    src = "def _kernel(y):\n    x = f_x(y)\n    return (x,)\n"
+    _compile(src, {"f_x": njit(lambda y: 2 * y)}, None, True)
+    anchors = sorted(p.name for p in root.glob("_kernel_*.py"))
+    assert anchors, "expected at least one anchor file"
+    before = set(root.glob("_kernel_*.py"))
+    _compile(src, {"f_x": njit(lambda y: 3 * y)}, None, True)
+    after = set(root.glob("_kernel_*.py"))
+    assert after - before, "different formula must produce a new anchor"

--- a/test/core/test_compile_kernel.py
+++ b/test/core/test_compile_kernel.py
@@ -302,3 +302,39 @@ def test_non_jittable_formula_fails_at_first_call_not_compile():
     ck = compile_kernel(g, ["variables.b"])     # must NOT raise here (lazy)
     with pytest.raises(TypingError):
         ck.execute({"ext": {"y": 1}})           # error surfaces at first call
+
+
+def test_cache_no_skeleton_collision(tmp_path):
+    # Two kernels with identical skeleton (one leaf -> one formula -> return) but
+    # different formulas (y*10 vs y*1000). With cache=True they must NOT load each
+    # other's cached binary. Run twice in fresh interpreters so the 2nd run reads
+    # the on-disk cache.
+    script = textwrap.dedent('''
+        from numba import njit
+        from numbox.core.variable.variable import Graph
+        from numbox.core.variable.compile_kernel import compile_kernel
+
+        def build(mult):
+            g = Graph(
+                variables_lists={"v": [
+                    {"name": "o", "inputs": {"y": "e"}, "formula": njit(lambda y: y * mult)},
+                ]},
+                external_source_names=["e"],
+            )
+            return compile_kernel(g, ["v.o"], cache=True)
+
+        a = build(10)
+        b = build(1000)
+        ra = a.execute({"e": {"y": 1}})["v.o"]
+        rb = b.execute({"e": {"y": 1}})["v.o"]
+        assert ra == 10, ra
+        assert rb == 1000, rb
+        print("OK", ra, rb)
+    ''')
+    f = tmp_path / "ck_cache_probe.py"
+    f.write_text(script)
+    env = {**os.environ, "NUMBA_CACHE_DIR": str(tmp_path / "nbcache")}
+    for _ in range(2):
+        p = subprocess.run([sys.executable, str(f)], capture_output=True, text=True, env=env)
+        assert p.returncode == 0, p.stdout + p.stderr
+        assert "OK 10 1000" in p.stdout, p.stdout + p.stderr

--- a/test/core/test_compile_kernel.py
+++ b/test/core/test_compile_kernel.py
@@ -1,3 +1,8 @@
+import os
+import subprocess
+import sys
+import textwrap
+
 import pytest
 from numba import njit
 from numba.core.dispatcher import Dispatcher
@@ -151,3 +156,20 @@ def test_compile_anchor_is_content_addressed():
     _compile(src, {"f_x": njit(lambda y: 3 * y)}, None, True)
     after = set(root.glob("_kernel_*.py"))
     assert after - before, "different formula must produce a new anchor"
+
+
+def test_compile_cache_survives_fresh_process(tmp_path):
+    script = textwrap.dedent('''
+        from numba import njit
+        from numbox.core.variable.compile_kernel import _compile
+        src = "def _kernel(y):\\n    x = f_x(y)\\n    return (x,)\\n"
+        k = _compile(src, {"f_x": njit(lambda y: 2 * y)}, None, True)
+        print("RESULT", k(10)[0])
+    ''')
+    f = tmp_path / "ck_warm.py"
+    f.write_text(script)
+    env = {**os.environ, "NUMBA_CACHE_DIR": str(tmp_path / "nbcache")}
+    for _ in range(2):
+        p = subprocess.run([sys.executable, str(f)], capture_output=True, text=True, env=env)
+        assert p.returncode == 0, p.stdout + p.stderr
+        assert "RESULT 20" in p.stdout, p.stdout + p.stderr

--- a/test/core/test_compile_kernel.py
+++ b/test/core/test_compile_kernel.py
@@ -7,11 +7,10 @@ import pytest
 from numba import njit
 from numba.core.dispatcher import Dispatcher
 from numbox.core.variable.compile_kernel import (
-    _sanitize, _assign_identifiers, _wrap_formula, _generate_body, _compile, _ANCHOR_SUBDIR,
+    _sanitize, _assign_identifiers, _wrap_formula, _generate_body, _compile,
     compile_kernel, CompiledKernel,
 )
 from numbox.core.variable.variable import Variable, Graph, Values
-from numbox.utils.preprocessing import _anchor_root
 
 
 def test_sanitize_basic():
@@ -147,15 +146,14 @@ def test_compile_runs():
     assert kernel(10) == (20,)
 
 
-def test_compile_anchor_is_content_addressed():
-    root = _anchor_root(_ANCHOR_SUBDIR)
+def test_compile_anchor_is_content_addressed(tmp_path, monkeypatch):
+    import numbox.utils.preprocessing as pp
+    monkeypatch.setattr(pp, "_anchor_root", lambda subdir: tmp_path)
     src = "def _kernel(y):\n    x = f_x(y)\n    return (x,)\n"
     _compile(src, {"f_x": njit(lambda y: 2 * y)}, None, True)
-    anchors = sorted(p.name for p in root.glob("_kernel_*.py"))
-    assert anchors, "expected at least one anchor file"
-    before = set(root.glob("_kernel_*.py"))
+    before = set(tmp_path.glob("_kernel_*.py"))
     _compile(src, {"f_x": njit(lambda y: 3 * y)}, None, True)
-    after = set(root.glob("_kernel_*.py"))
+    after = set(tmp_path.glob("_kernel_*.py"))
     assert after - before, "different formula must produce a new anchor"
 
 
@@ -215,3 +213,11 @@ def test_compile_kernel_missing_external_raises():
     ck = compile_kernel(g, ["variables.u"])
     with pytest.raises(KeyError):
         ck.execute({"basket": {}})
+
+
+def test_compile_kernel_missing_external_source_raises():
+    g = _diamond_graph()
+    ck = compile_kernel(g, ["variables.u"])
+    with pytest.raises(KeyError) as exc:
+        ck.execute({})                      # entire 'basket' source absent
+    assert "basket.y" in str(exc.value)

--- a/test/core/test_compile_kernel.py
+++ b/test/core/test_compile_kernel.py
@@ -152,6 +152,7 @@ def test_compile_anchor_is_content_addressed(tmp_path, monkeypatch):
     src = "def _kernel(y):\n    x = f_x(y)\n    return (x,)\n"
     _compile(src, {"f_x": njit(lambda y: 2 * y)}, None, True)
     before = set(tmp_path.glob("_kernel_*.py"))
+    assert before, "first _compile must create an anchor"
     _compile(src, {"f_x": njit(lambda y: 3 * y)}, None, True)
     after = set(tmp_path.glob("_kernel_*.py"))
     assert after - before, "different formula must produce a new anchor"
@@ -211,8 +212,9 @@ def test_compile_kernel_auto_specialization():
 def test_compile_kernel_missing_external_raises():
     g = _diamond_graph()
     ck = compile_kernel(g, ["variables.u"])
-    with pytest.raises(KeyError):
+    with pytest.raises(KeyError) as exc:
         ck.execute({"basket": {}})
+    assert "basket.y" in str(exc.value)
 
 
 def test_compile_kernel_missing_external_source_raises():

--- a/test/core/test_compile_kernel.py
+++ b/test/core/test_compile_kernel.py
@@ -338,3 +338,38 @@ def test_cache_no_skeleton_collision(tmp_path):
         p = subprocess.run([sys.executable, str(f)], capture_output=True, text=True, env=env)
         assert p.returncode == 0, p.stdout + p.stderr
         assert "OK 10 1000" in p.stdout, p.stdout + p.stderr
+
+
+def test_assign_identifiers_avoids_python_keyword():
+    # qual_name ".for" sanitizes to the keyword "for"; must get a suffix
+    v = Variable(name="for", source="")
+    ident = _assign_identifiers([v])[v]
+    import keyword as _kw
+    assert not _kw.iskeyword(ident)
+    assert ident.startswith("for_")
+
+
+def test_compile_kernel_keyword_node_name():
+    # namespace "_" + variable "for" -> qual_name "_.for" -> sanitizes to "for"
+    g = Graph(
+        variables_lists={"_": [
+            {"name": "for", "inputs": {"y": "e"}, "formula": njit(lambda y: y + 1)},
+        ]},
+        external_source_names=["e"],
+    )
+    ck = compile_kernel(g, ["_.for"])
+    assert ck.execute({"e": {"y": 5}}) == {"_.for": 6}
+
+
+def test_compile_kernel_newline_in_name_is_safe():
+    # an external input name containing a newline must not break the generated
+    # source via the trailing comment
+    g = Graph(
+        variables_lists={"v": [
+            {"name": "o", "inputs": {"a\nx": "e"}, "formula": njit(lambda a: a + 1)},
+        ]},
+        external_source_names=["e"],
+    )
+    ck = compile_kernel(g, ["v.o"])
+    assert "\n" not in ck.source.split("# ")[-1].splitlines()[0] or True  # comment stays single-logical-line
+    assert ck.execute({"e": {"a\nx": 10}}) == {"v.o": 11}

--- a/test/core/test_compile_kernel.py
+++ b/test/core/test_compile_kernel.py
@@ -1,5 +1,10 @@
-from numbox.core.variable.compile_kernel import _sanitize, _assign_identifiers
-from numbox.core.variable.variable import Variable
+import pytest
+from numba import njit
+from numba.core.dispatcher import Dispatcher
+from numbox.core.variable.compile_kernel import (
+    _sanitize, _assign_identifiers, _wrap_formula, _generate_body
+)
+from numbox.core.variable.variable import Variable, Graph
 
 
 def test_sanitize_basic():
@@ -39,3 +44,60 @@ def test_assign_identifiers_invalid_char_and_leading_digit():
     idents = _assign_identifiers([v1, v2])
     assert all(s.isidentifier() for s in idents.values())
     assert idents[v1] != idents[v2]
+
+
+def _diamond_graph():
+    return Graph(
+        variables_lists={"variables": [
+            {"name": "x", "inputs": {"y": "basket"}, "formula": njit(lambda y: 2 * y)},
+            {"name": "a", "inputs": {"x": "variables"}, "formula": njit(lambda x: x - 74)},
+            {"name": "b", "inputs": {"x": "variables"}, "formula": njit(lambda x: x + 0.5)},
+            {"name": "u", "inputs": {"a": "variables", "b": "variables"},
+             "formula": njit(lambda a, b: a + b)},
+        ]},
+        external_source_names=["basket"],
+    )
+
+
+def test_wrap_formula_passthrough_and_wrap():
+    d = njit(lambda x: x)
+    assert _wrap_formula(d) is d
+
+    def plain(x):
+        return x + 1
+    assert isinstance(_wrap_formula(plain), Dispatcher)
+
+
+def test_generate_body_shape():
+    g = _diamond_graph()
+    compiled = g.compile(["variables.u", "variables.a"])
+    idents = _assign_identifiers([n.variable for n in compiled.ordered_nodes])
+    source, bindings, params, outputs = _generate_body(compiled, ["variables.u", "variables.a"], idents)
+    y_var = next(v for v in idents if v.qual_name() == "basket.y")
+    assert params == [("basket", "y", idents[y_var])]
+    assert outputs == ["variables.u", "variables.a"]
+    assert source.startswith("def _kernel(")
+    assert source.rstrip().endswith(",)")
+    assert set(bindings) == {"f_" + idents[v] for v in idents if v.qual_name() != "basket.y"}
+
+
+def test_generate_body_errors():
+    g = _diamond_graph()
+    compiled = g.compile(["variables.u"])
+    idents = _assign_identifiers([n.variable for n in compiled.ordered_nodes])
+    with pytest.raises(ValueError):
+        _generate_body(compiled, [], idents)
+    with pytest.raises(ValueError):
+        _generate_body(compiled, ["variables.nope"], idents)
+
+    gph = Graph(
+        variables_lists={"variables": [
+            {"name": "x", "inputs": {"y": "basket"}, "formula": njit(lambda y: 2 * y)},
+            {"name": "broken", "inputs": {"x": "variables"}, "formula": None},
+        ]},
+        external_source_names=["basket"],
+    )
+    c2 = gph.compile(["variables.broken"])
+    id2 = _assign_identifiers([n.variable for n in c2.ordered_nodes])
+    with pytest.raises(ValueError):
+        _generate_body(c2, ["variables.broken"], id2)

--- a/test/core/test_compile_kernel.py
+++ b/test/core/test_compile_kernel.py
@@ -1,0 +1,33 @@
+from numbox.core.variable.compile_kernel import _sanitize, _assign_identifiers
+from numbox.core.variable.variable import Variable
+
+
+def test_sanitize_basic():
+    assert _sanitize("variables.a") == "variables_a"
+    assert _sanitize("first-name") == "first_name"
+    assert _sanitize("3m") == "v_3m"
+    assert _sanitize("a..b") == "a_b"
+    assert _sanitize("") == "v_"
+
+
+def test_assign_identifiers_unique_and_valid():
+    v1 = Variable(name="c", source="a_b")     # qual a_b.c -> base a_b_c
+    v2 = Variable(name="b_c", source="a")     # qual a.b_c -> base a_b_c (collision)
+    idents = _assign_identifiers([v1, v2])
+    assert idents[v1] != idents[v2]
+    assert all(s.isidentifier() for s in idents.values())
+
+
+def test_assign_identifiers_formula_prefix_collision():
+    node = Variable(name="x", source="variables")        # base variables_x
+    clash = Variable(name="variables_x", source="f")     # base f_variables_x == f_<node temp>
+    idents = _assign_identifiers([node, clash])
+    temps = set(idents.values())
+    fgs = {"f_" + t for t in temps}
+    assert temps.isdisjoint(fgs)                          # no temp equals any formula global
+
+
+def test_assign_identifiers_deterministic():
+    v1 = Variable(name="c", source="a_b")
+    v2 = Variable(name="b_c", source="a")
+    assert _assign_identifiers([v1, v2]) == _assign_identifiers([v1, v2])

--- a/test/core/test_compile_kernel.py
+++ b/test/core/test_compile_kernel.py
@@ -31,3 +31,11 @@ def test_assign_identifiers_deterministic():
     v1 = Variable(name="c", source="a_b")
     v2 = Variable(name="b_c", source="a")
     assert _assign_identifiers([v1, v2]) == _assign_identifiers([v1, v2])
+
+
+def test_assign_identifiers_invalid_char_and_leading_digit():
+    v1 = Variable(name="first-name", source="ext")   # invalid char
+    v2 = Variable(name="3m", source="ext")           # leading digit
+    idents = _assign_identifiers([v1, v2])
+    assert all(s.isidentifier() for s in idents.values())
+    assert idents[v1] != idents[v2]


### PR DESCRIPTION
## Summary

Adds `numbox.core.variable.compile_kernel` — a new capability **alongside** `core.work`: it compiles a `core.variable.variable.Graph` into a single fused `@njit` kernel for a requested set of variables, with interior nodes lowered to SSA temporaries so LLVM can inline/fuse across formulas.

- `compile_kernel(graph, required, *, jit_options=None, cache=True)` → a `CompiledKernel` exposing the bare `.kernel` (positional external args → tuple; zero-overhead hot path) and a dict-in/dict-out `.execute({src: {name: val}})` symmetric with `CompiledGraph.execute`, plus `.params` / `.outputs` / `.source` / `.identifiers`.
- No per-node type declarations are needed — numba infers every interior type from the kernel's runtime arguments; plain-Python formulas are auto-wrapped with `njit()`. This is distinct from `Work`, which builds a structref graph and requires per-node `init_value`/`ty`.
- Cross-process-correct content-addressed caching: the cache hash covers each formula's source **and** its closed-over values (so closure-factory formulas don't collide), reusing the existing `utils/preprocessing` anchor machinery. `core.work` and the frozen `Variable` dataclass are untouched.

Identifiers in the generated source are readable (derived from each variable's qualified name) with a minimal deterministic `sha256` suffix only on genuine collisions, so arbitrary `Variable` name strings (underscores, hyphens, leading digits) can never produce an invalid or aliased identifier.

v1 deliberately leaves out per-node `cacheable` memoization, incremental `recompute`, `None`-as-value formulas, and node-identity load/combine — use `CompiledGraph` or `Work` for those.

Also folds in a one-line CI fix: `link-check` now sets `failIfEmpty: false`, so a code-only or link-less-docs diff no longer fails the link check ("no links found" is not a link-check failure; broken links are still reported via `fail: true`).

Docs: a new `compile_kernel` section in `docs/numbox.core.variable.rst`. The design spec and implementation plan live under `docs/superpowers/` (fork-only; excluded from any future upstream PR).
