### PR TITLE
Sync main with upstream (2026-06-15): upstream #26 variable refactor

### DIFF
--- a/docs/numbox.core.variable.rst
+++ b/docs/numbox.core.variable.rst
@@ -73,6 +73,15 @@ The variable specification for `inputs` (if any) includes both the names of the 
 required to calculate the given variable via the function given by the `formula`,
 as well as the namespaces where these variables are going to be looked for in.
 
+Graph end nodes, located at the edge of the graph (a.k.a., leaf nodes) have neither `inputs`
+nor `formula` in their specifications. Specifying `formula` without `inputs`
+will not result in an exception, accommodating for the case of a function
+that computes and returns a value independent of any input parameters.
+It is also possible to specify `inputs`
+but no formula, which technically defines the placement of the node
+on the graph but leaves it up to the developer to defer specifying the node's calculation
+logic until later in the runtime.
+
 Names of the 'external' sources (of data values) need to be given to the `Graph` as well,
 via the `external_source_names` argument.
 When the :class:`numbox.core.variable.variable.Graph` is compiled

--- a/docs/numbox.core.variable.rst
+++ b/docs/numbox.core.variable.rst
@@ -73,34 +73,6 @@ The variable specification for `inputs` (if any) includes both the names of the 
 required to calculate the given variable via the function given by the `formula`,
 as well as the namespaces where these variables are going to be looked for in.
 
-Graph end nodes, located at the edge of the graph (a.k.a., leaf nodes) have neither `inputs`
-nor `formula` in their specifications. Specifying `formula` without `inputs`
-will not result in an exception, accommodating for the case of a function
-that computes and returns a value independent of any input parameters.
-It is also possible to specify `inputs`
-but no formula, which technically defines the placement of the node
-on the graph but leaves it up to the developer to defer specifying the node's calculation
-logic until later in the runtime.
-
-The variable can be specified as `cacheable` if its value calculated for the given tuple of
-arguments can be cached and later retrieved without re-calculation provided
-the arguments have not changed. The arguments types of the corresponding `formula` then need to be hashable -
-custom type sub-classing with its own `__hash__` might be needed in certain cases, thereby providing the definition
-of the identity of the arguments' values.
-When `cacheable=True` (by default it is `False`), the graph will avoid recalculation of the
-value provided the inputs haven't changed. It is not recommended to abuse the cache, especially
-for the continuous or large-cardinality spaces of identities of the parameters of the node's `formula`.
-
-It is worth noting here that the `cacheable` key is a rather brute force way
-to avoid identical re-computations.
-It is completely unrelated to the graph's dependency structure.
-On the other hand, the graph's `recompute`
-method, discussed below, only recomputes the values of variables that are dependent on the nodes
-that have been updated. That is, the strategy of the `recompute` method
-is determined by the graph's topology only
-and is independent of the `cacheable` specifications of the nodes'
-variables.
-
 Names of the 'external' sources (of data values) need to be given to the `Graph` as well,
 via the `external_source_names` argument.
 When the :class:`numbox.core.variable.variable.Graph` is compiled

--- a/numbox/core/variable/variable.py
+++ b/numbox/core/variable/variable.py
@@ -260,6 +260,7 @@ class CompiledGraph:
     required_external_variables: dict[str, dict[str, Variable]]
     debug: bool = False
     dependents: dict[Variable, list[CompiledNode]] = field(default_factory=lambda: {})
+    affected_cache: dict[frozenset[Variable], list[CompiledNode]] = field(default_factory=lambda: {})
 
     def __post_init__(self):
         for node in self.ordered_nodes:
@@ -319,6 +320,10 @@ class CompiledGraph:
         affected by `changed_vars`, in the same order as in the
         `self.ordered_nodes`.
         """
+        key = frozenset(changed_vars)
+        cached = self.affected_cache.get(key)
+        if cached is not None:
+            return cached
         affected = set()
         stack = list(changed_vars)
         while stack:
@@ -327,7 +332,9 @@ class CompiledGraph:
                 if node not in affected:
                     affected.add(node)
                     stack.append(node.variable)
-        return [node for node in self.ordered_nodes if node in affected]
+        affected_list = [node for node in self.ordered_nodes if node in affected]
+        self.affected_cache[key] = affected_list
+        return affected_list
 
     def _calculate(self, nodes: list[CompiledNode], values: Storage):
         """

--- a/numbox/core/variable/variable.py
+++ b/numbox/core/variable/variable.py
@@ -43,7 +43,6 @@ class Namespace(ABC):
 
 class Storage(Protocol):
     _values: dict['Variable', 'Value']
-    cache: dict[tuple['Variable', tuple[Any, ...]], 'VarValue']
 
     def get(self, variable: 'Variable') -> 'Value':
         """
@@ -220,7 +219,6 @@ class Values:
     will be held here. """
     def __init__(self):
         self._values: dict[Variable, Value] = {}
-        self.cache: dict[tuple['Variable', tuple[Any, ...]], VarValue] = {}
 
     def get(self, variable: Variable) -> Value:
         if variable not in self._values:
@@ -338,7 +336,7 @@ class CompiledGraph:
         All inputs need to be calculated first (i.e., to be non-`_null`)
         before the value of the given `Variable` can be `_calculate`d.
         This is possible because the `Variable`s in the list `nodes` are
-        supplied as a topologically ordered list `self.ordered_variables`,
+        supplied as a topologically ordered list `self.ordered_nodes`,
         or as an ordered sub-set thereof (see, e.g., `recompute`).
         """
         for node in nodes:
@@ -348,7 +346,7 @@ class CompiledGraph:
             for i, input_ in enumerate(node.inputs):
                 arg = values.get(input_).value
                 if arg is _null:
-                    raise RuntimeError(f"Uninitialized input for {node.variable}")
+                    raise RuntimeError(f"Uninitialized input {input_.qual_name()} for {node.variable}")
                 args[i] = arg
             if self.debug:
                 print(f"Calculating {node}\nwith metadata\n{node.variable.metadata}", file=sys.stderr)
@@ -448,7 +446,7 @@ class Graph:
             return variables_source
         raise KeyError(f"Unknown source {source_name}")
 
-    def _topological_order(self, required: list[str] | tuple[str] | str) -> tuple[list[Variable], set[Variable]]:
+    def _topological_order(self, required: list[str]) -> tuple[list[Variable], set[Variable]]:
         """
         :param required: qualified name(s) of `Variable` instance(s)
         for which a topological ordering of a DAG is to be determined.

--- a/numbox/core/variable/variable.py
+++ b/numbox/core/variable/variable.py
@@ -26,8 +26,10 @@ class Namespace(ABC):
     def __contains__(self, key: str) -> bool:
         """
         :param key: un-qualified name of the `Variable`
-        It is qualified with `self.name` - the name of this
-        `Namespace` namespace that the `Variable` belongs to.
+        searched for in this namespace.
+        If `in` thereby returns True, it means that the
+        found `Variable` is qualified with `self.name`,
+        the name of this `Namespace` namespace.
         """
         return key in self._variables
 
@@ -150,13 +152,14 @@ class Variable:
     inputs (which are names of other `Variable` instances) to
     names of their `Namespace`s.
     :param formula: (optional) function that calculates the
-    value of this `Variable` from its sources.
+    value of this `Variable` from its inputs.
     :param metadata: any possible metadata associated with
     this variable.
     :param cacheable: (default `False`) when `True`, the
     corresponding `Value` (see below) will be cached during
     calculation. When attempting to recompute with the same
-    inputs, cached value will be returned instead. Use sparingly!
+    inputs, cached value will be returned instead.
+    Use sparingly!
     """
     name: str
     source: str = field(default="")
@@ -216,7 +219,7 @@ class Value:
     `Values` storage.
     """
     variable: Variable
-    value: VarValue | _Null = field(default_factory=lambda: _null)
+    value: VarValue | _Null = field(default=_null)
 
 
 class Values:
@@ -296,7 +299,7 @@ class CompiledGraph:
         to dictionary from names of external `Variable`s to their values
         that are needed for the given calculation.
         :param values: an instance of `Values` storage of all calculated
-        values.
+        and external values.
         """
         for source_name, variables in self.required_external_variables.items():
             provided = external_values.get(source_name)
@@ -328,7 +331,7 @@ class CompiledGraph:
 
     def _calculate(self, nodes: list[CompiledNode], values: Storage):
         """
-        Calculate the values of the `Variable`s using their own `formula`
+        Calculate values of the `Variable`s using their own `formula`
         by evaluating them as functions of the values of the specified
         inputs.
 
@@ -344,22 +347,24 @@ class CompiledGraph:
             args = tuple(values.get(input_).value for input_ in node.inputs)
             if any(arg is _null for arg in args):
                 raise RuntimeError(f"Uninitialized input for {node.variable}, args = {args}")
-            cache_key = (node.variable, args)
-            if node.variable.cacheable and cache_key in values.cache:
-                values.get(node.variable).value = values.cache[cache_key]
-                continue
+            cacheable = node.variable.cacheable
+            if cacheable:
+                cache_key = (node.variable, args)
+                if cache_key in values.cache:
+                    values.get(node.variable).value = values.cache[cache_key]
+                    continue
             if self.debug:
                 print(f"Calculating {node}\nwith metadata\n{node.variable.metadata}", file=sys.stderr)
             result = node.variable.formula(*args)
-            if node.variable.cacheable:
-                values.cache[cache_key] = result
+            if cacheable:
+                values.cache[cache_key] = result  # noqa
             values.get(node.variable).value = result
 
     def recompute(self, changed: dict[str, dict[str, VarValue]], values: Storage):
         """
         :param changed: dict of sources to names to new values of changed
         `Variable`s coming from either `External` or `Variables` source.
-        :param values: storage of all the `Variable` values.
+        :param values: storage of all `Variable` values.
         """
         changed_vars = set()
         for src, vals in changed.items():
@@ -388,8 +393,8 @@ class Graph:
     ):
         """
         :param variables_lists: mapping of names of `Variables`
-        namespaces to the lists of `Variable` instances to be
-        added to those namespaces.
+        namespaces to the lists of specifications of `Variable`
+        instances to be added to these namespaces.
         :param external_source_names: list of names of possible
         `External` sources from which `Variable` inputs might
         be coming from.
@@ -448,7 +453,7 @@ class Graph:
             return variables_source
         raise KeyError(f"Unknown source {source_name}")
 
-    def _topological_order(self, required: list[str] | tuple[str] | str):
+    def _topological_order(self, required: list[str] | tuple[str] | str) -> tuple[list[Variable], set[Variable]]:
         """
         :param required: qualified name(s) of `Variable` instance(s)
         for which a topological ordering of a DAG is to be determined.

--- a/numbox/core/variable/variable.py
+++ b/numbox/core/variable/variable.py
@@ -64,7 +64,6 @@ class VarSpec(VarSpecBase, total=False):
     inputs: dict[str, str]
     formula: Callable
     metadata: str
-    cacheable: bool
 
 
 VarValue: TypeAlias = Any
@@ -155,18 +154,12 @@ class Variable:
     value of this `Variable` from its inputs.
     :param metadata: any possible metadata associated with
     this variable.
-    :param cacheable: (default `False`) when `True`, the
-    corresponding `Value` (see below) will be cached during
-    calculation. When attempting to recompute with the same
-    inputs, cached value will be returned instead.
-    Use sparingly!
     """
     name: str
     source: str = field(default="")
     inputs: Mapping[str, str] = field(default_factory=lambda: {})
     formula: Callable = field(default=None)
     metadata: str | None = field(default=None)
-    cacheable: bool = field(default=False)
 
     def __hash__(self):
         return hash((self.source, self.name))
@@ -351,20 +344,15 @@ class CompiledGraph:
         for node in nodes:
             if node.variable.formula is None:
                 continue
-            args = tuple(values.get(input_).value for input_ in node.inputs)
-            if any(arg is _null for arg in args):
-                raise RuntimeError(f"Uninitialized input for {node.variable}, args = {args}")
-            cacheable = node.variable.cacheable
-            if cacheable:
-                cache_key = (node.variable, args)
-                if cache_key in values.cache:
-                    values.get(node.variable).value = values.cache[cache_key]
-                    continue
+            args = [_null] * len(node.inputs)
+            for i, input_ in enumerate(node.inputs):
+                arg = values.get(input_).value
+                if arg is _null:
+                    raise RuntimeError(f"Uninitialized input for {node.variable}")
+                args[i] = arg
             if self.debug:
                 print(f"Calculating {node}\nwith metadata\n{node.variable.metadata}", file=sys.stderr)
             result = node.variable.formula(*args)
-            if cacheable:
-                values.cache[cache_key] = result  # noqa
             values.get(node.variable).value = result
 
     def recompute(self, changed: dict[str, dict[str, VarValue]], values: Storage):


### PR DESCRIPTION
Sync fork main with upstream/main. Merges upstream PR #26 (variable refactor: removed the cacheable option, added caching of affected compiled nodes, rewrote _calculate, doc updates). Clean merge with no conflicts; only variable.py and variable.rst change on main (fork-only CLAUDE.md and CI matrix untouched). Local gate on the merged tree: full suite 675 passed / 2 skipped, whole-tree flake8 clean.
