### PR TITLE
docs(sqlite-query): state absolute slack bounds in the _query_core trim comment

### DIFF
--- a/numbox/core/bindings/_sqlite_query.py
+++ b/numbox/core/bindings/_sqlite_query.py
@@ -151,8 +151,9 @@ def _query_core(stmt, ncols, offsets, tags, widths, itemsize):
         n += 1
         rc = sqlite3_step(stmt)
     # The bare slice is lifetime-safe (it shares the parent's NRT meminfo via
-    # make_view/impl_ret_borrowed); .copy() only trims the growth slack --
-    # under 2x for n > 16, up to 16x at small n (cap floors at 16).
+    # make_view/impl_ret_borrowed); .copy() only trims the growth slack: in
+    # absolute terms at most one doubling's worth (< n * itemsize bytes) for
+    # n > 16, and at most 16 rows' worth when n <= 16 (cap floors at 16).
     return out_u8[:n * itemsize].copy(), rc
 
 

--- a/numbox/core/bindings/_sqlite_query.py
+++ b/numbox/core/bindings/_sqlite_query.py
@@ -151,9 +151,9 @@ def _query_core(stmt, ncols, offsets, tags, widths, itemsize):
         n += 1
         rc = sqlite3_step(stmt)
     # The bare slice is lifetime-safe (it shares the parent's NRT meminfo via
-    # make_view/impl_ret_borrowed); .copy() only trims the growth slack: in
-    # absolute terms at most one doubling's worth (< n * itemsize bytes) for
-    # n > 16, and at most 16 rows' worth when n <= 16 (cap floors at 16).
+    # make_view/impl_ret_borrowed); .copy() only trims the growth slack, whose
+    # absolute size is under one doubling: less than n rows' worth (n * itemsize
+    # bytes) for n > 16, at most 16 rows' worth when n <= 16 (cap floors at 16).
     return out_u8[:n * itemsize].copy(), rc
 
 


### PR DESCRIPTION
One comment reword in `_query_core`, responding to [Goykhman's post-merge note](https://github.com/Goykhman/numbox/pull/22#discussion_r3392624520) on the upstream phase-5 PR that the 2x/16x ratios implied the opposite of the absolute memory magnitudes. The trim comment now states the absolute slack bounds instead: less than `n * itemsize` (one doubling's worth) for n > 16, at most 16 rows' worth below that. No code change.
